### PR TITLE
Epic: 6 quick-win fixes + diagnostics

### DIFF
--- a/apps/mobile/app/group-detail/[id]/index.tsx
+++ b/apps/mobile/app/group-detail/[id]/index.tsx
@@ -121,22 +121,24 @@ export default function GroupDetailScreen() {
   );
   const [sortOrder, setSortOrder] = useState<SortOrder>("desc");
 
-  // Handle share - opens custom action sheet
+  const shareMessage = group
+    ? t("groups.share.message", { name: group.name })
+    : "";
+  const shareUrl = group?.inviteToken
+    ? buildGroupInviteUrl(group.inviteToken)
+    : "";
+  const shareText = group?.inviteToken ? `${shareMessage}\n\n${shareUrl}` : "";
+
   const handleShare = useCallback(() => {
     if (!group?.inviteToken) {
       showDialog(t("common.status.error"), t("groups.share.noToken"));
       return;
     }
     setIsShareSheetOpen(true);
-  }, [group, showDialog, t]);
+  }, [group?.inviteToken, showDialog, t]);
 
-  // Share via WhatsApp directly
   const shareViaWhatsApp = useCallback(async () => {
     if (!group?.inviteToken) return;
-
-    const inviteUrl = buildGroupInviteUrl(group.inviteToken);
-    const message = t("groups.share.message", { name: group.name });
-    const shareText = `${message}\n\n${inviteUrl}`;
 
     const whatsappUrl = `whatsapp://send?text=${encodeURIComponent(shareText)}`;
 
@@ -155,15 +157,10 @@ export default function GroupDetailScreen() {
       logger.error("Failed to open WhatsApp:", error);
       showDialog(t("common.status.error"), t("groups.share.whatsappFailed"));
     }
-  }, [group, showDialog, t]);
+  }, [group?.inviteToken, shareText, showDialog, t]);
 
-  // Copy to clipboard
   const copyToClipboard = useCallback(async () => {
     if (!group?.inviteToken) return;
-
-    const inviteUrl = buildGroupInviteUrl(group.inviteToken);
-    const message = t("groups.share.message", { name: group.name });
-    const shareText = `${message}\n\n${inviteUrl}`;
 
     try {
       await Clipboard.setStringAsync(shareText);
@@ -173,26 +170,21 @@ export default function GroupDetailScreen() {
       logger.error("Failed to copy to clipboard:", error);
       showDialog(t("common.status.error"), t("groups.share.copyFailed"));
     }
-  }, [group, showDialog, t]);
+  }, [group?.inviteToken, shareText, showDialog, t]);
 
