### PR TITLE
feat(watch): localize companion app for en/de/es

### DIFF
--- a/apps/mobile/lib/i18n/index.ts
+++ b/apps/mobile/lib/i18n/index.ts
@@ -6,6 +6,7 @@ import {
 } from "@prostcounter/shared/i18n";
 
 import { logger } from "../logger";
+import { syncLanguageToWatch } from "../watch-sync";
 
 const LANGUAGE_KEY = "@prostcounter/language";
 
@@ -34,6 +35,10 @@ export async function initMobileI18n() {
 
     // Initialize with detected/saved language
     initI18n(locale);
+
+    // Mirror the initial locale to the watch so the Swift side can honor it
+    // on first launch before the user ever touches the language picker.
+    syncLanguageToWatch(locale);
   } catch (error) {
     // Fallback to English if anything fails
     logger.warn("Failed to initialize i18n with locale detection", { error });
@@ -54,6 +59,7 @@ export async function setLanguage(language: string) {
   }
 
   await sharedChangeLanguage(language);
+  syncLanguageToWatch(language);
 }
 
 // Re-export from shared

--- a/apps/mobile/lib/watch-sync.ts
+++ b/apps/mobile/lib/watch-sync.ts
@@ -57,3 +57,15 @@ export function clearSessionOnWatch(): void {
   setIfChanged(storage, "currentFestivalId", "");
   setIfChanged(storage, "expiresAt", "0");
 }
+
+/**
+ * Mirrors the user's selected language to the watch via App Group UserDefaults.
+ * The watch reads this on launch and overrides `AppleLanguages` so String Catalog
+ * lookups resolve against the chosen locale. Changes made while the watch app is
+ * running take effect on its next cold start (AppleLanguages is bundle-level).
+ */
+export function syncLanguageToWatch(lang: string): void {
+  const storage = getStorage();
+  if (!storage) return;
+  setIfChanged(storage, "preferredLanguage", lang);
+}

--- a/apps/mobile/targets/watch/Info.plist
+++ b/apps/mobile/targets/watch/Info.plist
@@ -7,7 +7,12 @@
       <key>NSAllowsLocalNetworking</key>
       <true/>
     </dict>
+    <!-- Localized for de/es in InfoPlist.xcstrings — update both together. -->
     <key>NSLocationWhenInUseUsageDescription</key>
     <string>ProstCounter uses your location to detect the nearest tent at the festival.</string>
+    <key>WATCH_SUPABASE_URL</key>
+    <string>https://jdmhjakxhtghsbnstyou.supabase.co</string>
+    <key>WATCH_SUPABASE_ANON_KEY</key>
+    <string>eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImpkbWhqYWt4aHRnaHNibnN0eW91Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDEyOTA2NjEsImV4cCI6MjA1Njg2NjY2MX0.ep_qWmBgtZgeE64XoHnTL0ihyEuYzEubOxREKFtjYnw</string>
   </dict>
 </plist>

--- a/apps/mobile/targets/watch/Info.plist
+++ b/apps/mobile/targets/watch/Info.plist
@@ -10,9 +10,5 @@
     <!-- Localized for de/es in InfoPlist.xcstrings — update both together. -->
     <key>NSLocationWhenInUseUsageDescription</key>
     <string>ProstCounter uses your location to detect the nearest tent at the festival.</string>
-    <key>WATCH_SUPABASE_URL</key>
-    <string>https://jdmhjakxhtghsbnstyou.supabase.co</string>
-    <key>WATCH_SUPABASE_ANON_KEY</key>
-    <string>eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImpkbWhqYWt4aHRnaHNibnN0eW91Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDEyOTA2NjEsImV4cCI6MjA1Njg2NjY2MX0.ep_qWmBgtZgeE64XoHnTL0ihyEuYzEubOxREKFtjYnw</string>
   </dict>
 </plist>

--- a/apps/mobile/targets/watch/InfoPlist.xcstrings
+++ b/apps/mobile/targets/watch/InfoPlist.xcstrings
@@ -1,0 +1,14 @@
+{
+  "sourceLanguage" : "en",
+  "version" : "1.0",
+  "strings" : {
+    "NSLocationWhenInUseUsageDescription" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "ProstCounter uses your location to detect the nearest tent at the festival." } },
+        "de" : { "stringUnit" : { "state" : "translated", "value" : "ProstCounter verwendet deinen Standort, um das nächstgelegene Festzelt zu erkennen." } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "ProstCounter usa tu ubicación para detectar la carpa más cercana del festival." } }
+      }
+    }
+  }
+}

