### PR TITLE
fix: skip tutorial auto-start when festival is not active

### DIFF
--- a/apps/mobile/lib/tutorial/TutorialContext.tsx
+++ b/apps/mobile/lib/tutorial/TutorialContext.tsx
@@ -5,10 +5,12 @@
  * Uses the shared hooks (useTutorialStatus, useCompleteTutorial) for persistence.
  */
 
+import { useFestival } from "@prostcounter/shared/contexts";
 import {
   useCompleteTutorial,
   useTutorialStatus,
 } from "@prostcounter/shared/hooks";
+import { getFestivalStatus } from "@prostcounter/shared/utils";
 import { type Href, useRouter } from "expo-router";
 import {
   createContext,
@@ -88,6 +90,7 @@ interface TutorialProviderProps {
 function TutorialProviderInner({ children }: TutorialProviderProps) {
   const { isAuthenticated } = useAuth();
   const { data: tutorialStatus, loading: isLoading } = useTutorialStatus();
+  const { currentFestival } = useFestival();
   const completeTutorial = useCompleteTutorial();
   const router = useRouter();
 
@@ -100,6 +103,9 @@ function TutorialProviderInner({ children }: TutorialProviderProps) {
   const targetRefs = useRef<Map<string, View>>(new Map());
 
   const isCompleted = tutorialStatus?.tutorial_completed ?? false;
+  const isFestivalActive = currentFestival
+    ? getFestivalStatus(currentFestival) === "active"
+    : false;
 
   // Auto-start tutorial for new users (only once per session)
   useEffect(() => {
@@ -112,7 +118,8 @@ function TutorialProviderInner({ children }: TutorialProviderProps) {
       tutorialStatus !== null &&
       !isCompleted &&
       !hasAutoStarted &&
-      !isActive
+      !isActive &&
+      isFestivalActive
     ) {
       const timer = setTimeout(() => {
         setIsActive(true);
@@ -129,6 +136,7 @@ function TutorialProviderInner({ children }: TutorialProviderProps) {
     isCompleted,
     hasAutoStarted,
     isActive,
+    isFestivalActive,
   ]);
 
   const currentStep = useMemo(

--- a/apps/web/contexts/TutorialContext.tsx
+++ b/apps/web/contexts/TutorialContext.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useFestival } from "@prostcounter/shared/contexts";
 import type { ReactNode } from "react";
 import {
   createContext,
@@ -11,6 +12,7 @@ import {
 
 import { TUTORIAL_CONSTANTS } from "@/components/Tutorial/constants";
 import { useCompleteTutorial } from "@/hooks/useProfile";
+import { getFestivalStatus } from "@/lib/festivalConstants";
 import { type TutorialStep, tutorialSteps } from "@/lib/tutorialSteps";
 
 interface TutorialContextType {
@@ -49,6 +51,10 @@ export function TutorialProvider({
   const [isCompleted, setIsCompleted] = useState(initialTutorialCompleted);
   const [visibleSteps, setVisibleSteps] = useState<TutorialStep[]>([]);
   const { mutateAsync: completeTutorial } = useCompleteTutorial();
+  const { currentFestival } = useFestival();
+  const isFestivalActive = currentFestival
+    ? getFestivalStatus(currentFestival) === "active"
+    : false;
 
   // Sync internal state with prop changes (when cache is invalidated)
   useEffect(() => {
@@ -182,7 +188,7 @@ export function TutorialProvider({
 
   // Auto-start tutorial for new users (only after status is loaded)
   useEffect(() => {
-    if (!isLoadingStatus && !isCompleted && !isActive) {
+    if (!isLoadingStatus && !isCompleted && !isActive && isFestivalActive) {
       // Small delay to ensure page is loaded
       const timer = setTimeout(() => {
         startTutorial();
@@ -190,7 +196,7 @@ export function TutorialProvider({
       return () => clearTimeout(timer);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isLoadingStatus, isCompleted, isActive]);
+  }, [isLoadingStatus, isCompleted, isActive, isFestivalActive]);
 
   const value: TutorialContextType = {
     isActive,

--- a/apps/web/lib/festivalConstants.ts
+++ b/apps/web/lib/festivalConstants.ts
@@ -1,7 +1,9 @@
 import type { Festival } from "@prostcounter/shared/schemas";
-import { endOfDay, isBefore, isWithinInterval, parseISO } from "date-fns";
+import { parseISO } from "date-fns";
 
 import type { FestivalTent } from "./types";
+
+export { getFestivalStatus } from "@prostcounter/shared/utils";
 
 // Default fallback values for when festival data is not available
 const DEFAULT_BEER_COST = 16.2;
@@ -24,29 +26,6 @@ export function getFestivalConstants(festival: Festival): FestivalConstants {
     festivalName: festival.name,
     festivalLocation: festival.location,
   };
-}
-
-function isFestivalActive(festival: Festival): boolean {
-  const now = new Date();
-  const startDate = parseISO(festival.startDate);
-  const endDate = endOfDay(parseISO(festival.endDate));
-
-  return isWithinInterval(now, { start: startDate, end: endDate });
-}
-
-function isFestivalUpcoming(festival: Festival): boolean {
-  const now = new Date();
-  const startDate = parseISO(festival.startDate);
-
-  return isBefore(now, startDate);
-}
-
-export function getFestivalStatus(
-  festival: Festival,
-): "upcoming" | "active" | "ended" {
-  if (isFestivalUpcoming(festival)) return "upcoming";
-  if (isFestivalActive(festival)) return "active";
-  return "ended";
 }
 
 // Helper function to get beer cost for a specific tent at a specific festival

--- a/packages/shared/src/utils/festival-status.ts
+++ b/packages/shared/src/utils/festival-status.ts
@@ -1,0 +1,24 @@
+import { endOfDay, isBefore, isWithinInterval, parseISO } from "date-fns";
+
+import type { Festival, FestivalStatus } from "../schemas/festival.schema";
+
+function isFestivalActive(festival: Festival): boolean {
+  const now = new Date();
+  const startDate = parseISO(festival.startDate);
+  const endDate = endOfDay(parseISO(festival.endDate));
+
+  return isWithinInterval(now, { start: startDate, end: endDate });
+}
+
+function isFestivalUpcoming(festival: Festival): boolean {
+  const now = new Date();
+  const startDate = parseISO(festival.startDate);
+
+  return isBefore(now, startDate);
+}
+
+export function getFestivalStatus(festival: Festival): FestivalStatus {
+  if (isFestivalUpcoming(festival)) return "upcoming";
+  if (isFestivalActive(festival)) return "active";
+  return "ended";
+}

--- a/packages/shared/src/utils/festival-status.ts
+++ b/packages/shared/src/utils/festival-status.ts
@@ -2,23 +2,13 @@ import { endOfDay, isBefore, isWithinInterval, parseISO } from "date-fns";
 
 import type { Festival, FestivalStatus } from "../schemas/festival.schema";
 
-function isFestivalActive(festival: Festival): boolean {
+export function getFestivalStatus(festival: Festival): FestivalStatus {
   const now = new Date();
   const startDate = parseISO(festival.startDate);
   const endDate = endOfDay(parseISO(festival.endDate));
 
-  return isWithinInterval(now, { start: startDate, end: endDate });
-}
-
-function isFestivalUpcoming(festival: Festival): boolean {
-  const now = new Date();
-  const startDate = parseISO(festival.startDate);
-
-  return isBefore(now, startDate);
-}
-
-export function getFestivalStatus(festival: Festival): FestivalStatus {
-  if (isFestivalUpcoming(festival)) return "upcoming";
-  if (isFestivalActive(festival)) return "active";
+  if (isBefore(now, startDate)) return "upcoming";
+  if (isWithinInterval(now, { start: startDate, end: endDate }))
+    return "active";
   return "ended";
 }

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -32,3 +32,6 @@ export { isNovuResponseValidationError, runNovuWriteTolerantly } from "./novu";
 
 // Name helpers
 export { splitFullName } from "./split-full-name";
+
+// Festival status
+export { getFestivalStatus } from "./festival-status";


### PR DESCRIPTION
## Summary
- Tutorial steps target home-screen elements that only render during an active festival (crowd summary, unified feed, attendance card, map share, highlights). Opening the app before a festival starts — or after it ends — used to auto-play a near-empty walkthrough.
- Auto-start is now gated on `getFestivalStatus(currentFestival) === "active"`. Manual invocation (the "Show tutorial" affordance) is untouched, so users can still replay the tutorial off-season.
- Extracted `getFestivalStatus` from `apps/web/lib/festivalConstants.ts` into `@prostcounter/shared/utils` so web and mobile use the same check. Web's `festivalConstants.ts` re-exports it, so the 11 existing web import sites are unchanged.
