### PR TITLE
fix(mobile): attendance delete leaves stale SQLite rows

### DIFF
--- a/apps/mobile/components/attendance/attendance-form-sheet.tsx
+++ b/apps/mobile/components/attendance/attendance-form-sheet.tsx
@@ -1,5 +1,4 @@
 import { zodResolver } from "@hookform/resolvers/zod";
-import { useDeleteAttendance } from "@prostcounter/shared/hooks";
 import { useTranslation } from "@prostcounter/shared/i18n";
 import type {
   AttendanceWithTotals,
@@ -47,6 +46,7 @@ import {
   useAdaptedConsumptionsByDate,
   useAdaptedTents,
 } from "@/lib/database/adapted-hooks";
+import { useLocalDeleteAttendance } from "@/lib/database/hooks";
 import { logger } from "@/lib/logger";
 
 import { TentSelectorSheet } from "../tent-selector/tent-selector-sheet";
@@ -121,7 +121,7 @@ export function AttendanceFormSheet({
   const isEditMode = !!existingAttendance;
   const { tents } = useAdaptedTents(festivalId);
   const { saveAttendance, isSaving } = useSaveAttendance();
-  const deleteAttendance = useDeleteAttendance();
+  const deleteAttendance = useLocalDeleteAttendance();
 
   const dateString =
     selectedDate && !isNaN(selectedDate.getTime())
@@ -443,20 +443,29 @@ export function AttendanceFormSheet({
     if (!existingAttendance?.id) return;
 
     try {
-      await deleteAttendance.mutateAsync(existingAttendance.id);
+      await deleteAttendance.mutateAsync({
+        attendanceId: existingAttendance.id,
+        festivalId,
+      });
       setShowDeleteConfirm(false);
       onSuccess?.();
       onClose();
     } catch (error) {
       logger.error("Failed to delete attendance:", error);
     }
-  }, [existingAttendance?.id, deleteAttendance, onSuccess, onClose]);
+  }, [
+    existingAttendance?.id,
+    deleteAttendance,
+    festivalId,
+    onSuccess,
+    onClose,
+  ]);
 
   const handleCancelDelete = useCallback(() => {
     setShowDeleteConfirm(false);
   }, []);
 
-  const isDeleting = deleteAttendance.loading;
+  const isDeleting = deleteAttendance.isPending;
   const isProcessing = isSaving || isDeleting;
 
   // Format date for display - guard against invalid dates

--- a/apps/mobile/components/attendance/calendar-action-sheet/attendance-tab-content.tsx
+++ b/apps/mobile/components/attendance/calendar-action-sheet/attendance-tab-content.tsx
@@ -1,6 +1,4 @@
 import { zodResolver } from "@hookform/resolvers/zod";
-import { useApiClient } from "@prostcounter/shared/data";
-import { useDeleteAttendance } from "@prostcounter/shared/hooks";
 import { useTranslation } from "@prostcounter/shared/i18n";
 import type {
   AttendanceWithTotals,
@@ -39,6 +37,7 @@ import {
   useAdaptedConsumptionsByDate,
   useAdaptedTents,
 } from "@/lib/database/adapted-hooks";
+import { useLocalDeleteAttendance } from "@/lib/database/hooks";
 import { logger } from "@/lib/logger";
 
 import { TentSelectorSheet } from "../../tent-selector/tent-selector-sheet";
@@ -106,8 +105,7 @@ export function AttendanceTabContent({
   const isEditMode = !!existingAttendance;
   const { tents } = useAdaptedTents(festivalId);
   const { saveAttendance, isSaving } = useSaveAttendance();
-  const deleteAttendance = useDeleteAttendance();
-  const apiClient = useApiClient();
+  const deleteAttendance = useLocalDeleteAttendance();
 
   // Format date string for API calls
   const dateString =
@@ -389,41 +387,10 @@ export function AttendanceTabContent({
     if (!existingAttendance?.id) return;
 
     try {
-      try {
-        await deleteAttendance.mutateAsync(existingAttendance.id);
-      } catch (error: unknown) {
-        // If 404, the local ID doesn't match the server ID (offline UUID mismatch)
-        // Look up the attendance by date and retry with the server ID
-        const is404 =
-          error instanceof Error &&
-          "statusCode" in error &&
-          (error as { statusCode: number }).statusCode === 404;
-        if (is404) {
-          const serverAttendance = await apiClient.attendance.getByDate({
-            festivalId,
-            date: dateString,
-          });
-          if (serverAttendance?.attendance?.id) {
-            try {
-              await deleteAttendance.mutateAsync(
-                serverAttendance.attendance.id,
-              );
-            } catch (retryError: unknown) {
-              // If the fallback delete also returns 404, it's already gone
-              const isRetry404 =
-                retryError instanceof Error &&
-                "statusCode" in retryError &&
-                (retryError as { statusCode: number }).statusCode === 404;
-              if (!isRetry404) {
-                throw retryError;
-              }
-            }
-          }
-          // If no server attendance either, it's already gone - proceed with cleanup
-        } else {
-          throw error;
-        }
-      }
+      await deleteAttendance.mutateAsync({
+        attendanceId: existingAttendance.id,
+        festivalId,
+      });
       setShowDeleteConfirm(false);
       onSuccess?.({ date: selectedDate, tentIds: [] });
       onClose();
@@ -433,9 +400,7 @@ export function AttendanceTabContent({
   }, [
     existingAttendance?.id,
     deleteAttendance,
-    apiClient,
     festivalId,
-    dateString,
     onSuccess,
     selectedDate,
     onClose,
@@ -445,7 +410,7 @@ export function AttendanceTabContent({
     setShowDeleteConfirm(false);
   }, []);
 
-  const isDeleting = deleteAttendance.loading;
+  const isDeleting = deleteAttendance.isPending;
   const isProcessing = isSaving || isDeleting;
 
   return (

--- a/apps/mobile/lib/database/hooks.ts
+++ b/apps/mobile/lib/database/hooks.ts
@@ -9,6 +9,7 @@
  * All query keys are managed via localKeys (query-keys.ts).
  */
 
+import { ATTENDANCE_SIDE_EFFECT_KEYS } from "@prostcounter/shared/hooks";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useContext } from "react";
 
@@ -447,12 +448,9 @@ export function useLocalDeleteAttendance() {
         queryClient.invalidateQueries({
           queryKey: ["local-consumptions"],
         });
-        // Server-side derived views that depend on attendance state.
-        queryClient.invalidateQueries({ queryKey: ["attendances"] });
-        queryClient.invalidateQueries({ queryKey: ["user"] });
-        queryClient.invalidateQueries({ queryKey: ["leaderboard"] });
-        queryClient.invalidateQueries({ queryKey: ["highlights"] });
-        queryClient.invalidateQueries({ queryKey: ["wrapped"] });
+        for (const key of ATTENDANCE_SIDE_EFFECT_KEYS) {
+          queryClient.invalidateQueries({ queryKey: [...key] });
+        }
       },
     },
   );

--- a/apps/mobile/lib/database/hooks.ts
+++ b/apps/mobile/lib/database/hooks.ts
@@ -447,6 +447,12 @@ export function useLocalDeleteAttendance() {
         queryClient.invalidateQueries({
           queryKey: ["local-consumptions"],
         });
+        // Server-side derived views that depend on attendance state.
+        queryClient.invalidateQueries({ queryKey: ["attendances"] });
+        queryClient.invalidateQueries({ queryKey: ["user"] });
+        queryClient.invalidateQueries({ queryKey: ["leaderboard"] });
+        queryClient.invalidateQueries({ queryKey: ["highlights"] });
+        queryClient.invalidateQueries({ queryKey: ["wrapped"] });
       },
     },
   );

--- a/apps/mobile/lib/database/sync/pull-user-data.ts
+++ b/apps/mobile/lib/database/sync/pull-user-data.ts
@@ -132,7 +132,13 @@ export async function pullAttendances(
     const attendances = response.data;
     const now = new Date().toISOString();
 
-    await processAttendances(db, attendances, attendancesResult, now);
+    await processAttendances(
+      db,
+      festivalId,
+      attendances,
+      attendancesResult,
+      now,
+    );
     await updateLastSyncAt(db, "attendances", now);
 
     await processTentVisits(
@@ -151,6 +157,7 @@ export async function pullAttendances(
 
 async function processAttendances(
   db: SQLite.SQLiteDatabase,
+  festivalId: string,
   attendances: Array<{
     id: string;
     userId: string;
@@ -270,6 +277,31 @@ async function processAttendances(
         result.inserted++;
       }
       // If byNaturalKey exists with matching ID, it was already handled above
+    }
+  }
+
+  // Reconcile server-side deletes: any row previously synced that the server
+  // no longer returns was deleted elsewhere (other device, web, admin). Mark
+  // it soft-deleted so the UI drops it and the periodic cleanup can purge it.
+  // Skips _dirty rows so in-flight local mutations aren't clobbered.
+  const serverIds = new Set(attendances.map((a) => a.id));
+  const localRows = await db.getAllAsync<{ id: string }>(
+    `SELECT id FROM attendances
+     WHERE festival_id = ?
+       AND _deleted = 0
+       AND _dirty = 0
+       AND _synced_at IS NOT NULL`,
+    [festivalId],
+  );
+  for (const row of localRows) {
+    if (!serverIds.has(row.id)) {
+      await db.runAsync(
+        `UPDATE attendances
+         SET _deleted = 1, _synced_at = ?
+         WHERE id = ?`,
+        [now, row.id],
+      );
+      result.deleted++;
     }
   }
 }

--- a/apps/mobile/lib/database/sync/pull-user-data.ts
+++ b/apps/mobile/lib/database/sync/pull-user-data.ts
@@ -132,12 +132,18 @@ export async function pullAttendances(
     const attendances = response.data;
     const now = new Date().toISOString();
 
+    // Only reconcile deletes when the response is the full festival snapshot.
+    // The list endpoint is paginated (limit: 100); if we only got a partial
+    // page, rows missing from the response might still live on the server.
+    const isFullSnapshot = attendances.length >= response.total;
+
     await processAttendances(
       db,
       festivalId,
       attendances,
       attendancesResult,
       now,
+      isFullSnapshot,
     );
     await updateLastSyncAt(db, "attendances", now);
 
@@ -169,6 +175,7 @@ async function processAttendances(
   }>,
   result: PullResult,
   now: string,
+  isFullSnapshot: boolean,
 ): Promise<void> {
   for (const att of attendances) {
     const existing = await db.getFirstAsync<LocalAttendance>(
@@ -284,6 +291,10 @@ async function processAttendances(
   // no longer returns was deleted elsewhere (other device, web, admin). Mark
   // it soft-deleted so the UI drops it and the periodic cleanup can purge it.
   // Skips _dirty rows so in-flight local mutations aren't clobbered.
+  // Skipped when the response was paginated/partial — we'd otherwise delete
+  // rows that still exist on the server but live on another page.
+  if (!isFullSnapshot) return;
+
   const serverIds = new Set(attendances.map((a) => a.id));
   const localRows = await db.getAllAsync<{ id: string }>(
     `SELECT id FROM attendances
@@ -301,6 +312,12 @@ async function processAttendances(
           `UPDATE attendances
            SET _deleted = 1, _synced_at = ?
            WHERE id = ?`,
+          [now, row.id],
+        );
+        await db.runAsync(
+          `UPDATE consumptions
+           SET _deleted = 1, _synced_at = ?
+           WHERE attendance_id = ? AND _deleted = 0`,
           [now, row.id],
         );
         result.deleted++;

--- a/apps/mobile/lib/database/sync/pull-user-data.ts
+++ b/apps/mobile/lib/database/sync/pull-user-data.ts
@@ -293,16 +293,19 @@ async function processAttendances(
        AND _synced_at IS NOT NULL`,
     [festivalId],
   );
-  for (const row of localRows) {
-    if (!serverIds.has(row.id)) {
-      await db.runAsync(
-        `UPDATE attendances
-         SET _deleted = 1, _synced_at = ?
-         WHERE id = ?`,
-        [now, row.id],
-      );
-      result.deleted++;
-    }
+  const stale = localRows.filter((row) => !serverIds.has(row.id));
+  if (stale.length > 0) {
+    await db.withTransactionAsync(async () => {
+      for (const row of stale) {
+        await db.runAsync(
+          `UPDATE attendances
+           SET _deleted = 1, _synced_at = ?
+           WHERE id = ?`,
+          [now, row.id],
+        );
+        result.deleted++;
+      }
+    });
   }
 }
 

--- a/packages/shared/src/hooks/index.ts
+++ b/packages/shared/src/hooks/index.ts
@@ -65,6 +65,7 @@ export {
 
 // Attendance hooks
 export {
+  ATTENDANCE_SIDE_EFFECT_KEYS,
   useAttendanceByDate,
   useAttendances,
   useDeleteAttendance,

--- a/packages/shared/src/hooks/useAttendance.ts
+++ b/packages/shared/src/hooks/useAttendance.ts
@@ -5,12 +5,26 @@
  */
 
 import {
-  useApiClient,
-  useQuery,
-  useMutation,
-  useInvalidateQueries,
   QueryKeys,
+  useApiClient,
+  useInvalidateQueries,
+  useMutation,
+  useQuery,
 } from "../data";
+
+/**
+ * Query-key prefixes to invalidate whenever an attendance is created,
+ * updated, or deleted. Listed as prefixes (e.g. ["leaderboard"] matches
+ * all ["leaderboard", ...] variants) so callers don't need to know the
+ * exact festival / criteria / user id.
+ */
+export const ATTENDANCE_SIDE_EFFECT_KEYS = [
+  ["attendances"],
+  ["user"],
+  ["leaderboard"],
+  ["highlights"],
+  ["wrapped"],
+] as const;
 
 /**
  * Hook to fetch user's attendance data for a festival
@@ -47,16 +61,9 @@ export function useDeleteAttendance() {
     },
     {
       onSuccess: () => {
-        // Invalidate all attendances (will match any festival)
-        invalidateQueries(["attendances"]);
-        // Invalidate user stats
-        invalidateQueries(["user"]);
-        // Also invalidate leaderboards since attendance affects rankings
-        invalidateQueries(["leaderboard"]);
-        // Invalidate highlights as they depend on attendance
-        invalidateQueries(["highlights"]);
-        // Invalidate wrapped data cache (attendance changes affect wrapped stats)
-        invalidateQueries(["wrapped"]);
+        for (const key of ATTENDANCE_SIDE_EFFECT_KEYS) {
+          invalidateQueries([...key]);
+        }
       },
     },
   );
@@ -103,18 +110,10 @@ export function useUpdatePersonalAttendance() {
     },
     {
       onSuccess: () => {
-        // Invalidate all attendances
-        invalidateQueries(["attendances"]);
-        // Invalidate attendance by date queries
+        for (const key of ATTENDANCE_SIDE_EFFECT_KEYS) {
+          invalidateQueries([...key]);
+        }
         invalidateQueries(["attendanceByDate"]);
-        // Invalidate user stats
-        invalidateQueries(["user"]);
-        // Invalidate leaderboards
-        invalidateQueries(["leaderboard"]);
-        // Invalidate highlights
-        invalidateQueries(["highlights"]);
-        // Invalidate wrapped data cache (attendance changes affect wrapped stats)
-        invalidateQueries(["wrapped"]);
       },
     },
   );

--- a/packages/shared/src/hooks/useAttendance.ts
+++ b/packages/shared/src/hooks/useAttendance.ts
@@ -20,6 +20,7 @@ import {
  */
 export const ATTENDANCE_SIDE_EFFECT_KEYS = [
   ["attendances"],
+  ["attendanceByDate"],
   ["user"],
   ["leaderboard"],
   ["highlights"],
@@ -113,7 +114,6 @@ export function useUpdatePersonalAttendance() {
         for (const key of ATTENDANCE_SIDE_EFFECT_KEYS) {
           invalidateQueries([...key]);
         }
-        invalidateQueries(["attendanceByDate"]);
       },
     },
   );


### PR DESCRIPTION
## Summary
- The mobile calendar and festival summary read from SQLite via `useAdaptedAttendances`, but delete was wired to the shared API-only `useDeleteAttendance` — API succeeded, SQLite never changed, ghost row stayed visible. Surfaces as "tap delete, see success toast, row is still there."
- Switched both delete sites (`attendance-tab-content.tsx`, `attendance-form-sheet.tsx`) to `useLocalDeleteAttendance`, which soft-deletes SQLite, cascades consumptions, enqueues the server DELETE, and invalidates both local and server query keys. Dropped the now-redundant 404-by-date retry (pull's byNaturalKey path already reconciles client/server UUID mismatches).
- Added a reconcile pass at the end of `processAttendances` (`pull-user-data.ts`): after the upsert loop, any previously synced row (`_synced_at IS NOT NULL AND _dirty = 0`) whose id isn't in the server response gets soft-deleted. Wrapped in `withTransactionAsync`. This retroactively cleans rows already stuck on users' devices and fixes cross-device deletes (delete on web → mobile stops showing it).
- Extracted `ATTENDANCE_SIDE_EFFECT_KEYS` in shared `useAttendance.ts`; used from both shared mutation hooks and the local hook. Collapses 10 duplicated invalidation lines.

OTA-safe (pure TS, no native changes — shares `runtimeVersion 1.4.1-a`).

## Test plan
- [ ] Install on a device that currently has a ghost attendance (e.g., user's stuck row). Pull-to-refresh on the attendance tab — ghost should disappear after next sync via the reconcile pass.
- [ ] Create an attendance, delete it from the calendar action sheet → row disappears from calendar AND festival summary immediately (local invalidation).
- [ ] Same test from the attendance form sheet (edit mode → trash icon).
- [ ] Delete an attendance on web → open mobile → pull-to-refresh → mobile no longer shows it.
- [ ] Offline: delete an attendance while airplane mode on → row disappears from UI. Re-enable network, verify server DELETE runs on next sync (no 404 loop).
- [ ] Leaderboard / wrapped / highlights screens refresh correctly after delete.
- [ ] `pnpm type-check && pnpm lint` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)