--- a/apps/mobile/targets/watch/Localizable.xcstrings
+++ b/apps/mobile/targets/watch/Localizable.xcstrings
@@ -1,0 +1,166 @@
+{
+  "sourceLanguage" : "en",
+  "version" : "1.0",
+  "strings" : {
+    "common.skip" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Skip" } },
+        "de" : { "stringUnit" : { "state" : "translated", "value" : "Überspringen" } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "Omitir" } }
+      }
+    },
+    "watch.crowd.crowded" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Crowded" } },
+        "de" : { "stringUnit" : { "state" : "translated", "value" : "Voll" } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "Lleno" } }
+      }
+    },
+    "watch.crowd.empty" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Empty" } },
+        "de" : { "stringUnit" : { "state" : "translated", "value" : "Leer" } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "Vacío" } }
+      }
+    },
+    "watch.crowd.moderate" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Moderate" } },
+        "de" : { "stringUnit" : { "state" : "translated", "value" : "Moderat" } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "Moderado" } }
+      }
+    },
+    "watch.crowd.prompt" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "How crowded is %@?" } },
+        "de" : { "stringUnit" : { "state" : "translated", "value" : "Wie voll ist %@?" } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "¿Qué tan llena está %@?" } }
+      }
+    },
+    "watch.drink.alcohol_free" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Alcohol-Free" } },
+        "de" : { "stringUnit" : { "state" : "translated", "value" : "Alkoholfrei" } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "Sin alcohol" } }
+      }
+    },
+    "watch.drink.beer" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Beer" } },
+        "de" : { "stringUnit" : { "state" : "translated", "value" : "Bier" } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "Cerveza" } }
+      }
+    },
+    "watch.drink.other" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Other drink…" } },
+        "de" : { "stringUnit" : { "state" : "translated", "value" : "Anderes Getränk…" } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "Otra bebida…" } }
+      }
+    },
+    "watch.drink.radler" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Radler" } },
+        "de" : { "stringUnit" : { "state" : "translated", "value" : "Radler" } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "Radler" } }
+      }
+    },
+    "watch.drink.soft_drink" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Soft Drink" } },
+        "de" : { "stringUnit" : { "state" : "translated", "value" : "Softdrink" } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "Refresco" } }
+      }
+    },
+    "watch.drink.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Drink" } },
+        "de" : { "stringUnit" : { "state" : "translated", "value" : "Getränk" } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "Bebida" } }
+      }
+    },
+    "watch.drink.wine" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Wine" } },
+        "de" : { "stringUnit" : { "state" : "translated", "value" : "Wein" } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "Vino" } }
+      }
+    },
+    "watch.error.notSent" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Not sent — tap Prost to retry" } },
+        "de" : { "stringUnit" : { "state" : "translated", "value" : "Nicht gesendet – tippe auf Prost, um es erneut zu versuchen" } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "No enviado — tocá Prost para reintentar" } }
+      }
+    },
+    "watch.status.noFestival" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Pick a festival on iPhone" } },
+        "de" : { "stringUnit" : { "state" : "translated", "value" : "Wähle ein Festival auf dem iPhone" } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "Elegí un festival en el iPhone" } }
+      }
+    },
+    "watch.status.noSession" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Sign in on iPhone first" } },
+        "de" : { "stringUnit" : { "state" : "translated", "value" : "Melde dich zuerst auf dem iPhone an" } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "Iniciá sesión primero en el iPhone" } }
+      }
+    },
+    "watch.tent.empty" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "No tents for this festival" } },
+        "de" : { "stringUnit" : { "state" : "translated", "value" : "Keine Zelte für dieses Festival" } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "No hay carpas para este festival" } }
+      }
+    },
+    "watch.tent.select" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Select tent" } },
+        "de" : { "stringUnit" : { "state" : "translated", "value" : "Zelt auswählen" } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "Seleccionar carpa" } }
+      }
+    },
+    "watch.tent.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Tent" } },
+        "de" : { "stringUnit" : { "state" : "translated", "value" : "Zelt" } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "Carpa" } }
+      }
+    },
+    "watch.today.count" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Today: %lld 🍺" } },
+        "de" : { "stringUnit" : { "state" : "translated", "value" : "Heute: %lld 🍺" } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "Hoy: %lld 🍺" } }
+      }
+    },
+    "watch.today.countMixed" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Today: %1$lld 🍺 · %2$lld other" } },
+        "de" : { "stringUnit" : { "state" : "translated", "value" : "Heute: %1$lld 🍺 · %2$lld andere" } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "Hoy: %1$lld 🍺 · %2$lld otras" } }
+      }
+    }
+  }
+}

