### PR TITLE
fix(mobile): Android JVM metaspace + iOS sendDeviceEvent deprecation

### DIFF
--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -143,6 +143,7 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
     "./plugins/withFirebaseNotificationColor.js",
     "./plugins/withGoogleMapsApiKey.js",
     "./plugins/withAsyncStorageMavenRepo.js",
+    "./plugins/withAndroidGradleJvmArgs.js",
     "@bacons/apple-targets",
     "expo-maps",
     "expo-updates",

--- a/apps/mobile/plugins/withAndroidGradleJvmArgs.js
+++ b/apps/mobile/plugins/withAndroidGradleJvmArgs.js
@@ -1,7 +1,22 @@
 const { withGradleProperties } = require("@expo/config-plugins");
 
 const JVM_ARGS_KEY = "org.gradle.jvmargs";
-const JVM_ARGS_VALUE = "-Xmx4096m -XX:MaxMetaspaceSize=2048m";
+const HEAP_FLAG = "-Xmx4096m";
+const METASPACE_FLAG = "-XX:MaxMetaspaceSize=2048m";
+
+/**
+ * Merge heap (-Xmx) and metaspace (-XX:MaxMetaspaceSize) flags into the
+ * existing jvmargs string, replacing any prior values for those two flags
+ * while preserving every other arg (e.g. -Dfile.encoding=UTF-8 or Kotlin
+ * daemon options the Expo template may add later).
+ */
+const mergeJvmArgs = (existing) => {
+  const tokens = (existing || "").split(/\s+/).filter(Boolean);
+  const preserved = tokens.filter(
+    (t) => !t.startsWith("-Xmx") && !t.startsWith("-XX:MaxMetaspaceSize"),
+  );
+  return [...preserved, HEAP_FLAG, METASPACE_FLAG].join(" ");
+};
 
 const withAndroidGradleJvmArgs = (config) =>
   withGradleProperties(config, (cfg) => {
@@ -9,20 +24,15 @@ const withAndroidGradleJvmArgs = (config) =>
     const existing = props.find(
       (p) => p.type === "property" && p.key === JVM_ARGS_KEY,
     );
+    const merged = mergeJvmArgs(existing?.value);
 
     if (existing) {
-      existing.value = JVM_ARGS_VALUE;
+      existing.value = merged;
     } else {
-      props.push({
-        type: "property",
-        key: JVM_ARGS_KEY,
-        value: JVM_ARGS_VALUE,
-      });
+      props.push({ type: "property", key: JVM_ARGS_KEY, value: merged });
     }
 
-    console.log(
-      `withAndroidGradleJvmArgs: set ${JVM_ARGS_KEY}=${JVM_ARGS_VALUE}`,
-    );
+    console.log(`withAndroidGradleJvmArgs: set ${JVM_ARGS_KEY}=${merged}`);
     return cfg;
   });
 

--- a/apps/mobile/plugins/withAndroidGradleJvmArgs.js
+++ b/apps/mobile/plugins/withAndroidGradleJvmArgs.js
@@ -1,0 +1,29 @@
+const { withGradleProperties } = require("@expo/config-plugins");
+
+const JVM_ARGS_KEY = "org.gradle.jvmargs";
+const JVM_ARGS_VALUE = "-Xmx4096m -XX:MaxMetaspaceSize=2048m";
+
+const withAndroidGradleJvmArgs = (config) =>
+  withGradleProperties(config, (cfg) => {
+    const props = cfg.modResults;
+    const existing = props.find(
+      (p) => p.type === "property" && p.key === JVM_ARGS_KEY,
+    );
+
+    if (existing) {
+      existing.value = JVM_ARGS_VALUE;
+    } else {
+      props.push({
+        type: "property",
+        key: JVM_ARGS_KEY,
+        value: JVM_ARGS_VALUE,
+      });
+    }
+
+    console.log(
+      `withAndroidGradleJvmArgs: set ${JVM_ARGS_KEY}=${JVM_ARGS_VALUE}`,
+    );
+    return cfg;
+  });
+
+module.exports = withAndroidGradleJvmArgs;

--- a/apps/mobile/plugins/withWatchSessionBridge.js
+++ b/apps/mobile/plugins/withWatchSessionBridge.js
@@ -86,9 +86,11 @@ final class WatchSessionBridge: NSObject {
     ]
     DispatchQueue.main.async {
       if let bridge = RCTBridge.current() {
-        bridge.eventDispatcher().sendDeviceEvent(
-          withName: "watchState",
-          body: payload
+        bridge.enqueueJSCall(
+          "RCTDeviceEventEmitter",
+          method: "emit",
+          args: ["watchState", payload],
+          completion: nil
         )
         watchBridgeLog.info("dispatched watchState paired=\\(WCSession.default.isPaired, privacy: .public) installed=\\(WCSession.default.isWatchAppInstalled, privacy: .public) to RN")
       }
@@ -186,9 +188,11 @@ extension WatchSessionBridge: WCSessionDelegate {
     guard let type = message["type"] as? String else { return }
     DispatchQueue.main.async {
       if let bridge = RCTBridge.current() {
-        bridge.eventDispatcher().sendDeviceEvent(
-          withName: "watchRemoteEvent",
-          body: ["type": type]
+        bridge.enqueueJSCall(
+          "RCTDeviceEventEmitter",
+          method: "emit",
+          args: ["watchRemoteEvent", ["type": type]],
+          completion: nil
         )
         watchBridgeLog.info("dispatched watchRemoteEvent type=\\(type, privacy: .public) to RN")
       } else {


### PR DESCRIPTION
## Summary

Two small build-time fixes surfaced while producing 1.4.1 release builds:

- **Android — JVM OOM on release build**: Local `eas build --platform android --profile production --local` failed at `:expo-updates:kspReleaseKotlin` with `java.lang.OutOfMemoryError: Metaspace` under Gradle's default `-Xmx2048m -XX:MaxMetaspaceSize=512m`. Added `plugins/withAndroidGradleJvmArgs.js` that uses `withGradleProperties` to set `org.gradle.jvmargs=-Xmx4096m -XX:MaxMetaspaceSize=2048m`, so the bump survives `expo prebuild --clean`.
- **iOS — deprecation warning in injected watch bridge**: `bridge.eventDispatcher().sendDeviceEvent(...)` is deprecated (`Subclass RCTEventEmitter instead`). The watch bridge is intentionally injected into `AppDelegate.swift` to avoid patching `project.pbxproj`, so a full `RCTEventEmitter` subclass isn't a good fit. Switched both call sites (`watchState`, `watchRemoteEvent`) to `bridge.enqueueJSCall("RCTDeviceEventEmitter", method: "emit", args: [...])`, which is what `RCTEventEmitter` uses internally.

No behavior change for JS consumers — `DeviceEventEmitter.addListener("watchState" / "watchRemoteEvent", ...)` keeps working unchanged.
