### PR TITLE
feat: enhance image upload functionality and update configurations

### DIFF
--- a/app/(private)/attendance/BeerPicturesUpload.tsx
+++ b/app/(private)/attendance/BeerPicturesUpload.tsx
@@ -3,7 +3,11 @@
 import { Button, buttonVariants } from "@/components/ui/button";
 import { PhotoPreview } from "@/components/ui/photo-preview";
 import { useToast } from "@/hooks/use-toast";
-import { beerPicturesSchema } from "@/lib/schemas/uploads";
+import {
+  beerPicturesSchema,
+  MAX_FILE_SIZE,
+  MAX_PICTURES,
+} from "@/lib/schemas/uploads";
 import { uploadBeerPicture } from "@/lib/sharedActions";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Camera, X } from "lucide-react";
@@ -18,8 +22,6 @@ interface BeerPicturesUploadProps {
   existingPictureUrls: string[];
   onPicturesUpdate: (newUrls: string[]) => void;
 }
-
-const MAX_PICTURES = 10;
 
 const PicturePreview = ({
   src,
@@ -100,10 +102,14 @@ export function BeerPicturesUpload({
       });
       reset();
     } catch (error) {
+      const fileSizeError =
+        error instanceof Error && error.message.includes("exceeded")
+          ? `File size exceeded (max ${MAX_FILE_SIZE / 1024 / 1024}MB)`
+          : "";
       toast({
         variant: "destructive",
         title: "Error",
-        description: "Failed to upload beer pictures. Please try again.",
+        description: `Failed to upload beer pictures${fileSizeError ? `: ${fileSizeError}` : ""}. Please try again.`,
       });
     }
   };

--- a/app/(private)/home/components/BeerPictureUpload.tsx
+++ b/app/(private)/home/components/BeerPictureUpload.tsx
@@ -2,7 +2,7 @@
 
 import { Button, buttonVariants } from "@/components/ui/button";
 import { useToast } from "@/hooks/use-toast";
-import { singlePictureSchema } from "@/lib/schemas/uploads";
+import { MAX_FILE_SIZE, singlePictureSchema } from "@/lib/schemas/uploads";
 import { uploadBeerPicture } from "@/lib/sharedActions";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Camera } from "lucide-react";
@@ -15,9 +15,6 @@ import type { SinglePictureFormData } from "@/lib/schemas/uploads";
 interface BeerPictureUploadProps {
   attendanceId: string | null;
 }
-
-const MAX_FILE_SIZE = 12 * 1024 * 1024; // 12MB
-const VALID_FILE_TYPES = ["image/jpeg", "image/png", "image/gif", "image/webp"];
 
 const PicturePreview = ({ picture }: { picture: File | null }) => {
   const [previewUrl, setPreviewUrl] = useState<string | null>(null);
@@ -76,10 +73,14 @@ export function BeerPictureUpload({ attendanceId }: BeerPictureUploadProps) {
       setPictureAlreadyUploaded(true);
       reset();
     } catch (error) {
+      const fileSizeError =
+        error instanceof Error && error.message.includes("exceeded")
+          ? `File size exceeded (max ${MAX_FILE_SIZE / 1024 / 1024}MB)`
+          : "";
       toast({
         variant: "destructive",
         title: "Error",
-        description: "Failed to upload beer picture. Please try again.",
+        description: `Failed to upload beer picture${fileSizeError ? `: ${fileSizeError}` : ""}. Please try again.`,
       });
     }
   };

--- a/app/api/image/[id]/route.ts
+++ b/app/api/image/[id]/route.ts
@@ -62,7 +62,7 @@ export async function GET(
   }
 
   try {
-    const supabase = createClient();
+    const supabase = createClient(true); // Use service role for storage access
 
     const { data, error } = await supabase.storage
       .from(bucket)

--- a/components/ui/photo-preview.tsx
+++ b/components/ui/photo-preview.tsx
@@ -48,9 +48,7 @@ export function PhotoPreview({
               "relative cursor-pointer rounded overflow-hidden border border-gray-200 hover:border-yellow-400 transition-colors",
               thumbnailSize,
             )}
-            onClick={() =>
-              setSelectedImage(`/api/image/${url}?bucket=${bucket}`)
-            }
+            onClick={() => setSelectedImage(url)}
           >
             <Image
               src={`/api/image/${url}?bucket=${bucket}`}
@@ -85,7 +83,7 @@ export function PhotoPreview({
           {selectedImage && (
             <div className="relative w-full h-full">
               <Image
-                src={selectedImage}
+                src={`/api/image/${selectedImage}?bucket=${bucket}`}
                 alt="Full size photo"
                 width={1200}
                 height={800}

--- a/lib/schemas/uploads.ts
+++ b/lib/schemas/uploads.ts
@@ -1,8 +1,8 @@
 import { z } from "zod";
 
-const MAX_FILE_SIZE = 12 * 1024 * 1024; // 12MB
+export const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB
+export const MAX_PICTURES = 10;
 const VALID_FILE_TYPES = ["image/jpeg", "image/png", "image/gif", "image/webp"];
-const MAX_PICTURES = 10;
 
 export const beerPicturesSchema = z.object({
   pictures: z
@@ -10,7 +10,7 @@ export const beerPicturesSchema = z.object({
       z
         .instanceof(File)
         .refine((file) => file.size <= MAX_FILE_SIZE, {
-          message: "File is too large (max 12MB)",
+          message: `File is too large (max ${MAX_FILE_SIZE / 1024 / 1024}MB)`,
         })
         .refine((file) => VALID_FILE_TYPES.includes(file.type), {
           message: "Unsupported file format (use JPEG, PNG, GIF, or WebP)",
@@ -24,7 +24,7 @@ export const singlePictureSchema = z.object({
   picture: z
     .instanceof(File)
     .refine((file) => file.size <= MAX_FILE_SIZE, {
-      message: "File is too large (max 12MB)",
+      message: `File is too large (max ${MAX_FILE_SIZE / 1024 / 1024}MB)`,
     })
     .refine((file) => VALID_FILE_TYPES.includes(file.type), {
       message: "Unsupported file format (use JPEG, PNG, GIF, or WebP)",
@@ -35,7 +35,7 @@ export const avatarSchema = z.object({
   avatar: z
     .instanceof(File)
     .refine((file) => file.size <= MAX_FILE_SIZE, {
-      message: "File is too large (max 12MB)",
+      message: `File is too large (max ${MAX_FILE_SIZE / 1024 / 1024}MB)`,
     })
     .refine((file) => VALID_FILE_TYPES.includes(file.type), {
       message: "Unsupported file format (use JPEG, PNG, GIF, or WebP)",

--- a/next.config.ts
+++ b/next.config.ts
@@ -8,6 +8,11 @@ const nextConfig: NextConfig = {
   eslint: {
     ignoreDuringBuilds: true,
   },
+  experimental: {
+    serverActions: {
+      bodySizeLimit: "10mb",
+    },
+  },
   images: {
     localPatterns: [
       {


### PR DESCRIPTION
- Added experimental server actions with a body size limit of 10MB in next.config.ts.
- Refactored BeerPicturesUpload and BeerPictureUpload components to utilize MAX_FILE_SIZE and provide detailed error messages for file size issues.
- Updated photo-preview component to correctly handle image URLs for better user experience.
- Adjusted upload schemas to reflect the new maximum file size and ensure consistent error messaging across components.