--- a/apps/mobile/targets/watch/Localizable.xcstrings
+++ b/apps/mobile/targets/watch/Localizable.xcstrings
@@ -157,9 +157,51 @@
     "watch.today.countMixed" : {
       "extractionState" : "manual",
       "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Today: %1$lld 🍺 · %2$lld other" } },
-        "de" : { "stringUnit" : { "state" : "translated", "value" : "Heute: %1$lld 🍺 · %2$lld andere" } },
-        "es" : { "stringUnit" : { "state" : "translated", "value" : "Hoy: %1$lld 🍺 · %2$lld otras" } }
+        "en" : {
+          "stringUnit" : { "state" : "translated", "value" : "Today: %1$lld 🍺 · %#@others@" },
+          "substitutions" : {
+            "others" : {
+              "argNum" : 2,
+              "formatSpecifier" : "lld",
+              "variations" : {
+                "plural" : {
+                  "one" : { "stringUnit" : { "state" : "translated", "value" : "%arg other" } },
+                  "other" : { "stringUnit" : { "state" : "translated", "value" : "%arg others" } }
+                }
+              }
+            }
+          }
+        },
+        "de" : {
+          "stringUnit" : { "state" : "translated", "value" : "Heute: %1$lld 🍺 · %#@others@" },
+          "substitutions" : {
+            "others" : {
+              "argNum" : 2,
+              "formatSpecifier" : "lld",
+              "variations" : {
+                "plural" : {
+                  "one" : { "stringUnit" : { "state" : "translated", "value" : "%arg weiteres" } },
+                  "other" : { "stringUnit" : { "state" : "translated", "value" : "%arg weitere" } }
+                }
+              }
+            }
+          }
+        },
+        "es" : {
+          "stringUnit" : { "state" : "translated", "value" : "Hoy: %1$lld 🍺 · %#@others@" },
+          "substitutions" : {
+            "others" : {
+              "argNum" : 2,
+              "formatSpecifier" : "lld",
+              "variations" : {
+                "plural" : {
+                  "one" : { "stringUnit" : { "state" : "translated", "value" : "%arg otra" } },
+                  "other" : { "stringUnit" : { "state" : "translated", "value" : "%arg otras" } }
+                }
+              }
+            }
+          }
+        }
       }
     }
   }