-  // Open native share sheet
   const openNativeShare = useCallback(async () => {
     if (!group?.inviteToken) return;
-
-    const inviteUrl = buildGroupInviteUrl(group.inviteToken);
-    const message = t("groups.share.message", { name: group.name });
-    const shareText = `${message}\n\n${inviteUrl}`;
 
     try {
       await Share.share({
         message: shareText,
-        title: message,
+        title: shareMessage,
       });
       setIsShareSheetOpen(false);
     } catch (error) {
       logger.error("Failed to share:", error);
     }
-  }, [group, t]);
+  }, [group?.inviteToken, shareText, shareMessage]);
 
   // Handle settings navigation
   const handleSettings = useCallback(() => {

--- a/apps/mobile/app/group-detail/[id]/index.tsx
+++ b/apps/mobile/app/group-detail/[id]/index.tsx
@@ -1,4 +1,4 @@
-import { getAppUrl } from "@prostcounter/shared";
+import { buildGroupInviteUrl } from "@prostcounter/shared";
 import { useFestival } from "@prostcounter/shared/contexts";
 import {
   useGroupLeaderboard,
@@ -134,7 +134,7 @@ export default function GroupDetailScreen() {
   const shareViaWhatsApp = useCallback(async () => {
     if (!group?.inviteToken) return;
 
-    const inviteUrl = `${getAppUrl()}/join-group?token=${group.inviteToken}`;
+    const inviteUrl = buildGroupInviteUrl(group.inviteToken);
     const message = t("groups.share.message", { name: group.name });
     const shareText = `${message}\n\n${inviteUrl}`;
 
@@ -161,7 +161,7 @@ export default function GroupDetailScreen() {
   const copyToClipboard = useCallback(async () => {
     if (!group?.inviteToken) return;
 
-    const inviteUrl = `${getAppUrl()}/join-group?token=${group.inviteToken}`;
+    const inviteUrl = buildGroupInviteUrl(group.inviteToken);
     const message = t("groups.share.message", { name: group.name });
     const shareText = `${message}\n\n${inviteUrl}`;
 
@@ -179,7 +179,7 @@ export default function GroupDetailScreen() {
   const openNativeShare = useCallback(async () => {
     if (!group?.inviteToken) return;
 
-    const inviteUrl = `${getAppUrl()}/join-group?token=${group.inviteToken}`;
+    const inviteUrl = buildGroupInviteUrl(group.inviteToken);
     const message = t("groups.share.message", { name: group.name });
     const shareText = `${message}\n\n${inviteUrl}`;
 

--- a/apps/mobile/app/map/index.tsx
+++ b/apps/mobile/app/map/index.tsx
@@ -278,9 +278,11 @@ function NearbyFriendsList({ members }: { members: LocationSessionMember[] }) {
               <Text className="font-medium text-typography-900">
                 {member.fullName || member.username}
               </Text>
-              <Text className="text-sm text-typography-500">
-                {member.groupName}
-              </Text>
+              {member.groupNames.length > 0 && (
+                <Text className="text-sm text-typography-500">
+                  {member.groupNames.join(", ")}
+                </Text>
+              )}
             </VStack>
             {member.distance !== null && (
               <Text className="text-sm text-typography-500">

--- a/apps/mobile/components/groups/invite-link-section.tsx
+++ b/apps/mobile/components/groups/invite-link-section.tsx
@@ -1,4 +1,4 @@
-import { getAppUrl } from "@prostcounter/shared";
+import { buildGroupInviteUrl } from "@prostcounter/shared";
 import { useRenewInviteToken } from "@prostcounter/shared/hooks";
 import { useTranslation } from "@prostcounter/shared/i18n";
 import { Check, Copy, Link, RefreshCw, Share2 } from "lucide-react-native";
@@ -31,9 +31,7 @@ export function InviteLinkSection({
   const renewToken = useRenewInviteToken();
   const [copied, setCopied] = useState(false);
 
-  const inviteUrl = inviteToken
-    ? `${getAppUrl()}/join-group?token=${inviteToken}`
-    : "";
+  const inviteUrl = inviteToken ? buildGroupInviteUrl(inviteToken) : "";
 
   // Handle copy to clipboard (uses Share as fallback)
   const handleCopy = useCallback(async () => {

--- a/apps/mobile/components/groups/qr-code-sheet.tsx
+++ b/apps/mobile/components/groups/qr-code-sheet.tsx
@@ -1,4 +1,4 @@
-import { getAppUrl } from "@prostcounter/shared";
+import { buildGroupInviteUrl } from "@prostcounter/shared";
 import { useRenewInviteToken } from "@prostcounter/shared/hooks";
 import { useTranslation } from "@prostcounter/shared/i18n";
 import { QrCode, RefreshCw } from "lucide-react-native";
@@ -75,10 +75,7 @@ export function QRCodeSheet({
     }
   }, [groupId, renewToken]);
 
-  const appUrl = getAppUrl();
-  const joinUrl = currentToken
-    ? `${appUrl}/api/join-group?token=${currentToken}`
-    : null;
+  const joinUrl = currentToken ? buildGroupInviteUrl(currentToken) : null;
 
   return (
     <Actionsheet isOpen={isOpen} onClose={onClose}>

--- a/apps/mobile/components/location/FriendMap.tsx
+++ b/apps/mobile/components/location/FriendMap.tsx
@@ -174,7 +174,10 @@ export function FriendMap({
               longitude: member.lastLocation.longitude,
             },
             title: member.fullName || member.username || "Friend",
-            snippet: member.groupName || undefined,
+            snippet:
+              member.groupNames.length > 0
+                ? member.groupNames.join(", ")
+                : undefined,
           });
         }
       });

--- a/apps/mobile/components/location/GroupSelector.tsx
+++ b/apps/mobile/components/location/GroupSelector.tsx
@@ -18,12 +18,12 @@ import {
   CheckboxLabel,
 } from "@/components/ui/checkbox";
 import { HStack } from "@/components/ui/hstack";
+import { LabeledSwitchRow } from "@/components/ui/labeled-switch-row";
 import { Pressable } from "@/components/ui/pressable";
 import { Spinner } from "@/components/ui/spinner";
-import { Switch } from "@/components/ui/switch";
 import { Text } from "@/components/ui/text";
 import { VStack } from "@/components/ui/vstack";
-import { Colors, IconColors, SwitchColors } from "@/lib/constants/colors";
+import { Colors, IconColors } from "@/lib/constants/colors";
 import { useAdaptedGroups } from "@/lib/database/adapted-hooks";
 
 interface Group {
@@ -119,26 +119,11 @@ export function GroupSelector({
 
   return (
     <VStack space="sm" className="pt-3">
-      {/* Share with all toggle */}
-      <Pressable
-        onPress={() => handleShareWithAllToggle(!shareWithAll)}
-        className="active:opacity-80"
-      >
-        <HStack className="items-center justify-between rounded-lg bg-background-0 p-2">
-          <Text className="text-sm text-typography-700">
-            {t("location.groups.shareWithAll")}
-          </Text>
-          <Switch
-            size="sm"
-            value={shareWithAll}
-            onValueChange={handleShareWithAllToggle}
-            trackColor={{
-              false: SwitchColors.trackOff,
-              true: SwitchColors.trackOn,
-            }}
-          />
-        </HStack>
-      </Pressable>
+      <LabeledSwitchRow
+        title={t("location.groups.shareWithAll")}
+        value={shareWithAll}
+        onValueChange={handleShareWithAllToggle}
+      />
 
       {/* Divider with text */}
       <HStack className="items-center py-1">

--- a/apps/mobile/components/location/GroupSelectorSheet.tsx
+++ b/apps/mobile/components/location/GroupSelectorSheet.tsx
@@ -26,12 +26,11 @@ import {
 } from "@/components/ui/checkbox";
 import { Heading } from "@/components/ui/heading";
 import { HStack } from "@/components/ui/hstack";
-import { Pressable } from "@/components/ui/pressable";
+import { LabeledSwitchRow } from "@/components/ui/labeled-switch-row";
 import { Spinner } from "@/components/ui/spinner";
-import { Switch } from "@/components/ui/switch";
 import { Text } from "@/components/ui/text";
 import { VStack } from "@/components/ui/vstack";
-import { Colors, IconColors, SwitchColors } from "@/lib/constants/colors";
+import { Colors, IconColors } from "@/lib/constants/colors";
 import { useAdaptedGroups } from "@/lib/database/adapted-hooks";
 
 interface Group {
@@ -144,30 +143,13 @@ export function GroupSelectorSheet({
             </VStack>
           ) : (
             <>
-              {/* Share with all toggle */}
-              <Pressable
-                onPress={() => handleShareWithAllToggle(!shareWithAll)}
-                className="active:opacity-80"
-              >
-                <HStack className="items-center justify-between rounded-lg bg-background-50 p-4">
-                  <VStack className="flex-1">
-                    <Text className="font-medium text-typography-900">
-                      {t("location.groups.shareWithAll")}
-                    </Text>
-                    <Text className="text-sm text-typography-500">
-                      {t("location.groups.shareWithAllDescription")}
-                    </Text>
-                  </VStack>
-                  <Switch
-                    value={shareWithAll}
-                    onValueChange={handleShareWithAllToggle}
-                    trackColor={{
-                      false: SwitchColors.trackOff,
-                      true: SwitchColors.trackOn,
-                    }}
-                  />
-                </HStack>
-              </Pressable>
+              <LabeledSwitchRow
+                variant="prominent"
+                title={t("location.groups.shareWithAll")}
+                description={t("location.groups.shareWithAllDescription")}
+                value={shareWithAll}
+                onValueChange={handleShareWithAllToggle}
+              />
 
               {/* Group list */}
               <VStack space="xs">

--- a/apps/mobile/components/location/LocationMapModal.tsx
+++ b/apps/mobile/components/location/LocationMapModal.tsx
@@ -282,9 +282,11 @@ function NearbyFriendsList({ members }: { members: LocationSessionMember[] }) {
               <Text className="font-medium text-typography-900">
                 {member.fullName || member.username}
               </Text>
-              <Text className="text-sm text-typography-500">
-                {member.groupName}
-              </Text>
+              {member.groupNames.length > 0 && (
+                <Text className="text-sm text-typography-500">
+                  {member.groupNames.join(", ")}
+                </Text>
+              )}
             </VStack>
             {member.distance !== null && (
               <Text className="text-sm text-typography-500">

--- a/apps/mobile/components/location/LocationSharingToggle.tsx
+++ b/apps/mobile/components/location/LocationSharingToggle.tsx
@@ -4,6 +4,7 @@ import {
   AlertTriangle,
   ChevronDown,
   ChevronUp,
+  Heart,
   MapPin,
   Radio,
   Users,
@@ -16,10 +17,11 @@ import { Button, ButtonSpinner, ButtonText } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { HStack } from "@/components/ui/hstack";
 import { Pressable } from "@/components/ui/pressable";
+import { Switch } from "@/components/ui/switch";
 import { Text } from "@/components/ui/text";
 import { VStack } from "@/components/ui/vstack";
 import { useGlobalAlert } from "@/lib/alerts";
-import { Colors, IconColors } from "@/lib/constants/colors";
+import { Colors, IconColors, SwitchColors } from "@/lib/constants/colors";
 import { useLocationContext } from "@/lib/location";
 
 import { GroupSelector } from "./GroupSelector";
@@ -69,6 +71,7 @@ export function LocationSharingToggle({
   const [isGroupSelectorOpen, setIsGroupSelectorOpen] = useState(false);
   const [shareWithAll, setShareWithAll] = useState(true);
   const [selectedGroupIds, setSelectedGroupIds] = useState<string[]>([]);
+  const [shareWithFriends, setShareWithFriends] = useState(false);
   // Inline warning message (shown when background location has issues)
   const [inlineWarning, setInlineWarning] = useState<string | null>(null);
 
@@ -107,7 +110,12 @@ export function LocationSharingToggle({
       }
       // Pass groupIds only if not sharing with all groups
       const groupIds = shareWithAll ? undefined : selectedGroupIds;
-      const result = await startSharing(festivalId, selectedDuration, groupIds);
+      const result = await startSharing(
+        festivalId,
+        selectedDuration,
+        groupIds,
+        shareWithFriends,
+      );
 
       if (!result.success) {
         showAlert(
@@ -137,6 +145,7 @@ export function LocationSharingToggle({
     selectedDuration,
     shareWithAll,
     selectedGroupIds,
+    shareWithFriends,
     showAlert,
     useInlineWarnings,
     t,
@@ -148,7 +157,12 @@ export function LocationSharingToggle({
     if (granted) {
       // Pass groupIds only if not sharing with all groups
       const groupIds = shareWithAll ? undefined : selectedGroupIds;
-      const result = await startSharing(festivalId, selectedDuration, groupIds);
+      const result = await startSharing(
+        festivalId,
+        selectedDuration,
+        groupIds,
+        shareWithFriends,
+      );
 
       if (!result.success) {
         showAlert(
@@ -173,6 +187,7 @@ export function LocationSharingToggle({
     selectedDuration,
     shareWithAll,
     selectedGroupIds,
+    shareWithFriends,
     showAlert,
     useInlineWarnings,
     t,
@@ -392,6 +407,38 @@ export function LocationSharingToggle({
                       shareWithAll={shareWithAll}
                       onShareWithAllChange={setShareWithAll}
                     />
+
+                    {/* Also share with friends (additive to group visibility) */}
+                    <Pressable
+                      onPress={() => setShareWithFriends(!shareWithFriends)}
+                      className="mt-3 active:opacity-80"
+                      accessibilityLabel={t(
+                        "location.friends.alsoShareWithFriends",
+                      )}
+                    >
+                      <HStack className="items-center justify-between rounded-lg bg-background-0 p-2">
+                        <HStack space="sm" className="flex-1 items-center pr-2">
+                          <Heart size={16} color={IconColors.default} />
+                          <VStack className="flex-1">
+                            <Text className="text-sm text-typography-700">
+                              {t("location.friends.alsoShareWithFriends")}
+                            </Text>
+                            <Text className="text-xs text-typography-500">
+                              {t("location.friends.alsoShareDescription")}
+                            </Text>
+                          </VStack>
+                        </HStack>
+                        <Switch
+                          size="sm"
+                          value={shareWithFriends}
+                          onValueChange={setShareWithFriends}
+                          trackColor={{
+                            false: SwitchColors.trackOff,
+                            true: SwitchColors.trackOn,
+                          }}
+                        />
+                      </HStack>
+                    </Pressable>
                   </View>
                 )}
               </VStack>

--- a/apps/mobile/components/location/LocationSharingToggle.tsx
+++ b/apps/mobile/components/location/LocationSharingToggle.tsx
@@ -110,12 +110,11 @@ export function LocationSharingToggle({
       }
       // Pass groupIds only if not sharing with all groups
       const groupIds = shareWithAll ? undefined : selectedGroupIds;
-      const result = await startSharing(
-        festivalId,
-        selectedDuration,
+      const result = await startSharing(festivalId, {
+        durationMinutes: selectedDuration,
         groupIds,
         shareWithFriends,
-      );
+      });
 
       if (!result.success) {
         showAlert(
@@ -157,12 +156,11 @@ export function LocationSharingToggle({
     if (granted) {
       // Pass groupIds only if not sharing with all groups
       const groupIds = shareWithAll ? undefined : selectedGroupIds;
-      const result = await startSharing(
-        festivalId,
-        selectedDuration,
+      const result = await startSharing(festivalId, {
+        durationMinutes: selectedDuration,
         groupIds,
         shareWithFriends,
-      );
+      });
 
       if (!result.success) {
         showAlert(
@@ -413,7 +411,7 @@ export function LocationSharingToggle({
                       onPress={() => setShareWithFriends(!shareWithFriends)}
                       className="mt-3 active:opacity-80"
                       accessibilityLabel={t(
-                        "location.friends.alsoShareWithFriends",
+                        "location.groups.alsoShareWithFriends",
                       )}
                     >
                       <HStack className="items-center justify-between rounded-lg bg-background-0 p-2">
@@ -421,10 +419,12 @@ export function LocationSharingToggle({
                           <Heart size={16} color={IconColors.default} />
                           <VStack className="flex-1">
                             <Text className="text-sm text-typography-700">
-                              {t("location.friends.alsoShareWithFriends")}
+                              {t("location.groups.alsoShareWithFriends")}
                             </Text>
                             <Text className="text-xs text-typography-500">
-                              {t("location.friends.alsoShareDescription")}
+                              {t(
+                                "location.groups.alsoShareWithFriendsDescription",
+                              )}
                             </Text>
                           </VStack>
                         </HStack>

--- a/apps/mobile/components/location/LocationSharingToggle.tsx
+++ b/apps/mobile/components/location/LocationSharingToggle.tsx
@@ -16,12 +16,12 @@ import { View } from "react-native";
 import { Button, ButtonSpinner, ButtonText } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { HStack } from "@/components/ui/hstack";
+import { LabeledSwitchRow } from "@/components/ui/labeled-switch-row";
 import { Pressable } from "@/components/ui/pressable";
-import { Switch } from "@/components/ui/switch";
 import { Text } from "@/components/ui/text";
 import { VStack } from "@/components/ui/vstack";
 import { useGlobalAlert } from "@/lib/alerts";
-import { Colors, IconColors, SwitchColors } from "@/lib/constants/colors";
+import { Colors, IconColors } from "@/lib/constants/colors";
 import { useLocationContext } from "@/lib/location";
 
 import { GroupSelector } from "./GroupSelector";
@@ -407,38 +407,16 @@ export function LocationSharingToggle({
                     />
 
                     {/* Also share with friends (additive to group visibility) */}
-                    <Pressable
-                      onPress={() => setShareWithFriends(!shareWithFriends)}
-                      className="mt-3 active:opacity-80"
-                      accessibilityLabel={t(
-                        "location.groups.alsoShareWithFriends",
+                    <LabeledSwitchRow
+                      className="mt-3"
+                      icon={Heart}
+                      title={t("location.groups.alsoShareWithFriends")}
+                      description={t(
+                        "location.groups.alsoShareWithFriendsDescription",
                       )}
-                    >
-                      <HStack className="items-center justify-between rounded-lg bg-background-0 p-2">
-                        <HStack space="sm" className="flex-1 items-center pr-2">
-                          <Heart size={16} color={IconColors.default} />
-                          <VStack className="flex-1">
-                            <Text className="text-sm text-typography-700">
-                              {t("location.groups.alsoShareWithFriends")}
-                            </Text>
-                            <Text className="text-xs text-typography-500">
-                              {t(
-                                "location.groups.alsoShareWithFriendsDescription",
-                              )}
-                            </Text>
-                          </VStack>
-                        </HStack>
-                        <Switch
-                          size="sm"
-                          value={shareWithFriends}
-                          onValueChange={setShareWithFriends}
-                          trackColor={{
-                            false: SwitchColors.trackOff,
-                            true: SwitchColors.trackOn,
-                          }}
-                        />
-                      </HStack>
-                    </Pressable>
+                      value={shareWithFriends}
+                      onValueChange={setShareWithFriends}
+                    />
                   </View>
                 )}
               </VStack>

--- a/apps/mobile/components/ui/labeled-switch-row/index.tsx
+++ b/apps/mobile/components/ui/labeled-switch-row/index.tsx
@@ -1,0 +1,91 @@
+import { cn } from "@prostcounter/ui";
+import type { LucideIcon } from "lucide-react-native";
+
+import { HStack } from "@/components/ui/hstack";
+import { Pressable } from "@/components/ui/pressable";
+import { Switch } from "@/components/ui/switch";
+import { Text } from "@/components/ui/text";
+import { VStack } from "@/components/ui/vstack";
+import { IconColors, SwitchColors } from "@/lib/constants/colors";
+
+export interface LabeledSwitchRowProps {
+  value: boolean;
+  onValueChange: (value: boolean) => void;
+  title: string;
+  description?: string;
+  /** Optional leading icon. Rendered at 16px with the default icon color. */
+  icon?: LucideIcon;
+  /**
+   * Visual density:
+   * - "compact" (default): inline inside lists/accordions — p-2, smaller text.
+   * - "prominent": bottom sheets / standalone cards — p-4, bolder title.
+   */
+  variant?: "compact" | "prominent";
+  accessibilityLabel?: string;
+  /** Applied to the outer Pressable (useful for spacing like `mt-3`). */
+  className?: string;
+}
+
+export function LabeledSwitchRow({
+  value,
+  onValueChange,
+  title,
+  description,
+  icon: Icon,
+  variant = "compact",
+  accessibilityLabel,
+  className,
+}: LabeledSwitchRowProps) {
+  const isProminent = variant === "prominent";
+  return (
+    <Pressable
+      onPress={() => onValueChange(!value)}
+      className={cn("active:opacity-80", className)}
+      accessibilityLabel={accessibilityLabel ?? title}
+    >
+      <HStack
+        className={cn(
+          "items-center justify-between rounded-lg",
+          isProminent ? "bg-background-50 p-4" : "bg-background-0 p-2",
+        )}
+      >
+        <HStack space="sm" className="flex-1 items-center pr-2">
+          {Icon ? <Icon size={16} color={IconColors.default} /> : null}
+          <VStack className="flex-1">
+            <Text
+              className={
+                isProminent
+                  ? "font-medium text-typography-900"
+                  : "text-sm text-typography-700"
+              }
+            >
+              {title}
+            </Text>
+            {description ? (
+              <Text
+                className={
+                  isProminent
+                    ? "text-sm text-typography-500"
+                    : "text-xs text-typography-500"
+                }
+              >
+                {description}
+              </Text>
+            ) : null}
+          </VStack>
+        </HStack>
+        <Switch
+          size={isProminent ? "md" : "sm"}
+          value={value}
+          onValueChange={onValueChange}
+          trackColor={{
+            false: SwitchColors.trackOff,
+            true: SwitchColors.trackOn,
+          }}
+        />
+      </HStack>
+    </Pressable>
+  );
+}
+
+LabeledSwitchRow.displayName = "LabeledSwitchRow";

--- a/apps/mobile/hooks/useAvatarUpload.ts
+++ b/apps/mobile/hooks/useAvatarUpload.ts
@@ -7,9 +7,10 @@
 
 import { useInvalidateQueries } from "@prostcounter/shared/data";
 import { QueryKeys } from "@prostcounter/shared/data";
-import { replaceLocalhostInUrl } from "@prostcounter/shared/utils";
+import { replaceLocalhostInUrl, safeHost } from "@prostcounter/shared/utils";
 
 import { apiClient } from "@/lib/api-client";
+import { Sentry } from "@/lib/sentry";
 
 import { type ImageSource, useImageUpload } from "./useImageUpload";
 
@@ -62,20 +63,53 @@ export function useAvatarUpload({
 
       // Step 2: Upload compressed image directly to storage
       // Fix URL for local dev: replace localhost with the mobile client's Supabase host
-      const fixedUploadUrl = replaceLocalhostInUrl(
-        uploadUrl,
-        process.env.EXPO_PUBLIC_SUPABASE_URL || "",
-      );
-      const uploadResponse = await fetch(fixedUploadUrl, {
-        method: "PUT",
-        headers: {
-          "Content-Type": image.mimeType,
-        },
-        body: image.arrayBuffer,
-      });
+      const envSupabaseUrl = process.env.EXPO_PUBLIC_SUPABASE_URL || "";
+      const fixedUploadUrl = replaceLocalhostInUrl(uploadUrl, envSupabaseUrl);
+
+      let uploadResponse: Response;
+      try {
+        uploadResponse = await fetch(fixedUploadUrl, {
+          method: "PUT",
+          headers: {
+            "Content-Type": image.mimeType,
+          },
+          body: image.arrayBuffer,
+        });
+      } catch (networkErr) {
+        Sentry.captureException(networkErr, {
+          tags: { flow: "avatar-upload" },
+          extra: {
+            stage: "network",
+            uploadHost: safeHost(fixedUploadUrl),
+            envSupabaseHost: safeHost(envSupabaseUrl),
+            mimeType: image.mimeType,
+            fileSize: image.arrayBuffer.byteLength,
+          },
+        });
+        throw networkErr;
+      }
 
       if (!uploadResponse.ok) {
-        throw new Error("Failed to upload image to storage");
+        const bodySnippet = await uploadResponse
+          .text()
+          .catch(() => "<no body>");
+        Sentry.captureMessage("Storage PUT failed", {
+          level: "error",
+          tags: { flow: "avatar-upload" },
+          extra: {
+            stage: "http",
+            status: uploadResponse.status,
+            statusText: uploadResponse.statusText,
+            body: bodySnippet.slice(0, 500),
+            uploadHost: safeHost(fixedUploadUrl),
+            envSupabaseHost: safeHost(envSupabaseUrl),
+            mimeType: image.mimeType,
+            fileSize: image.arrayBuffer.byteLength,
+          },
+        });
+        throw new Error(
+          `Storage upload failed (${uploadResponse.status} on ${safeHost(fixedUploadUrl)})`,
+        );
       }
 
       // Step 3: Confirm upload with just the filename

--- a/apps/mobile/hooks/useAvatarUpload.ts
+++ b/apps/mobile/hooks/useAvatarUpload.ts
@@ -7,10 +7,10 @@
 
 import { useInvalidateQueries } from "@prostcounter/shared/data";
 import { QueryKeys } from "@prostcounter/shared/data";
-import { replaceLocalhostInUrl, safeHost } from "@prostcounter/shared/utils";
+import { replaceLocalhostInUrl } from "@prostcounter/shared/utils";
 
 import { apiClient } from "@/lib/api-client";
-import { Sentry } from "@/lib/sentry";
+import { putToStorageWithDiagnostics } from "@/lib/storage-upload";
 
 import { type ImageSource, useImageUpload } from "./useImageUpload";
 
@@ -66,51 +66,13 @@ export function useAvatarUpload({
       const envSupabaseUrl = process.env.EXPO_PUBLIC_SUPABASE_URL || "";
       const fixedUploadUrl = replaceLocalhostInUrl(uploadUrl, envSupabaseUrl);
 
-      let uploadResponse: Response;
-      try {
-        uploadResponse = await fetch(fixedUploadUrl, {
-          method: "PUT",
-          headers: {
-            "Content-Type": image.mimeType,
-          },
-          body: image.arrayBuffer,
-        });
-      } catch (networkErr) {
-        Sentry.captureException(networkErr, {
-          tags: { flow: "avatar-upload" },
-          extra: {
-            stage: "network",
-            uploadHost: safeHost(fixedUploadUrl),
-            envSupabaseHost: safeHost(envSupabaseUrl),
-            mimeType: image.mimeType,
-            fileSize: image.arrayBuffer.byteLength,
-          },
-        });
-        throw networkErr;
-      }
-
-      if (!uploadResponse.ok) {
-        const bodySnippet = await uploadResponse
-          .text()
-          .catch(() => "<no body>");
-        Sentry.captureMessage("Storage PUT failed", {
-          level: "error",
-          tags: { flow: "avatar-upload" },
-          extra: {
-            stage: "http",
-            status: uploadResponse.status,
-            statusText: uploadResponse.statusText,
-            body: bodySnippet.slice(0, 500),
-            uploadHost: safeHost(fixedUploadUrl),
-            envSupabaseHost: safeHost(envSupabaseUrl),
-            mimeType: image.mimeType,
-            fileSize: image.arrayBuffer.byteLength,
-          },
-        });
-        throw new Error(
-          `Storage upload failed (${uploadResponse.status} on ${safeHost(fixedUploadUrl)})`,
-        );
-      }
+      await putToStorageWithDiagnostics({
+        url: fixedUploadUrl,
+        body: image.arrayBuffer,
+        mimeType: image.mimeType,
+        envSupabaseUrl,
+        flow: "avatar-upload",
+      });
 
       // Step 3: Confirm upload with just the filename
       await apiClient.profile.confirmAvatarUpload(fileName);

--- a/apps/mobile/hooks/useBeerPictureUpload.ts
+++ b/apps/mobile/hooks/useBeerPictureUpload.ts
@@ -11,10 +11,11 @@
  * 3. API: Get signed upload URL → Upload to storage → Confirm upload
  */
 
-import { replaceLocalhostInUrl } from "@prostcounter/shared/utils";
+import { replaceLocalhostInUrl, safeHost } from "@prostcounter/shared/utils";
 import { useCallback, useState } from "react";
 
 import { apiClient } from "@/lib/api-client";
+import { Sentry } from "@/lib/sentry";
 
 import { type ImageSource, useImageUpload } from "./useImageUpload";
 
@@ -155,20 +156,58 @@ export function useBeerPictureUpload({
 
           // Step 3: Upload compressed image directly to storage
           // Fix URL for local dev: replace localhost with the mobile client's Supabase host
+          const envSupabaseUrl = process.env.EXPO_PUBLIC_SUPABASE_URL || "";
           const fixedUploadUrl = replaceLocalhostInUrl(
             uploadUrl,
-            process.env.EXPO_PUBLIC_SUPABASE_URL || "",
+            envSupabaseUrl,
           );
-          const uploadResponse = await fetch(fixedUploadUrl, {
-            method: "PUT",
-            headers: {
-              "Content-Type": compressedImage.mimeType,
-            },
-            body: compressedImage.arrayBuffer,
-          });
+
+          let uploadResponse: Response;
+          try {
+            uploadResponse = await fetch(fixedUploadUrl, {
+              method: "PUT",
+              headers: {
+                "Content-Type": compressedImage.mimeType,
+              },
+              body: compressedImage.arrayBuffer,
+            });
+          } catch (networkErr) {
+            // No response at all (DNS, TLS, timeout). The host is the single
+            // most useful field here — captures "wrong URL in the build" cases.
+            Sentry.captureException(networkErr, {
+              tags: { flow: "beer-picture-upload" },
+              extra: {
+                stage: "network",
+                uploadHost: safeHost(fixedUploadUrl),
+                envSupabaseHost: safeHost(envSupabaseUrl),
+                mimeType: compressedImage.mimeType,
+                fileSize: compressedImage.arrayBuffer.byteLength,
+              },
+            });
+            throw networkErr;
+          }
 
           if (!uploadResponse.ok) {
-            throw new Error("Failed to upload image to storage");
+            const bodySnippet = await uploadResponse
+              .text()
+              .catch(() => "<no body>");
+            Sentry.captureMessage("Storage PUT failed", {
+              level: "error",
+              tags: { flow: "beer-picture-upload" },
+              extra: {
+                stage: "http",
+                status: uploadResponse.status,
+                statusText: uploadResponse.statusText,
+                body: bodySnippet.slice(0, 500),
+                uploadHost: safeHost(fixedUploadUrl),
+                envSupabaseHost: safeHost(envSupabaseUrl),
+                mimeType: compressedImage.mimeType,
+                fileSize: compressedImage.arrayBuffer.byteLength,
+              },
+            });
+            throw new Error(
+              `Storage upload failed (${uploadResponse.status} on ${safeHost(fixedUploadUrl)})`,
+            );
           }
 
           // Step 4: Confirm upload with API

--- a/apps/mobile/hooks/useBeerPictureUpload.ts
+++ b/apps/mobile/hooks/useBeerPictureUpload.ts
@@ -11,11 +11,11 @@
  * 3. API: Get signed upload URL → Upload to storage → Confirm upload
  */
 
-import { replaceLocalhostInUrl, safeHost } from "@prostcounter/shared/utils";
+import { replaceLocalhostInUrl } from "@prostcounter/shared/utils";
 import { useCallback, useState } from "react";
 
 import { apiClient } from "@/lib/api-client";
-import { Sentry } from "@/lib/sentry";
+import { putToStorageWithDiagnostics } from "@/lib/storage-upload";
 
 import { type ImageSource, useImageUpload } from "./useImageUpload";
 
@@ -162,53 +162,13 @@ export function useBeerPictureUpload({
             envSupabaseUrl,
           );
 
-          let uploadResponse: Response;
-          try {
-            uploadResponse = await fetch(fixedUploadUrl, {
-              method: "PUT",
-              headers: {
-                "Content-Type": compressedImage.mimeType,
-              },
-              body: compressedImage.arrayBuffer,
-            });
-          } catch (networkErr) {
-            // No response at all (DNS, TLS, timeout). The host is the single
-            // most useful field here — captures "wrong URL in the build" cases.
-            Sentry.captureException(networkErr, {
-              tags: { flow: "beer-picture-upload" },
-              extra: {
-                stage: "network",
-                uploadHost: safeHost(fixedUploadUrl),
-                envSupabaseHost: safeHost(envSupabaseUrl),
-                mimeType: compressedImage.mimeType,
-                fileSize: compressedImage.arrayBuffer.byteLength,
-              },
-            });
-            throw networkErr;
-          }
-
-          if (!uploadResponse.ok) {
-            const bodySnippet = await uploadResponse
-              .text()
-              .catch(() => "<no body>");
-            Sentry.captureMessage("Storage PUT failed", {
-              level: "error",
-              tags: { flow: "beer-picture-upload" },
-              extra: {
-                stage: "http",
-                status: uploadResponse.status,
-                statusText: uploadResponse.statusText,
-                body: bodySnippet.slice(0, 500),
-                uploadHost: safeHost(fixedUploadUrl),
-                envSupabaseHost: safeHost(envSupabaseUrl),
-                mimeType: compressedImage.mimeType,
-                fileSize: compressedImage.arrayBuffer.byteLength,
-              },
-            });
-            throw new Error(
-              `Storage upload failed (${uploadResponse.status} on ${safeHost(fixedUploadUrl)})`,
-            );
-          }
+          await putToStorageWithDiagnostics({
+            url: fixedUploadUrl,
+            body: compressedImage.arrayBuffer,
+            mimeType: compressedImage.mimeType,
+            envSupabaseUrl,
+            flow: "beer-picture-upload",
+          });
 
           // Step 4: Confirm upload with API
           const confirmedPhoto =

--- a/apps/mobile/lib/location/LocationContext.tsx
+++ b/apps/mobile/lib/location/LocationContext.tsx
@@ -82,6 +82,7 @@ interface LocationContextType {
     festivalId: string,
     durationMinutes?: number,
     groupIds?: string[],
+    shareWithFriends?: boolean,
   ) => Promise<StartSharingResult>;
   stopSharing: () => Promise<boolean>;
   startLocalTracking: (festivalId?: string) => Promise<boolean>;
@@ -197,6 +198,8 @@ export function LocationProvider({ children }: { children: ReactNode }) {
    * @param festivalId - Festival to share location for
    * @param durationMinutes - How long to share (default 2 hours)
    * @param groupIds - Specific groups to share with (undefined = all groups)
+   * @param shareWithFriends - When true, accepted friends can see this session
+   *   regardless of group overlap (additive to the group visibility)
    * @returns Result object with success status, session, and background status
    */
   const startSharing = useCallback(
@@ -204,6 +207,7 @@ export function LocationProvider({ children }: { children: ReactNode }) {
       festivalId: string,
       durationMinutes = 120,
       groupIds?: string[],
+      shareWithFriends = false,
     ): Promise<StartSharingResult> => {
       if (!location.hasPermission) {
         logger.warn("No permission to start sharing");
@@ -235,6 +239,7 @@ export function LocationProvider({ children }: { children: ReactNode }) {
           // Pass visibility and groupIds if specific groups selected
           visibility: groupIds && groupIds.length > 0 ? "specific" : "groups",
           groupIds: groupIds && groupIds.length > 0 ? groupIds : undefined,
+          shareWithFriends,
         });
 
         if (!result?.session) {
@@ -729,7 +734,12 @@ const defaultContext: LocationContextType = {
   requestPermission: async () => false,
   requestBackgroundPermission: async () => false,
   markPromptAsShown: async () => {},
-  startSharing: async (_festivalId, _durationMinutes?, _groupIds?) => ({
+  startSharing: async (
+    _festivalId,
+    _durationMinutes?,
+    _groupIds?,
+    _shareWithFriends?,
+  ) => ({
     success: false,
     backgroundEnabled: false,
   }),

--- a/apps/mobile/lib/location/LocationContext.tsx
+++ b/apps/mobile/lib/location/LocationContext.tsx
@@ -48,6 +48,21 @@ export interface StartSharingResult {
 }
 
 /**
+ * Options for startSharing — bundled so the call site stays readable as new
+ * visibility knobs are added (shareWithFriends, groupIds, durationMinutes...).
+ */
+export interface StartSharingOptions {
+  /** How long to share, in minutes. Default 120 (2 hours). */
+  durationMinutes?: number;
+  /** Specific groups to share with. When omitted, shares with all the user's
+   *  groups for this festival. */
+  groupIds?: string[];
+  /** Additive: when true, accepted friends can see this session regardless of
+   *  group overlap. */
+  shareWithFriends?: boolean;
+}
+
+/**
  * Location Context Type
  */
 interface LocationContextType {
@@ -80,9 +95,7 @@ interface LocationContextType {
   markPromptAsShown: () => Promise<void>;
   startSharing: (
     festivalId: string,
-    durationMinutes?: number,
-    groupIds?: string[],
-    shareWithFriends?: boolean,
+    options?: StartSharingOptions,
   ) => Promise<StartSharingResult>;
   stopSharing: () => Promise<boolean>;
   startLocalTracking: (festivalId?: string) => Promise<boolean>;
@@ -194,21 +207,20 @@ export function LocationProvider({ children }: { children: ReactNode }) {
   );
 
   /**
-   * Start location sharing
+   * Start location sharing.
    * @param festivalId - Festival to share location for
-   * @param durationMinutes - How long to share (default 2 hours)
-   * @param groupIds - Specific groups to share with (undefined = all groups)
-   * @param shareWithFriends - When true, accepted friends can see this session
-   *   regardless of group overlap (additive to the group visibility)
-   * @returns Result object with success status, session, and background status
+   * @param options - Visibility + duration knobs; see StartSharingOptions
    */
   const startSharing = useCallback(
     async (
       festivalId: string,
-      durationMinutes = 120,
-      groupIds?: string[],
-      shareWithFriends = false,
+      options: StartSharingOptions = {},
     ): Promise<StartSharingResult> => {
+      const {
+        durationMinutes = 120,
+        groupIds,
+        shareWithFriends = false,
+      } = options;
       if (!location.hasPermission) {
         logger.warn("No permission to start sharing");
         return {
@@ -734,12 +746,7 @@ const defaultContext: LocationContextType = {
   requestPermission: async () => false,
   requestBackgroundPermission: async () => false,
   markPromptAsShown: async () => {},
-  startSharing: async (
-    _festivalId,
-    _durationMinutes?,
-    _groupIds?,
-    _shareWithFriends?,
-  ) => ({
+  startSharing: async () => ({
     success: false,
     backgroundEnabled: false,
   }),

--- a/apps/mobile/lib/storage-upload.ts
+++ b/apps/mobile/lib/storage-upload.ts
@@ -1,0 +1,70 @@
+import { safeHost } from "@prostcounter/shared/utils";
+
+import { Sentry } from "@/lib/sentry";
+
+export type UploadFlow = "beer-picture-upload" | "avatar-upload";
+
+interface PutToStorageArgs {
+  url: string;
+  body: ArrayBuffer;
+  mimeType: string;
+  /** Client-configured Supabase URL — logged alongside the actual upload host so
+   *  a "wrong URL in the build" mismatch jumps out at a glance in Sentry. */
+  envSupabaseUrl: string;
+  flow: UploadFlow;
+}
+
+/**
+ * PUT a blob to a signed Supabase-storage URL and report failures to Sentry
+ * with enough context (status, body snippet, upload host, env host, mime type,
+ * size) to diagnose "why did it fail" from the event alone.
+ */
+export async function putToStorageWithDiagnostics({
+  url,
+  body,
+  mimeType,
+  envSupabaseUrl,
+  flow,
+}: PutToStorageArgs): Promise<void> {
+  const extra = {
+    uploadHost: safeHost(url),
+    envSupabaseHost: safeHost(envSupabaseUrl),
+    mimeType,
+    fileSize: body.byteLength,
+  };
+
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      method: "PUT",
+      headers: { "Content-Type": mimeType },
+      body,
+    });
+  } catch (networkErr) {
+    // No response at all (DNS, TLS, timeout). The host pair is the single
+    // most useful field here — captures "wrong URL in the build" cases.
+    Sentry.captureException(networkErr, {
+      tags: { flow },
+      extra: { stage: "network", ...extra },
+    });
+    throw networkErr;
+  }
+
+  if (!response.ok) {
+    const bodySnippet = await response.text().catch(() => "<no body>");
+    Sentry.captureMessage("Storage PUT failed", {
+      level: "error",
+      tags: { flow },
+      extra: {
+        stage: "http",
+        status: response.status,
+        statusText: response.statusText,
+        body: bodySnippet.slice(0, 500),
+        ...extra,
+      },
+    });
+    throw new Error(
+      `Storage upload failed (${response.status} on ${extra.uploadHost})`,
+    );
+  }
+}

--- a/apps/web/components/QR/QRButton.tsx
+++ b/apps/web/components/QR/QRButton.tsx
@@ -34,7 +34,10 @@ export default function QRButton({
   const generateShareLink = useCallback(async () => {
     try {
       const { inviteToken } = await renewToken({ groupId });
-      const newGroupLink = `${APP_URL}/api/join-group?token=${inviteToken}`;
+      // Use /join-group (not /api/join-group) so the URL matches the mobile
+      // app's Universal Link / Android App Link intent filter. The web app
+      // still forwards /join-group -> /api/join-group internally.
+      const newGroupLink = `${APP_URL}/join-group?token=${inviteToken}`;
       startTransition(() => {
         setGroupLink(newGroupLink);
       });

--- a/apps/web/components/QR/QRButton.tsx
+++ b/apps/web/components/QR/QRButton.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { buildGroupInviteUrl } from "@prostcounter/shared";
 import { QrCode } from "lucide-react";
 import { startTransition, useCallback, useEffect, useState } from "react";
 import { toast } from "sonner";
@@ -27,17 +28,17 @@ export default function QRButton({
   const [groupLink, setGroupLink] = useState("");
   const [tokenGenerated, setTokenGenerated] = useState(false);
 
-  const APP_URL = typeof window !== "undefined" ? window.location.origin : "";
-
   const { mutateAsync: renewToken } = useRenewInviteToken();
 
   const generateShareLink = useCallback(async () => {
     try {
       const { inviteToken } = await renewToken({ groupId });
-      // Use /join-group (not /api/join-group) so the URL matches the mobile
-      // app's Universal Link / Android App Link intent filter. The web app
-      // still forwards /join-group -> /api/join-group internally.
-      const newGroupLink = `${APP_URL}/join-group?token=${inviteToken}`;
+      // Pin the origin to the browser window so the link matches whatever host
+      // the user is currently on (prod, preview, local). The shared helper
+      // enforces the "/join-group" path that the mobile intent filter expects.
+      const origin =
+        typeof window !== "undefined" ? window.location.origin : undefined;
+      const newGroupLink = buildGroupInviteUrl(inviteToken, origin);
       startTransition(() => {
         setGroupLink(newGroupLink);
       });
@@ -46,7 +47,7 @@ export default function QRButton({
         description: "Failed to generate QR code. Please try again.",
       });
     }
-  }, [groupId, APP_URL, renewToken]);
+  }, [groupId, renewToken]);
 
   const handleQRClick = async () => {
     if (!tokenGenerated) {

--- a/apps/web/components/ShareButton/ShareButton.tsx
+++ b/apps/web/components/ShareButton/ShareButton.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { buildGroupInviteUrl } from "@prostcounter/shared";
 import { Share2 } from "lucide-react";
 import {
   startTransition,
@@ -39,17 +40,14 @@ export default function ShareButton({
     url: groupLink,
   });
 
-  const APP_URL = typeof window !== "undefined" ? window.location.origin : "";
-
   const { mutateAsync: renewToken } = useRenewInviteToken();
 
   const generateShareLink = useCallback(async () => {
     try {
       const { inviteToken } = await renewToken({ groupId });
-      // Use /join-group (not /api/join-group) so the URL matches the mobile
-      // app's Universal Link / Android App Link intent filter. The web app
-      // still forwards /join-group -> /api/join-group internally.
-      const newGroupLink = `${APP_URL}/join-group?token=${inviteToken}`;
+      const origin =
+        typeof window !== "undefined" ? window.location.origin : undefined;
+      const newGroupLink = buildGroupInviteUrl(inviteToken, origin);
       startTransition(() => {
         setGroupLink(newGroupLink);
       });
@@ -58,7 +56,7 @@ export default function ShareButton({
         description: "Failed to generate share link. Please try again.",
       });
     }
-  }, [groupId, APP_URL, renewToken]);
+  }, [groupId, renewToken]);
 
   const handleShareClick = async () => {
     if (!tokenGenerated) {

--- a/apps/web/components/ShareButton/ShareButton.tsx
+++ b/apps/web/components/ShareButton/ShareButton.tsx
@@ -46,7 +46,10 @@ export default function ShareButton({
   const generateShareLink = useCallback(async () => {
     try {
       const { inviteToken } = await renewToken({ groupId });
-      const newGroupLink = `${APP_URL}/api/join-group?token=${inviteToken}`;
+      // Use /join-group (not /api/join-group) so the URL matches the mobile
+      // app's Universal Link / Android App Link intent filter. The web app
+      // still forwards /join-group -> /api/join-group internally.
+      const newGroupLink = `${APP_URL}/join-group?token=${inviteToken}`;
       startTransition(() => {
         setGroupLink(newGroupLink);
       });

--- a/packages/api-client/src/generated.ts
+++ b/packages/api-client/src/generated.ts
@@ -5373,6 +5373,8 @@ export interface paths {
                          */
                         visibility?: "groups" | "specific";
                         groupIds?: string[];
+                        /** @default false */
+                        shareWithFriends?: boolean;
                     };
                 };
             };

--- a/packages/api-client/src/generated.ts
+++ b/packages/api-client/src/generated.ts
@@ -5631,7 +5631,6 @@ export interface paths {
                     latitude?: number | null;
                     longitude?: number | null;
                     radiusMeters?: number;
-                    groupId?: string;
                 };
                 header?: never;
                 path?: never;
@@ -5655,9 +5654,7 @@ export interface paths {
                                 fullName: string | null;
                                 /** Format: uri */
                                 avatarUrl: string | null;
-                                /** Format: uuid */
-                                groupId: string;
-                                groupName: string;
+                                groupNames: string[];
                                 lastLocation: {
                                     latitude: number;
                                     longitude: number;

--- a/packages/api-client/src/typed-client.ts
+++ b/packages/api-client/src/typed-client.ts
@@ -2053,6 +2053,8 @@ export function createTypedApiClient(config: ApiClientConfig) {
         visibility?: "groups" | "specific";
         /** Group IDs to share with when visibility is "specific" */
         groupIds?: string[];
+        /** Additive: when true, accepted friends can see this session */
+        shareWithFriends?: boolean;
       }): Promise<{
         session: {
           id: string;

--- a/packages/api-client/src/typed-client.ts
+++ b/packages/api-client/src/typed-client.ts
@@ -2153,7 +2153,6 @@ export function createTypedApiClient(config: ApiClientConfig) {
         latitude: number;
         longitude: number;
         radiusMeters?: number;
-        groupId?: string;
       }): Promise<{
         members: Array<{
           sessionId: string;
@@ -2161,8 +2160,7 @@ export function createTypedApiClient(config: ApiClientConfig) {
           username: string;
           fullName: string | null;
           avatarUrl: string | null;
-          groupId: string;
-          groupName: string;
+          groupNames: string[];
           lastLocation: {
             latitude: number;
             longitude: number;
@@ -2186,7 +2184,6 @@ export function createTypedApiClient(config: ApiClientConfig) {
         });
         if (query.radiusMeters)
           params.set("radiusMeters", query.radiusMeters.toString());
-        if (query.groupId) params.set("groupId", query.groupId);
 
         const response = await fetchWithLogging(
           "GET",

--- a/packages/api/openapi.json
+++ b/packages/api/openapi.json
@@ -9922,6 +9922,10 @@
                       "type": "string",
                       "format": "uuid"
                     }
+                  },
+                  "shareWithFriends": {
+                    "type": "boolean",
+                    "default": false
                   }
                 },
                 "required": [

--- a/packages/api/openapi.json
+++ b/packages/api/openapi.json
@@ -10428,15 +10428,6 @@
             "required": false,
             "name": "radiusMeters",
             "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "required": false,
-            "name": "groupId",
-            "in": "query"
           }
         ],
         "responses": {
@@ -10472,12 +10463,11 @@
                             "nullable": true,
                             "format": "uri"
                           },
-                          "groupId": {
-                            "type": "string",
-                            "format": "uuid"
-                          },
-                          "groupName": {
-                            "type": "string"
+                          "groupNames": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
                           },
                           "lastLocation": {
                             "type": "object",
@@ -10519,8 +10509,7 @@
                           "username",
                           "fullName",
                           "avatarUrl",
-                          "groupId",
-                          "groupName",
+                          "groupNames",
                           "lastLocation",
                           "distance"
                         ]

--- a/packages/api/src/repositories/interfaces/location.repository.ts
+++ b/packages/api/src/repositories/interfaces/location.repository.ts
@@ -66,7 +66,6 @@ export interface ILocationRepository {
    * @param latitude - Current latitude
    * @param longitude - Current longitude
    * @param radiusMeters - Search radius in meters
-   * @param groupId - Optional group filter
    * @returns Array of nearby members with their locations
    */
   getNearbyMembers(
@@ -75,7 +74,6 @@ export interface ILocationRepository {
     latitude: number,
     longitude: number,
     radiusMeters: number,
-    groupId?: string,
   ): Promise<LocationSessionMember[]>;
 
   /**

--- a/packages/api/src/repositories/supabase/attendance.repository.ts
+++ b/packages/api/src/repositories/supabase/attendance.repository.ts
@@ -218,14 +218,24 @@ export class SupabaseAttendanceRepository implements IAttendanceRepository {
       throw new DatabaseError("Unauthorized to delete this attendance");
     }
 
-    // Delete the attendance (consumptions will cascade delete)
-    const { error } = await this.supabase
+    // Delete the attendance (consumptions will cascade delete).
+    // Use .select() so the driver returns the affected rows; otherwise a
+    // silent 0-row delete (RLS denial or blocking FK) is indistinguishable
+    // from a real delete and the route handler would happily report success.
+    const { data: deleted, error } = await this.supabase
       .from("attendances")
       .delete()
-      .eq("id", id);
+      .eq("id", id)
+      .select("id");
 
     if (error) {
       throw new DatabaseError(`Failed to delete attendance: ${error.message}`);
+    }
+
+    if (!deleted || deleted.length === 0) {
+      throw new DatabaseError(
+        `Attendance delete affected 0 rows for id=${id}; likely RLS policy or FK constraint`,
+      );
     }
   }
 

--- a/packages/api/src/repositories/supabase/consumption.repository.ts
+++ b/packages/api/src/repositories/supabase/consumption.repository.ts
@@ -146,13 +146,20 @@ export class SupabaseConsumptionRepository implements IConsumptionRepository {
       throw new DatabaseError("Unauthorized to delete this consumption");
     }
 
-    const { error } = await this.supabase
+    const { data: deleted, error } = await this.supabase
       .from("consumptions")
       .delete()
-      .eq("id", id);
+      .eq("id", id)
+      .select("id");
 
     if (error) {
       throw new DatabaseError(`Failed to delete consumption: ${error.message}`);
+    }
+
+    if (!deleted || deleted.length === 0) {
+      throw new DatabaseError(
+        `Consumption delete affected 0 rows for id=${id}; likely RLS policy or FK constraint`,
+      );
     }
   }
 

--- a/packages/api/src/repositories/supabase/friend.repository.ts
+++ b/packages/api/src/repositories/supabase/friend.repository.ts
@@ -223,26 +223,40 @@ export class SupabaseFriendRepository implements IFriendRepository {
   }
 
   async cancelRequest(friendshipId: string, userId: string): Promise<void> {
-    const { error } = await this.supabase
+    const { data: deleted, error } = await this.supabase
       .from("friendships")
       .delete()
       .eq("id", friendshipId)
       .eq("requester_id", userId)
-      .eq("status", "pending");
+      .eq("status", "pending")
+      .select("id");
 
     if (error) throw new DatabaseError(error.message);
+
+    if (!deleted || deleted.length === 0) {
+      throw new DatabaseError(
+        `Friend request cancel affected 0 rows for id=${friendshipId}; not pending, not the requester, or RLS policy blocked`,
+      );
+    }
   }
 
   async unfriend(userId: string, friendUserId: string): Promise<void> {
-    const { error } = await this.supabase
+    const { data: deleted, error } = await this.supabase
       .from("friendships")
       .delete()
       .eq("status", "accepted")
       .or(
         `and(requester_id.eq.${userId},addressee_id.eq.${friendUserId}),and(requester_id.eq.${friendUserId},addressee_id.eq.${userId})`,
-      );
+      )
+      .select("id");
 
     if (error) throw new DatabaseError(error.message);
+
+    if (!deleted || deleted.length === 0) {
+      throw new DatabaseError(
+        `Unfriend affected 0 rows for pair (${userId}, ${friendUserId}); no accepted friendship or RLS policy blocked`,
+      );
+    }
   }
 
   async getSuggestions(userId: string): Promise<FriendSuggestion[]> {

--- a/packages/api/src/repositories/supabase/group.repository.ts
+++ b/packages/api/src/repositories/supabase/group.repository.ts
@@ -212,14 +212,21 @@ export class SupabaseGroupRepository implements IGroupRepository {
   }
 
   async removeMember(groupId: string, userId: string): Promise<void> {
-    const { error } = await this.supabase
+    const { data: deleted, error } = await this.supabase
       .from("group_members")
       .delete()
       .eq("group_id", groupId)
-      .eq("user_id", userId);
+      .eq("user_id", userId)
+      .select("user_id");
 
     if (error) {
       throw new DatabaseError(`Failed to remove member: ${error.message}`);
+    }
+
+    if (!deleted || deleted.length === 0) {
+      throw new DatabaseError(
+        `Group member removal affected 0 rows for group=${groupId}, user=${userId}; not a member or RLS policy blocked`,
+      );
     }
   }
 

--- a/packages/api/src/repositories/supabase/location.repository.ts
+++ b/packages/api/src/repositories/supabase/location.repository.ts
@@ -259,12 +259,14 @@ export class SupabaseLocationRepository implements ILocationRepository {
   async getNearbyMembers(
     userId: string,
     festivalId: string,
-    latitude: number,
-    longitude: number,
+    _latitude: number,
+    _longitude: number,
     radiusMeters: number,
-    groupId?: string,
   ): Promise<LocationSessionMember[]> {
-    // Use the database RPC function for proximity search
+    // Use the database RPC function for proximity search. Note the RPC derives
+    // the caller's current position from their own active session, so the
+    // latitude/longitude args are not passed through — kept in the interface
+    // for the route handler's response shape.
     const { data, error } = await this.supabase.rpc(
       "get_nearby_group_members",
       {
@@ -280,20 +282,13 @@ export class SupabaseLocationRepository implements ILocationRepository {
       );
     }
 
-    // Filter by groupId if provided
-    let filtered = data || [];
-    if (groupId) {
-      filtered = filtered.filter((m: any) => m.group_id === groupId);
-    }
-
-    return filtered.map((m: any) => ({
+    return (data || []).map((m: any) => ({
       sessionId: m.session_id,
       userId: m.user_id,
       username: m.username,
       fullName: m.full_name,
       avatarUrl: m.avatar_url,
-      groupId: m.group_id,
-      groupName: m.group_name,
+      groupNames: (m.group_names ?? []) as string[],
       lastLocation:
         m.latitude && m.longitude
           ? {

--- a/packages/api/src/repositories/supabase/location.repository.ts
+++ b/packages/api/src/repositories/supabase/location.repository.ts
@@ -44,6 +44,7 @@ export class SupabaseLocationRepository implements ILocationRepository {
       is_active: true,
       started_at: new Date().toISOString(),
       expires_at: expiresAt.toISOString(),
+      share_with_friends: input.shareWithFriends ?? false,
     };
 
     let { data: session, error: sessionError } = await this.supabase

--- a/packages/api/src/repositories/supabase/photo.repository.ts
+++ b/packages/api/src/repositories/supabase/photo.repository.ts
@@ -225,14 +225,21 @@ export class SupabasePhotoRepository implements IPhotoRepository {
     }
 
     // Delete database record
-    const { error: dbError } = await this.supabase
+    const { data: deleted, error: dbError } = await this.supabase
       .from("beer_pictures")
       .delete()
       .eq("id", pictureId)
-      .eq("user_id", userId);
+      .eq("user_id", userId)
+      .select("id");
 
     if (dbError) {
       throw new DatabaseError(`Failed to delete picture: ${dbError.message}`);
+    }
+
+    if (!deleted || deleted.length === 0) {
+      throw new DatabaseError(
+        `Picture delete affected 0 rows for id=${pictureId}; not owned by user or RLS policy blocked`,
+      );
     }
   }
 

--- a/packages/api/src/repositories/supabase/profile.repository.ts
+++ b/packages/api/src/repositories/supabase/profile.repository.ts
@@ -212,13 +212,20 @@ export class SupabaseProfileRepository {
       .eq("user_id", userId);
 
     // 10. Delete profile (this should cascade or be handled by RLS)
-    const { error } = await this.supabase
+    const { data: deleted, error } = await this.supabase
       .from("profiles")
       .delete()
-      .eq("id", userId);
+      .eq("id", userId)
+      .select("id");
 
     if (error) {
       throw new Error(`Failed to delete profile: ${error.message}`);
+    }
+
+    if (!deleted || deleted.length === 0) {
+      throw new Error(
+        `Profile delete affected 0 rows for id=${userId}; likely RLS policy blocked`,
+      );
     }
   }
 

--- a/packages/api/src/routes/__tests__/attendance.route.test.ts
+++ b/packages/api/src/routes/__tests__/attendance.route.test.ts
@@ -324,9 +324,10 @@ describe("Attendance Routes - Unit Tests", () => {
         createMockChain(mockSupabaseSuccess({ user_id: mockUser.id })),
       );
 
-      // Mock attendance delete operation
+      // Mock attendance delete operation — must return at least one row so
+      // the repository's "0 rows affected" guard doesn't fire.
       vi.mocked(mockSupabase.from).mockReturnValueOnce(
-        createMockChain(mockSupabaseSuccess(null)),
+        createMockChain(mockSupabaseSuccess([{ id: attendanceId }])),
       );
 
       const req = createAuthRequest(`/attendance/${attendanceId}`, {

--- a/packages/api/src/routes/__tests__/location.route.test.ts
+++ b/packages/api/src/routes/__tests__/location.route.test.ts
@@ -446,8 +446,7 @@ describe("Location Routes - Unit Tests", () => {
           username: "beerfan",
           fullName: "Beer Fan",
           avatarUrl: "https://example.com/avatar1.jpg",
-          groupId: "group-e89b-12d3-a456-426614174001",
-          groupName: "Beer Buddies",
+          groupNames: ["Beer Buddies"],
           lastLocation: {
             latitude: 48.1352,
             longitude: 11.5821,
@@ -462,8 +461,7 @@ describe("Location Routes - Unit Tests", () => {
           username: "prosthund",
           fullName: "Prost Hund",
           avatarUrl: null,
-          groupId: "group-e89b-12d3-a456-426614174001",
-          groupName: "Beer Buddies",
+          groupNames: ["Beer Buddies"],
           lastLocation: {
             latitude: 48.1355,
             longitude: 11.5825,
@@ -502,38 +500,6 @@ describe("Location Routes - Unit Tests", () => {
         latitude,
         longitude,
         1000,
-        undefined,
-      );
-    });
-
-    it("should filter by group ID", async () => {
-      const festivalId = "123e4567-e89b-12d3-a456-426614174000";
-      const groupId = "923e4567-e89b-12d3-a456-426614174001"; // Valid UUID
-      const latitude = 48.1351;
-      const longitude = 11.582;
-
-      mockLocationService.getNearbyMembers.mockResolvedValueOnce([]);
-
-      const req = createAuthRequest(
-        `/location/nearby?festivalId=${festivalId}&latitude=${latitude}&longitude=${longitude}&groupId=${groupId}`,
-        {
-          method: "GET",
-        },
-      );
-
-      const res = await app.request(req.url, {
-        method: req.method,
-        headers: req.headers,
-      });
-
-      expect(res.status).toBe(200);
-      expect(mockLocationService.getNearbyMembers).toHaveBeenCalledWith(
-        mockUser.id,
-        festivalId,
-        latitude,
-        longitude,
-        1000, // Default radius
-        groupId,
       );
     });
 
@@ -636,24 +602,6 @@ describe("Location Routes - Unit Tests", () => {
 
       const req = createAuthRequest(
         `/location/nearby?festivalId=${festivalId}&latitude=100&longitude=11.582`, // Invalid latitude
-        {
-          method: "GET",
-        },
-      );
-
-      const res = await app.request(req.url, {
-        method: req.method,
-        headers: req.headers,
-      });
-
-      expect(res.status).toBe(400);
-    });
-
-    it("should validate groupId is valid UUID when provided", async () => {
-      const festivalId = "123e4567-e89b-12d3-a456-426614174000";
-
-      const req = createAuthRequest(
-        `/location/nearby?festivalId=${festivalId}&latitude=48.1351&longitude=11.582&groupId=invalid-uuid`,
         {
           method: "GET",
         },

--- a/packages/api/src/routes/location.route.ts
+++ b/packages/api/src/routes/location.route.ts
@@ -304,7 +304,6 @@ app.openapi(getNearbyMembersRoute, async (c) => {
     query.latitude,
     query.longitude,
     query.radiusMeters,
-    query.groupId,
   );
 
   return c.json(

--- a/packages/api/src/services/location.service.ts
+++ b/packages/api/src/services/location.service.ts
@@ -155,7 +155,6 @@ export class LocationService {
    * @param latitude - Current latitude
    * @param longitude - Current longitude
    * @param radiusMeters - Search radius in meters
-   * @param groupId - Optional group filter
    * @returns Array of nearby members with their locations
    */
   async getNearbyMembers(
@@ -164,7 +163,6 @@ export class LocationService {
     latitude: number,
     longitude: number,
     radiusMeters: number,
-    groupId?: string,
   ): Promise<LocationSessionMember[]> {
     // Validate radius
     if (radiusMeters < 100 || radiusMeters > 5000) {
@@ -188,7 +186,6 @@ export class LocationService {
       latitude,
       longitude,
       radiusMeters,
-      groupId,
     );
 
     // Filter out user's own location (shouldn't be in results, but defensive)

--- a/packages/db/src/types.ts
+++ b/packages/db/src/types.ts
@@ -761,6 +761,7 @@ export type Database = {
           festival_id: string
           id: string
           is_active: boolean
+          share_with_friends: boolean
           started_at: string
           updated_at: string
           user_id: string
@@ -771,6 +772,7 @@ export type Database = {
           festival_id: string
           id?: string
           is_active?: boolean
+          share_with_friends?: boolean
           started_at?: string
           updated_at?: string
           user_id: string
@@ -781,6 +783,7 @@ export type Database = {
           festival_id?: string
           id?: string
           is_active?: boolean
+          share_with_friends?: boolean
           started_at?: string
           updated_at?: string
           user_id?: string

--- a/packages/shared/src/i18n/locales/de.json
+++ b/packages/shared/src/i18n/locales/de.json
@@ -1646,11 +1646,9 @@
       "multipleGroups": "{{count}} Gruppen",
       "collapseHint": "Tippe zum Zuklappen",
       "expandHint": "Tippe zum Aufklappen",
-      "orSelectSpecific": "Oder bestimmte Gruppen auswählen"
-    },
-    "friends": {
+      "orSelectSpecific": "Oder bestimmte Gruppen auswählen",
       "alsoShareWithFriends": "Auch mit meinen Freunden teilen",
-      "alsoShareDescription": "Freunde sehen deinen Standort auch, wenn ihr in keiner gemeinsamen Gruppe seid"
+      "alsoShareWithFriendsDescription": "Freunde sehen deinen Standort auch, wenn ihr in keiner gemeinsamen Gruppe seid"
     },
     "proximity": {
       "veryClose": "Sehr nah",

--- a/packages/shared/src/i18n/locales/de.json
+++ b/packages/shared/src/i18n/locales/de.json
@@ -1648,6 +1648,10 @@
       "expandHint": "Tippe zum Aufklappen",
       "orSelectSpecific": "Oder bestimmte Gruppen auswählen"
     },
+    "friends": {
+      "alsoShareWithFriends": "Auch mit meinen Freunden teilen",
+      "alsoShareDescription": "Freunde sehen deinen Standort auch, wenn ihr in keiner gemeinsamen Gruppe seid"
+    },
     "proximity": {
       "veryClose": "Sehr nah",
       "hint": "Tippen, um auf Karte anzuzeigen und einzuchecken",

--- a/packages/shared/src/i18n/locales/en.json
+++ b/packages/shared/src/i18n/locales/en.json
@@ -1904,11 +1904,9 @@
       "multipleGroups": "{{count}} groups",
       "collapseHint": "Tap to collapse",
       "expandHint": "Tap to expand",
-      "orSelectSpecific": "Or select specific groups"
-    },
-    "friends": {
+      "orSelectSpecific": "Or select specific groups",
       "alsoShareWithFriends": "Also share with my friends",
-      "alsoShareDescription": "Friends can see your location even if you don't share a group"
+      "alsoShareWithFriendsDescription": "Friends can see your location even if you don't share a group"
     },
     "proximity": {
       "veryClose": "Very close",

--- a/packages/shared/src/i18n/locales/en.json
+++ b/packages/shared/src/i18n/locales/en.json
@@ -1906,6 +1906,10 @@
       "expandHint": "Tap to expand",
       "orSelectSpecific": "Or select specific groups"
     },
+    "friends": {
+      "alsoShareWithFriends": "Also share with my friends",
+      "alsoShareDescription": "Friends can see your location even if you don't share a group"
+    },
     "proximity": {
       "veryClose": "Very close",
       "hint": "Tap to view on map and check in",

--- a/packages/shared/src/i18n/locales/es.json
+++ b/packages/shared/src/i18n/locales/es.json
@@ -1896,6 +1896,10 @@
       "expandHint": "Tocá para expandir",
       "orSelectSpecific": "O seleccioná grupos específicos"
     },
+    "friends": {
+      "alsoShareWithFriends": "Compartir también con mis amigos",
+      "alsoShareDescription": "Tus amigos ven tu ubicación aunque no compartan un grupo con vos"
+    },
     "proximity": {
       "veryClose": "Muy cerca",
       "hint": "Tocá para ver en el mapa y registrarte",

--- a/packages/shared/src/i18n/locales/es.json
+++ b/packages/shared/src/i18n/locales/es.json
@@ -1894,11 +1894,9 @@
       "multipleGroups": "{{count}} grupos",
       "collapseHint": "Tocá para contraer",
       "expandHint": "Tocá para expandir",
-      "orSelectSpecific": "O seleccioná grupos específicos"
-    },
-    "friends": {
+      "orSelectSpecific": "O seleccioná grupos específicos",
       "alsoShareWithFriends": "Compartir también con mis amigos",
-      "alsoShareDescription": "Tus amigos ven tu ubicación aunque no compartan un grupo con vos"
+      "alsoShareWithFriendsDescription": "Tus amigos ven tu ubicación aunque no compartan un grupo con vos"
     },
     "proximity": {
       "veryClose": "Muy cerca",

--- a/packages/shared/src/schemas/location.schema.ts
+++ b/packages/shared/src/schemas/location.schema.ts
@@ -77,6 +77,13 @@ export const StartLocationSessionSchema = z
      * Required when visibility is "specific", ignored when "groups"
      */
     groupIds: z.array(z.uuid({ error: "Invalid group ID" })).optional(),
+    /**
+     * Additive visibility: when true, the user's accepted friends can see this
+     * session regardless of group overlap. Combines with the group visibility
+     * (a user sees this session if they share a selected group OR they are a
+     * friend and this flag is true).
+     */
+    shareWithFriends: z.boolean().optional().default(false),
   })
   .refine(
     (data) =>

--- a/packages/shared/src/schemas/location.schema.ts
+++ b/packages/shared/src/schemas/location.schema.ts
@@ -34,7 +34,11 @@ export const LocationSessionSchema = z.object({
 export type LocationSession = z.infer<typeof LocationSessionSchema>;
 
 /**
- * Location session with member info
+ * Location session with member info.
+ *
+ * `groupNames` mirrors the `group_names text[]` that the get_nearby_group_members
+ * RPC actually returns — one entry per group the member and caller both belong
+ * to (empty when visibility is purely friend-based).
  */
 export const LocationSessionMemberSchema = z.object({
   sessionId: z.uuid(),
@@ -42,8 +46,7 @@ export const LocationSessionMemberSchema = z.object({
   username: z.string(),
   fullName: z.string().nullable(),
   avatarUrl: z.url().nullable(),
-  groupId: z.uuid(),
-  groupName: z.string(),
+  groupNames: z.array(z.string()),
   lastLocation: LocationPointSchema.nullable(),
   distance: z.number().nullable(), // Distance in meters (if calculated)
 });
@@ -171,7 +174,6 @@ export const GetNearbyMembersQuerySchema = z.object({
     .max(5000)
     .optional()
     .default(1000), // 1km default
-  groupId: z.uuid({ error: "Invalid group ID" }).optional(), // Filter to specific group
 });
 
 export type GetNearbyMembersQuery = z.infer<typeof GetNearbyMembersQuerySchema>;

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -1,5 +1,9 @@
 // URL utilities
-export { getAppUrl, replaceLocalhostInUrl } from "./url";
+export {
+  buildGroupInviteUrl,
+  getAppUrl,
+  replaceLocalhostInUrl,
+} from "./url";
 
 // Date utilities
 export {

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -1,5 +1,5 @@
 // URL utilities
-export { getAppUrl, replaceLocalhostInUrl } from "./url";
+export { getAppUrl, replaceLocalhostInUrl, safeHost } from "./url";
 
 // Date utilities
 export {

--- a/packages/shared/src/utils/url.ts
+++ b/packages/shared/src/utils/url.ts
@@ -55,3 +55,16 @@ export function replaceLocalhostInUrl(
     return url;
   }
 }
+
+/**
+ * Parse just the host out of a URL without throwing. Useful for logging /
+ * diagnostics where an unparseable input should surface as a sentinel string
+ * rather than crash the caller.
+ */
+export function safeHost(url: string): string {
+  try {
+    return new URL(url).host;
+  } catch {
+    return "<invalid-url>";
+  }
+}

--- a/packages/shared/src/utils/url.ts
+++ b/packages/shared/src/utils/url.ts
@@ -61,9 +61,15 @@ export function replaceLocalhostInUrl(
  * mobile app intercepts via Universal Links / Android App Links (see
  * apps/mobile/app.config.ts intent filters), so every invite URL we share
  * MUST use this path (not "/api/join-group") for deeplinking to work.
+ *
+ * @param token - Invite token (URL-encoded internally so non-UUID formats are safe).
+ * @param baseUrl - Optional origin override. Web callers pass `window.location.origin`
+ *                  so the link matches the current browser origin; mobile callers
+ *                  omit it to pick up getAppUrl() (EXPO_PUBLIC_APP_URL).
  */
-export function buildGroupInviteUrl(token: string): string {
-  return `${getAppUrl()}/join-group?token=${token}`;
+export function buildGroupInviteUrl(token: string, baseUrl?: string): string {
+  const origin = baseUrl ?? getAppUrl();
+  return `${origin}/join-group?token=${encodeURIComponent(token)}`;
 }
 
 /**

--- a/packages/shared/src/utils/url.ts
+++ b/packages/shared/src/utils/url.ts
@@ -55,3 +55,13 @@ export function replaceLocalhostInUrl(
     return url;
   }
 }
+
+/**
+ * Build a shareable group-invite URL. The path "/join-group" is the one the
+ * mobile app intercepts via Universal Links / Android App Links (see
+ * apps/mobile/app.config.ts intent filters), so every invite URL we share
+ * MUST use this path (not "/api/join-group") for deeplinking to work.
+ */
+export function buildGroupInviteUrl(token: string): string {
+  return `${getAppUrl()}/join-group?token=${token}`;
+}

--- a/supabase/migrations/20260423120000_add_friend_location_sharing.sql
+++ b/supabase/migrations/20260423120000_add_friend_location_sharing.sql
@@ -9,8 +9,7 @@ ALTER TABLE public.location_sessions
 COMMENT ON COLUMN public.location_sessions.share_with_friends IS
   'When true, the user''s accepted friends can see this session regardless of group overlap.';
 
-DROP FUNCTION IF EXISTS public.get_nearby_group_members(uuid, uuid, integer);
-
+-- Signature unchanged, so CREATE OR REPLACE preserves existing GRANTs.
 CREATE OR REPLACE FUNCTION public.get_nearby_group_members(
   input_user_id uuid,
   input_festival_id uuid,

--- a/supabase/migrations/20260423120000_add_friend_location_sharing.sql
+++ b/supabase/migrations/20260423120000_add_friend_location_sharing.sql
@@ -1,0 +1,123 @@
+-- Extend location sharing so it can also be made visible to the sharer's friends,
+-- independently of group membership. Backed by a new boolean column on
+-- location_sessions and an updated RPC that ORs the friends check into the
+-- visibility filter of get_nearby_group_members().
+
+ALTER TABLE public.location_sessions
+  ADD COLUMN IF NOT EXISTS share_with_friends boolean NOT NULL DEFAULT false;
+
+COMMENT ON COLUMN public.location_sessions.share_with_friends IS
+  'When true, the user''s accepted friends can see this session regardless of group overlap.';
+
+DROP FUNCTION IF EXISTS public.get_nearby_group_members(uuid, uuid, integer);
+
+CREATE OR REPLACE FUNCTION public.get_nearby_group_members(
+  input_user_id uuid,
+  input_festival_id uuid,
+  radius_meters integer DEFAULT 1000
+)
+RETURNS TABLE (
+  user_id uuid,
+  username text,
+  full_name text,
+  avatar_url text,
+  session_id uuid,
+  latitude double precision,
+  longitude double precision,
+  distance_meters double precision,
+  last_updated timestamptz,
+  group_names text[]
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  user_lat double precision;
+  user_lng double precision;
+BEGIN
+  -- Enforce that the caller is querying their own data
+  IF input_user_id != auth.uid() THEN
+    RAISE EXCEPTION 'Access denied: input_user_id must match authenticated user';
+  END IF;
+
+  -- Get user's current location from their active session
+  SELECT lp.latitude, lp.longitude INTO user_lat, user_lng
+  FROM public.location_sessions ls
+  JOIN public.location_points lp ON lp.session_id = ls.id
+  WHERE ls.user_id = input_user_id
+    AND ls.festival_id = input_festival_id
+    AND ls.is_active = true
+    AND ls.expires_at > NOW()
+  ORDER BY lp.recorded_at DESC
+  LIMIT 1;
+
+  -- If user has no active location, return empty result
+  IF user_lat IS NULL THEN
+    RETURN;
+  END IF;
+
+  RETURN QUERY
+  SELECT
+    ls.user_id::uuid,
+    p.username::text,
+    p.full_name::text,
+    p.avatar_url::text,
+    ls.id::uuid AS session_id,
+    lp.latitude::double precision,
+    lp.longitude::double precision,
+    (6371000 * acos(
+      LEAST(1.0, GREATEST(-1.0,
+        cos(radians(user_lat)) * cos(radians(lp.latitude)) *
+        cos(radians(lp.longitude) - radians(user_lng)) +
+        sin(radians(user_lat)) * sin(radians(lp.latitude))
+      ))
+    ))::double precision AS distance_meters,
+    lp.recorded_at::timestamptz AS last_updated,
+    COALESCE(
+      (SELECT array_agg(DISTINCT g.name)::text[]
+       FROM public.group_members gm
+       JOIN public.groups g ON g.id = gm.group_id
+       WHERE gm.user_id = ls.user_id
+         AND g.festival_id = input_festival_id
+         AND EXISTS (SELECT 1 FROM public.group_members gm2
+                     WHERE gm2.group_id = gm.group_id AND gm2.user_id = input_user_id)),
+      ARRAY[]::text[]
+    ) AS group_names
+  FROM public.location_sessions ls
+  JOIN public.location_points lp ON lp.session_id = ls.id
+  JOIN public.profiles p ON p.id = ls.user_id
+  WHERE ls.festival_id = input_festival_id
+    AND ls.is_active = true
+    AND ls.expires_at > NOW()
+    AND ls.user_id != input_user_id
+    -- Get only the latest point for each session
+    AND lp.recorded_at = (SELECT MAX(lp2.recorded_at) FROM public.location_points lp2 WHERE lp2.session_id = ls.id)
+    -- Filter by radius using Haversine formula
+    AND (6371000 * acos(LEAST(1.0, GREATEST(-1.0,
+        cos(radians(user_lat)) * cos(radians(lp.latitude)) *
+        cos(radians(lp.longitude) - radians(user_lng)) +
+        sin(radians(user_lat)) * sin(radians(lp.latitude))
+      )))) <= radius_meters
+    -- Visibility: either a shared group, or the session opts into friend visibility
+    AND (
+      EXISTS (
+        SELECT 1 FROM public.group_members gm1
+        JOIN public.group_members gm2 ON gm2.group_id = gm1.group_id
+        WHERE gm1.user_id = ls.user_id AND gm2.user_id = input_user_id
+      )
+      OR (
+        ls.share_with_friends = true
+        AND public.is_friend(input_user_id, ls.user_id) = true
+      )
+    )
+  ORDER BY distance_meters;
+END;
+$$;
+
+COMMENT ON FUNCTION public.get_nearby_group_members(uuid, uuid, integer) IS
+'Returns nearby users sharing location. Visibility is the UNION of (shared group with caller) and (ls.share_with_friends = true AND is_friend(caller, owner)). Validates input_user_id matches auth.uid() to prevent unauthorized access.';
+
+GRANT ALL ON FUNCTION public.get_nearby_group_members(uuid, uuid, integer) TO anon;
+GRANT ALL ON FUNCTION public.get_nearby_group_members(uuid, uuid, integer) TO authenticated;
+GRANT ALL ON FUNCTION public.get_nearby_group_members(uuid, uuid, integer) TO service_role;

--- a/supabase/migrations/20260423120000_add_friend_location_sharing.sql
+++ b/supabase/migrations/20260423120000_add_friend_location_sharing.sql
@@ -35,8 +35,11 @@ DECLARE
   user_lat double precision;
   user_lng double precision;
 BEGIN
-  -- Enforce that the caller is querying their own data
-  IF input_user_id != auth.uid() THEN
+  -- Enforce that the caller is querying their own data. auth.uid() is NULL for
+  -- unauthenticated/anon callers and `NULL != anything` yields NULL (not TRUE),
+  -- which would bypass the IF. The explicit NULL check closes that hole — and
+  -- matters here because this function is granted to the `anon` role.
+  IF auth.uid() IS NULL OR input_user_id <> auth.uid() THEN
     RAISE EXCEPTION 'Access denied: input_user_id must match authenticated user';
   END IF;
 

--- a/supabase/migrations/20260423130000_nearby_members_friend_left_join.sql
+++ b/supabase/migrations/20260423130000_nearby_members_friend_left_join.sql
@@ -1,0 +1,118 @@
+-- Optimize get_nearby_group_members by rewriting the friends-visibility branch
+-- as a LEFT JOIN against friendships instead of a per-row is_friend() call.
+-- The unique index idx_friendships_unique_pair (added in
+-- 20260318150000_friendship_security_fixes.sql) guarantees at most one
+-- friendship row per user pair, so the LEFT JOIN cannot duplicate rows.
+--
+-- Semantically identical to the prior version; enables the planner to use
+-- index joins over N function invocations when the candidate session set
+-- is large.
+
+CREATE OR REPLACE FUNCTION public.get_nearby_group_members(
+  input_user_id uuid,
+  input_festival_id uuid,
+  radius_meters integer DEFAULT 1000
+)
+RETURNS TABLE (
+  user_id uuid,
+  username text,
+  full_name text,
+  avatar_url text,
+  session_id uuid,
+  latitude double precision,
+  longitude double precision,
+  distance_meters double precision,
+  last_updated timestamptz,
+  group_names text[]
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  user_lat double precision;
+  user_lng double precision;
+BEGIN
+  IF input_user_id != auth.uid() THEN
+    RAISE EXCEPTION 'Access denied: input_user_id must match authenticated user';
+  END IF;
+
+  SELECT lp.latitude, lp.longitude INTO user_lat, user_lng
+  FROM public.location_sessions ls
+  JOIN public.location_points lp ON lp.session_id = ls.id
+  WHERE ls.user_id = input_user_id
+    AND ls.festival_id = input_festival_id
+    AND ls.is_active = true
+    AND ls.expires_at > NOW()
+  ORDER BY lp.recorded_at DESC
+  LIMIT 1;
+
+  IF user_lat IS NULL THEN
+    RETURN;
+  END IF;
+
+  RETURN QUERY
+  SELECT
+    ls.user_id::uuid,
+    p.username::text,
+    p.full_name::text,
+    p.avatar_url::text,
+    ls.id::uuid AS session_id,
+    lp.latitude::double precision,
+    lp.longitude::double precision,
+    (6371000 * acos(
+      LEAST(1.0, GREATEST(-1.0,
+        cos(radians(user_lat)) * cos(radians(lp.latitude)) *
+        cos(radians(lp.longitude) - radians(user_lng)) +
+        sin(radians(user_lat)) * sin(radians(lp.latitude))
+      ))
+    ))::double precision AS distance_meters,
+    lp.recorded_at::timestamptz AS last_updated,
+    COALESCE(
+      (SELECT array_agg(DISTINCT g.name)::text[]
+       FROM public.group_members gm
+       JOIN public.groups g ON g.id = gm.group_id
+       WHERE gm.user_id = ls.user_id
+         AND g.festival_id = input_festival_id
+         AND EXISTS (SELECT 1 FROM public.group_members gm2
+                     WHERE gm2.group_id = gm.group_id AND gm2.user_id = input_user_id)),
+      ARRAY[]::text[]
+    ) AS group_names
+  FROM public.location_sessions ls
+  JOIN public.location_points lp ON lp.session_id = ls.id
+  JOIN public.profiles p ON p.id = ls.user_id
+  -- At most one friendship per pair (enforced by idx_friendships_unique_pair),
+  -- so this LEFT JOIN cannot duplicate rows. It's gated on share_with_friends
+  -- so sessions that didn't opt into friend visibility don't join at all.
+  LEFT JOIN public.friendships f
+    ON f.status = 'accepted'
+    AND ls.share_with_friends = true
+    AND (
+      (f.requester_id = input_user_id AND f.addressee_id = ls.user_id)
+      OR (f.requester_id = ls.user_id AND f.addressee_id = input_user_id)
+    )
+  WHERE ls.festival_id = input_festival_id
+    AND ls.is_active = true
+    AND ls.expires_at > NOW()
+    AND ls.user_id != input_user_id
+    AND lp.recorded_at = (SELECT MAX(lp2.recorded_at) FROM public.location_points lp2 WHERE lp2.session_id = ls.id)
+    AND (6371000 * acos(LEAST(1.0, GREATEST(-1.0,
+        cos(radians(user_lat)) * cos(radians(lp.latitude)) *
+        cos(radians(lp.longitude) - radians(user_lng)) +
+        sin(radians(user_lat)) * sin(radians(lp.latitude))
+      )))) <= radius_meters
+    -- Visibility: either a shared group OR the friendship LEFT JOIN matched.
+    AND (
+      EXISTS (
+        SELECT 1 FROM public.group_members gm1
+        JOIN public.group_members gm2 ON gm2.group_id = gm1.group_id
+        WHERE gm1.user_id = ls.user_id AND gm2.user_id = input_user_id
+      )
+      OR f.id IS NOT NULL
+    )
+  ORDER BY distance_meters;
+END;
+$$;
+
+COMMENT ON FUNCTION public.get_nearby_group_members(uuid, uuid, integer) IS
+'Returns nearby users sharing location. Visibility is the UNION of (shared group with caller) and (ls.share_with_friends = true AND caller is an accepted friend of owner). Validates input_user_id matches auth.uid() to prevent unauthorized access.';

--- a/supabase/migrations/20260423130000_nearby_members_friend_left_join.sql
+++ b/supabase/migrations/20260423130000_nearby_members_friend_left_join.sql
@@ -33,7 +33,9 @@ DECLARE
   user_lat double precision;
   user_lng double precision;
 BEGIN
-  IF input_user_id != auth.uid() THEN
+  -- Reject unauthenticated callers explicitly; see the matching comment in
+  -- 20260423120000_add_friend_location_sharing.sql for the rationale.
+  IF auth.uid() IS NULL OR input_user_id <> auth.uid() THEN
     RAISE EXCEPTION 'Access denied: input_user_id must match authenticated user';
   END IF;
 


### PR DESCRIPTION
Bundles six independent fixes into one branch so they can land together. Each was developed on its own feature branch and merged here with `--no-ff`; commits remain separable if we ever need to revert one.

## Summary

- **fix(mobile): QR-code invite URL deeplinks** — QR encoded `/api/join-group`, which bypassed the Android/iOS intent filter (`pathPrefix: "/join-group"`) and always opened the web. Switched both the mobile QR sheet and group-detail Share flow to a new `buildGroupInviteUrl` helper in `@prostcounter/shared`.
- **fix(web): QR/Share URLs use `/join-group`** — same URL-shape bug on the web `QRButton` and `ShareButton` (they built `/join-group` already, but this commit consolidates on the shared helper so web and mobile can't drift again).
- **fix(api): surface silent 0-row deletes** — Supabase `.delete()` returns `{ error: null }` on 0 affected rows (RLS/FK block), so the calendar "deleted" toast was lying. Added `.select("id")` + 0-row assertion to `attendance.repository.ts` plus five sibling repos (`consumption`, `friend.cancelRequest`/`unfriend`, `group.removeMember`, `photo.delete`, `profile.deleteProfile` final row). Left cases where 0 rows is legitimate (e.g. `photo.deleteByAttendanceId`, the 9 cascade cleanups in `deleteProfile`).
- **fix(mobile): diagnostics for storage PUT failures** — picture uploads were failing on the prod APK with no observability (bare `throw new Error("Failed to upload image to storage")`). Extracted `putToStorageWithDiagnostics` helper; on failure it reports status/body/uploadHost/envSupabaseHost/mime/size to Sentry. Diagnostics-only per product call — the hypothesis is a URL mismatch in the signed upload URL vs `EXPO_PUBLIC_SUPABASE_URL`, which the host-pair comparison will make obvious at first glance.
- **feat(location): share with friends, additive to groups** — new `share_with_friends` column on `location_sessions`, extended `get_nearby_group_members` RPC with a friends-branch (OR-ed onto the existing shared-group check), wired through the Zod schema / API route / repository / mobile UI. Added a "Also share with my friends" `LabeledSwitchRow` under the existing group selector so users can pick either/both.
- **refactor(mobile): extract `LabeledSwitchRow`** — the Pressable>HStack>icon+VStack+Switch pattern showed up in `LocationSharingToggle`, `GroupSelector`, and `GroupSelectorSheet`. One shared component with `compact`/`prominent` variants.
- **perf(db): rewrite nearby RPC friends check as LEFT JOIN** — initial migration used a correlated subquery; LEFT JOIN is cheaper and the `friendships` unique index on `(LEAST(requester, addressee), GREATEST(requester, addressee))` guarantees no row duplication.

## Follow-up (not in this PR)

- QR-code share is creator-only because both `QRButton` and `ShareButton` always call `renewInviteToken` on open. Non-creator members get a "Failed to generate QR code" toast. Fix: split into a read-token endpoint (any member) vs renew (creator-only).
- `get_nearby_group_members`' shared-group `EXISTS` has no festival filter — two users who share a group on festival A can see each other's sessions on festival B. Pre-existing; the LEFT JOIN rewrite preserved the original behavior.
- Location-permission intro modal copy still says "Only visible to your group members"; should mention friends now.