--- a/apps/mobile/targets/watch/Services/TentResolver.swift
+++ b/apps/mobile/targets/watch/Services/TentResolver.swift
@@ -23,7 +23,8 @@ enum TentResolver {
 
     /// Placeholder shown when no tent has been resolved yet. Acts as a CTA
     /// label on the tent-picker button so users know why it's tappable.
-    static let noTentPlaceholder = "Select tent"
+    /// Computed so it resolves against the current locale each time.
+    static var noTentPlaceholder: String { String(localized: "watch.tent.select") }
 
     static func resolve(
         attendance: AttendanceByDate?,

--- a/apps/mobile/targets/watch/ViewModels/AppViewModel.swift
+++ b/apps/mobile/targets/watch/ViewModels/AppViewModel.swift
@@ -16,11 +16,11 @@ final class AppViewModel: ObservableObject {
 
         var label: String {
             switch self {
-            case .beer: return "Beer"
-            case .radler: return "Radler"
-            case .alcoholFree: return "Alcohol-free"
-            case .wine: return "Wine"
-            case .softDrink: return "Soft drink"
+            case .beer: return String(localized: "watch.drink.beer")
+            case .radler: return String(localized: "watch.drink.radler")
+            case .alcoholFree: return String(localized: "watch.drink.alcohol_free")
+            case .wine: return String(localized: "watch.drink.wine")
+            case .softDrink: return String(localized: "watch.drink.soft_drink")
             }
         }
 
@@ -47,19 +47,21 @@ final class AppViewModel: ObservableObject {
 
     /// Watch-side crowd levels. Server enum is empty|moderate|crowded|full;
     /// we skip "full" to keep the small-screen picker to 3 actions + Skip.
+    /// Case names mirror the mobile/web translation keys under `crowdReport.levels.*`
+    /// so the shared i18n strings can be reused verbatim.
     enum CrowdLevel: String, CaseIterable, Identifiable, Encodable {
         case empty = "empty"
-        case busy = "moderate"
-        case packed = "crowded"
+        case moderate = "moderate"
+        case crowded = "crowded"
 
         var id: String { rawValue }
 
         /// User-facing label shown on the picker button.
         var label: String {
             switch self {
-            case .empty: return "Empty"
-            case .busy: return "Busy"
-            case .packed: return "Packed"
+            case .empty: return String(localized: "watch.crowd.empty")
+            case .moderate: return String(localized: "watch.crowd.moderate")
+            case .crowded: return String(localized: "watch.crowd.crowded")
             }
         }
     }

--- a/apps/mobile/targets/watch/Views/CrowdPromptView.swift
+++ b/apps/mobile/targets/watch/Views/CrowdPromptView.swift
@@ -16,7 +16,10 @@ struct CrowdPromptView: View {
                     .foregroundStyle(.green)
                 Text(
                     String(
-                        format: NSLocalizedString("watch.crowd.prompt", comment: ""),
+                        format: NSLocalizedString(
+                            "watch.crowd.prompt",
+                            comment: "Crowd report question header. %@ is the tent name."
+                        ),
                         tentName
                     )
                 )

--- a/apps/mobile/targets/watch/Views/CrowdPromptView.swift
+++ b/apps/mobile/targets/watch/Views/CrowdPromptView.swift
@@ -11,24 +11,29 @@ struct CrowdPromptView: View {
     var body: some View {
         ScrollView {
             VStack(spacing: 8) {
-                Text("✓ Prost!")
+                Text(verbatim: "✓ Prost!")
                     .font(.caption)
                     .foregroundStyle(.green)
-                Text("How crowded is \(tentName)?")
-                    .font(.footnote)
-                    .multilineTextAlignment(.center)
+                Text(
+                    String(
+                        format: NSLocalizedString("watch.crowd.prompt", comment: ""),
+                        tentName
+                    )
+                )
+                .font(.footnote)
+                .multilineTextAlignment(.center)
 
                 ForEach(AppViewModel.CrowdLevel.allCases) { level in
                     Button {
                         onSubmit(level)
                     } label: {
-                        Text(level.label)
+                        Text(verbatim: level.label)
                             .frame(maxWidth: .infinity, minHeight: 36)
                     }
                     .buttonStyle(.bordered)
                 }
 
-                Button("Skip") { onSkip() }
+                Button("common.skip") { onSkip() }
                     .buttonStyle(.plain)
                     .font(.caption)
                     .foregroundStyle(.secondary)

--- a/apps/mobile/targets/watch/Views/DrinkTypePickerView.swift
+++ b/apps/mobile/targets/watch/Views/DrinkTypePickerView.swift
@@ -19,8 +19,8 @@ struct DrinkTypePickerView: View {
                             onPick(type)
                         } label: {
                             HStack {
-                                Text(type.emoji)
-                                Text(type.label).font(.footnote)
+                                Text(verbatim: type.emoji)
+                                Text(verbatim: type.label).font(.footnote)
                                 Spacer()
                             }
                             .frame(maxWidth: .infinity, minHeight: 40)
@@ -30,7 +30,7 @@ struct DrinkTypePickerView: View {
                 }
                 .padding(.horizontal, 6)
             }
-            .navigationTitle("Drink")
+            .navigationTitle(Text("watch.drink.title"))
         }
     }
 }

--- a/apps/mobile/targets/watch/Views/MainView.swift
+++ b/apps/mobile/targets/watch/Views/MainView.swift
@@ -33,8 +33,8 @@ struct MainView: View {
                     }
                 } label: {
                     HStack(spacing: 4) {
-                        Text("🍺")
-                        Text("Prost!")
+                        Text(verbatim: "🍺")
+                        Text(verbatim: "Prost!")
                     }
                     .font(.title3.bold())
                     .frame(maxWidth: .infinity, minHeight: 44)
@@ -46,7 +46,7 @@ struct MainView: View {
                     viewModel.status == .noFestival
                 )
 
-                Button("Other drink…") {
+                Button(String(localized: "watch.drink.other")) {
                     showingDrinkPicker = true
                 }
                 .font(.footnote)
@@ -106,9 +106,16 @@ struct MainView: View {
     private var todaySummary: String {
         let others = max(0, viewModel.drinkCount - viewModel.beerCount)
         if others == 0 {
-            return "Today: \(viewModel.drinkCount) 🍺"
+            return String(
+                format: NSLocalizedString("watch.today.count", comment: ""),
+                viewModel.drinkCount
+            )
         }
-        return "Today: \(viewModel.beerCount) 🍺 · \(others) other"
+        return String(
+            format: NSLocalizedString("watch.today.countMixed", comment: ""),
+            viewModel.beerCount,
+            others
+        )
     }
 
     @ViewBuilder
@@ -117,7 +124,7 @@ struct MainView: View {
         case .idle, .loading, .logging:
             EmptyView()
         case .success:
-            Text("✓ Prost!")
+            Text(verbatim: "✓ Prost!")
                 .font(.caption2)
                 .foregroundStyle(.green)
                 .task {
@@ -125,15 +132,15 @@ struct MainView: View {
                     viewModel.acknowledgeSuccess()
                 }
         case .needsRetry:
-            Text("Not sent — tap Prost to retry")
+            Text("watch.error.notSent")
                 .font(.caption2)
                 .foregroundStyle(.red)
         case .noSession:
-            Text("Sign in on iPhone first")
+            Text("watch.status.noSession")
                 .font(.caption2)
                 .foregroundStyle(.orange)
         case .noFestival:
-            Text("Pick a festival on iPhone")
+            Text("watch.status.noFestival")
                 .font(.caption2)
                 .foregroundStyle(.orange)
         }

--- a/apps/mobile/targets/watch/Views/MainView.swift
+++ b/apps/mobile/targets/watch/Views/MainView.swift
@@ -107,12 +107,18 @@ struct MainView: View {
         let others = max(0, viewModel.drinkCount - viewModel.beerCount)
         if others == 0 {
             return String(
-                format: NSLocalizedString("watch.today.count", comment: ""),
+                format: NSLocalizedString(
+                    "watch.today.count",
+                    comment: "Today summary when only beers were logged. %lld is drink count."
+                ),
                 viewModel.drinkCount
             )
         }
         return String(
-            format: NSLocalizedString("watch.today.countMixed", comment: ""),
+            format: NSLocalizedString(
+                "watch.today.countMixed",
+                comment: "Today summary with beers and other drinks. %1$lld is beers, %2$lld is others."
+            ),
             viewModel.beerCount,
             others
         )

--- a/apps/mobile/targets/watch/Views/MainView.swift
+++ b/apps/mobile/targets/watch/Views/MainView.swift
@@ -111,7 +111,7 @@ struct MainView: View {
                     "watch.today.count",
                     comment: "Today summary when only beers were logged. %lld is drink count."
                 ),
-                viewModel.drinkCount
+                Int64(viewModel.drinkCount)
             )
         }
         return String(
@@ -119,8 +119,8 @@ struct MainView: View {
                 "watch.today.countMixed",
                 comment: "Today summary with beers and other drinks. %1$lld is beers, %2$lld is others."
             ),
-            viewModel.beerCount,
-            others
+            Int64(viewModel.beerCount),
+            Int64(others)
         )
     }
 

--- a/apps/mobile/targets/watch/Views/TentPickerView.swift
+++ b/apps/mobile/targets/watch/Views/TentPickerView.swift
@@ -9,7 +9,7 @@ struct TentPickerView: View {
         ScrollView {
             VStack(spacing: 6) {
                 if tents.isEmpty {
-                    Text("No tents for this festival")
+                    Text("watch.tent.empty")
                         .font(.footnote)
                         .foregroundStyle(.secondary)
                         .padding(.top, 16)
@@ -21,7 +21,7 @@ struct TentPickerView: View {
             }
             .padding(.horizontal, 6)
         }
-        .navigationTitle("Tent")
+        .navigationTitle(Text("watch.tent.title"))
     }
 }
 

--- a/apps/mobile/targets/watch/index.swift
+++ b/apps/mobile/targets/watch/index.swift
@@ -3,6 +3,11 @@ import SwiftUI
 @main
 struct WatchEntry: App {
     init() {
+        // Apply the user's language preference (mirrored from the iPhone via
+        // the App Group) BEFORE any SwiftUI view loads, so String Catalog
+        // lookups resolve against the chosen locale on this launch.
+        Self.applyPreferredLanguage()
+
         // Activate WCSession receiver so the watch can persist session tokens
         // forwarded from the iPhone bridge (updateApplicationContext +
         // sendMessage fast path) into the App Group UserDefaults.
@@ -12,6 +17,33 @@ struct WatchEntry: App {
     var body: some Scene {
         WindowGroup {
             ContentView()
+        }
+    }
+
+    /// Reads `preferredLanguage` from the App Group UserDefaults (written by
+    /// `syncLanguageToWatch` in apps/mobile/lib/watch-sync.ts) and overrides
+    /// `AppleLanguages` in standard UserDefaults. Read once per process launch:
+    /// `AppleLanguages` is resolved by the bundle before SwiftUI init runs, so
+    /// this write only takes effect on the NEXT cold launch.
+    private static func applyPreferredLanguage() {
+        guard
+            let defaults = UserDefaults(suiteName: "group.com.prostcounter.shared"),
+            let lang = defaults.string(forKey: "preferredLanguage"),
+            ["en", "de", "es"].contains(lang)
+        else {
+            // No preference synced yet — fall through to device locale.
+            return
+        }
+        let standard = UserDefaults.standard
+        // Only write when the value actually changes, so we avoid churning
+        // cfprefsd on every cold launch. Synchronize to force an immediate
+        // flush to disk — without it, a short-lived process may exit before
+        // cfprefsd persists the write, and the next launch reads the stale
+        // value from disk.
+        let currentLanguages = standard.array(forKey: "AppleLanguages") as? [String]
+        if currentLanguages != [lang] {
+            standard.set([lang], forKey: "AppleLanguages")
+            standard.synchronize()
         }
     }
 }

--- a/apps/mobile/targets/watch/index.swift
+++ b/apps/mobile/targets/watch/index.swift
@@ -27,7 +27,7 @@ struct WatchEntry: App {
     /// this write only takes effect on the NEXT cold launch.
     private static func applyPreferredLanguage() {
         guard
-            let defaults = UserDefaults(suiteName: "group.com.prostcounter.shared"),
+            let defaults = UserDefaults(suiteName: TokenStore.appGroup),
             let lang = defaults.string(forKey: "preferredLanguage"),
             ["en", "de", "es"].contains(lang)
         else {

--- a/apps/mobile/targets/watch/index.swift
+++ b/apps/mobile/targets/watch/index.swift
@@ -3,9 +3,9 @@ import SwiftUI
 @main
 struct WatchEntry: App {
     init() {
-        // Apply the user's language preference (mirrored from the iPhone via
-        // the App Group) BEFORE any SwiftUI view loads, so String Catalog
-        // lookups resolve against the chosen locale on this launch.
+        // Persist the user's language preference (mirrored from the iPhone via
+        // the App Group) into `AppleLanguages`. Takes effect on the NEXT cold
+        // launch — see `applyPreferredLanguage()` for the timing detail.
         Self.applyPreferredLanguage()
 
         // Activate WCSession receiver so the watch can persist session tokens


### PR DESCRIPTION
## Summary
- Adds native String Catalogs (`Localizable.xcstrings` + `InfoPlist.xcstrings`) so the watch UI and the `NSLocationWhenInUseUsageDescription` prompt render in en / de / es.
- Bridges the user's language preference from the mobile app via App Group UserDefaults (`syncLanguageToWatch` in `watch-sync.ts`, read at launch by `WatchEntry.init()` and applied via `AppleLanguages`). Falls back to device locale when no preference is synced.
- Realigns watch `CrowdLevel` cases to mobile's `empty / moderate / crowded` enum so the shared `crowdReport.levels.*` translations can be reused verbatim. Server enum raw values are unchanged.
- `Prost!` kept untranslated across all locales (brand / theme word).

Verified on booted simulator pair (iPhone 17 Pro + Apple Watch Series 11): `.xcstrings` files compile into per-locale `.lproj/*.strings` in the watch `.app` bundle, and cold-launching with `preferredLanguage=de|es` in the App Group renders the expected localized UI. One known watchOS semantic: `AppleLanguages` overrides take effect on the next cold launch after they are written (bundle strings resolve before `@main init`), so live iPhone language switches while the watch app is foregrounded will render on the next restart.
