### PR TITLE
fix(mobile): stop cold-start 401 storm (PROST-COUNTER-86)

### DIFF
--- a/apps/mobile/lib/__tests__/api-client.test.ts
+++ b/apps/mobile/lib/__tests__/api-client.test.ts
@@ -1,0 +1,55 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const getSession = vi.fn();
+
+vi.mock("../supabase", () => ({
+  supabase: { auth: { get getSession() { return getSession; } } },
+}));
+vi.mock("../logger", () => ({
+  logger: {
+    info: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn(),
+    logApiRequest: vi.fn(), logApiResponse: vi.fn(), logApiError: vi.fn(),
+  },
+}));
+vi.mock("expo-constants", () => ({
+  default: { expoConfig: { extra: { apiUrl: "https://example.test/api" } } },
+}));
+
+async function callFestivalsAndCaptureHeaders() {
+  const fetchMock = vi.fn(async (_url: string, _init?: RequestInit) => ({
+    ok: true, status: 200,
+    headers: new Headers({ "content-type": "application/json" }),
+    clone() { return this; },
+    async json() { return { festivals: [] }; },
+  }) as unknown as Response);
+  vi.stubGlobal("fetch", fetchMock);
+  const { apiClient } = await import("../api-client");
+  await apiClient.festivals.list().catch(() => {});
+  return fetchMock;
+}
+
+describe("getAuthHeaders (via apiClient)", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    getSession.mockReset();
+  });
+
+  it("attaches a Bearer token when a session exists", async () => {
+    getSession.mockResolvedValue({
+      data: { session: { access_token: "tok-123", expires_at: Math.floor(Date.now() / 1000) + 3600 } },
+    });
+    const fetchMock = await callFestivalsAndCaptureHeaders();
+    const headers = fetchMock.mock.calls[0]![1]!.headers as Record<string, string>;
+    expect(headers.Authorization).toBe("Bearer tok-123");
+  });
+
+  it("throws AuthRequiredError and fires NO request when there is no session", async () => {
+    getSession.mockResolvedValue({ data: { session: null } });
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    const { apiClient } = await import("../api-client");
+    const { AuthRequiredError } = await import("@prostcounter/api-client");
+    await expect(apiClient.festivals.list()).rejects.toBeInstanceOf(AuthRequiredError);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/mobile/lib/__tests__/logger-api-response.test.ts
+++ b/apps/mobile/lib/__tests__/logger-api-response.test.ts
@@ -1,0 +1,32 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { logger } from "../logger";
+
+describe("logger.logApiResponse Sentry policy", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("routes 4xx to warn, not error", () => {
+    const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
+    const errorSpy = vi.spyOn(logger, "error").mockImplementation(() => {});
+    logger.logApiResponse("GET", "https://example.test/api/v1/festivals?", 401, null);
+    expect(errorSpy).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("routes 5xx to error", () => {
+    const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
+    const errorSpy = vi.spyOn(logger, "error").mockImplementation(() => {});
+    logger.logApiResponse("POST", "https://example.test/api/v1/groups/join-by-token", 500, null);
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("does not log a 2xx as warn or error", () => {
+    const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
+    const errorSpy = vi.spyOn(logger, "error").mockImplementation(() => {});
+    logger.logApiResponse("GET", "https://example.test/api/v1/profile", 200, {});
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+});

--- a/apps/mobile/lib/api-client.ts
+++ b/apps/mobile/lib/api-client.ts
@@ -5,14 +5,14 @@
  * with platform-specific auth configuration.
  */
 
-import { ApiError, type ApiHeaders, createTypedApiClient } from "@prostcounter/api-client";
+import { ApiError, AuthRequiredError, type ApiHeaders, createTypedApiClient } from "@prostcounter/api-client";
 import Constants from "expo-constants";
 
 import { logger } from "./logger";
 import { supabase } from "./supabase";
 
 // Re-export ApiError for convenience
-export { ApiError };
+export { ApiError, AuthRequiredError };
 
 /**
  * Base URL for API requests
@@ -36,27 +36,13 @@ function withAuth(token: string): ApiHeaders {
   return { ...BASE_HEADERS, Authorization: `Bearer ${token}` };
 }
 
-// Deduplicates concurrent token refresh calls
-let refreshPromise: Promise<string | null> | null = null;
-
-async function refreshAccessToken(): Promise<string | null> {
-  try {
-    const { data: refreshed, error } = await supabase.auth.refreshSession();
-    if (error || !refreshed.session?.access_token) {
-      logger.warn("Supabase session refresh failed", {
-        hasError: !!error,
-      });
-      return null;
-    }
-    return refreshed.session.access_token;
-  } catch {
-    logger.warn("Supabase session refresh threw an exception");
-    return null;
-  }
-}
-
 /**
- * Get auth headers for API requests using Supabase mobile client
+ * Get auth headers for API requests using the Supabase mobile client.
+ *
+ * supabase-js owns token refresh: getSession() refreshes an expired token
+ * internally and dedupes concurrent refreshes. If no usable token is
+ * available afterward, we THROW rather than send an anonymous request that
+ * would deterministically 401.
  */
 async function getAuthHeaders(): Promise<ApiHeaders> {
   const {
@@ -64,33 +50,10 @@ async function getAuthHeaders(): Promise<ApiHeaders> {
   } = await supabase.auth.getSession();
 
   if (session?.access_token) {
-    const expiresAt = session.expires_at;
-    const now = Math.floor(Date.now() / 1000);
-
-    // Proactively refresh tokens near expiry to avoid 401s on app resume
-    if (expiresAt && expiresAt - now < 60) {
-      if (!refreshPromise) {
-        refreshPromise = refreshAccessToken().finally(() => {
-          refreshPromise = null;
-        });
-      }
-      const newToken = await refreshPromise;
-
-      if (newToken) {
-        return withAuth(newToken);
-      }
-
-      // Refresh failed — don't send an already-expired token
-      if (expiresAt <= now) {
-        return BASE_HEADERS;
-      }
-      // Token not yet expired, send it and accept it may expire mid-flight
-    }
-
     return withAuth(session.access_token);
   }
 
-  return BASE_HEADERS;
+  throw new AuthRequiredError();
 }
 
 /**

--- a/apps/mobile/lib/auth/AuthContext.tsx
+++ b/apps/mobile/lib/auth/AuthContext.tsx
@@ -1,6 +1,14 @@
 import * as Sentry from "@sentry/react-native";
 import type { Session, User } from "@supabase/supabase-js";
-import { createContext, type ReactNode, useCallback, useContext, useEffect, useState } from "react";
+import {
+  createContext,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 import { identifyDevice } from "vexo-analytics";
 
 import { clearAllData } from "@/lib/database/debug";
@@ -41,9 +49,15 @@ interface AuthContextType {
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
 
+/** A SIGNED_OUT the user did not trigger means the library evicted a dead session. */
+export function isDeadSessionSignOut(event: string, userInitiated: boolean): boolean {
+  return event === "SIGNED_OUT" && !userInitiated;
+}
+
 export function AuthProvider({ children }: { children: ReactNode }) {
   const [session, setSession] = useState<Session | null>(null);
   const [isLoading, setIsLoading] = useState(true);
+  const userInitiatedSignOutRef = useRef(false);
 
   useEffect(() => {
     // Get initial session
@@ -72,7 +86,17 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     // Listen for auth changes
     const {
       data: { subscription },
-    } = supabase.auth.onAuthStateChange(async (_event, session) => {
+    } = supabase.auth.onAuthStateChange(async (event, session) => {
+      if (isDeadSessionSignOut(event, userInitiatedSignOutRef.current)) {
+        Sentry.captureMessage("Session expired: signed out by auth library", {
+          level: "warning",
+          tags: { source: "auth", reason: "dead_session" },
+        });
+      }
+      if (event === "SIGNED_OUT") {
+        userInitiatedSignOutRef.current = false;
+      }
+
       setSession(session);
 
       // Set Sentry user context for error tracking
@@ -116,6 +140,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   }, []);
 
   const signOut = useCallback(async () => {
+    userInitiatedSignOutRef.current = true;
     await supabase.auth.signOut();
     await clearAllAuthData();
     // Clear local SQLite data to avoid stale data from previous user session

--- a/apps/mobile/lib/auth/AuthContext.tsx
+++ b/apps/mobile/lib/auth/AuthContext.tsx
@@ -54,6 +54,29 @@ export function isDeadSessionSignOut(event: string, userInitiated: boolean): boo
   return event === "SIGNED_OUT" && !userInitiated;
 }
 
+/**
+ * Runs a user-initiated sign-out, marking the ref so the auth listener can tell
+ * this SIGNED_OUT apart from a library-driven dead-session eviction. On success
+ * the ref stays set until the SIGNED_OUT event clears it. If the sign-out call
+ * throws, no SIGNED_OUT event will arrive to clear the ref, so clear it here;
+ * otherwise a later genuine eviction would be misclassified and its warning
+ * suppressed. Reset only on the failure path, never in a finally: a finally
+ * would clear the ref before the async SIGNED_OUT lands and mislabel a real
+ * user sign-out as a dead session.
+ */
+export async function runUserSignOut(
+  userInitiatedRef: { current: boolean },
+  signOut: () => Promise<unknown>,
+): Promise<void> {
+  userInitiatedRef.current = true;
+  try {
+    await signOut();
+  } catch (error) {
+    userInitiatedRef.current = false;
+    throw error;
+  }
+}
+
 export function AuthProvider({ children }: { children: ReactNode }) {
   const [session, setSession] = useState<Session | null>(null);
   const [isLoading, setIsLoading] = useState(true);
@@ -140,8 +163,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   }, []);
 
   const signOut = useCallback(async () => {
-    userInitiatedSignOutRef.current = true;
-    await supabase.auth.signOut();
+    await runUserSignOut(userInitiatedSignOutRef, () => supabase.auth.signOut());
     await clearAllAuthData();
     // Clear local SQLite data to avoid stale data from previous user session
     try {

--- a/apps/mobile/lib/auth/__tests__/dead-session-event.test.ts
+++ b/apps/mobile/lib/auth/__tests__/dead-session-event.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it, vi } from "vitest";
+
+// AuthContext.tsx pulls in several native-only modules (react-native, expo-*,
+// @sentry/react-native, vexo-analytics) transitively. Mock them out so the
+// module can be imported in a plain node test environment to exercise the
+// pure `isDeadSessionSignOut` helper.
+vi.mock("@sentry/react-native", () => ({
+  captureMessage: vi.fn(),
+  setUser: vi.fn(),
+}));
+vi.mock("vexo-analytics", () => ({
+  identifyDevice: vi.fn(),
+}));
+vi.mock("@/lib/database/debug", () => ({
+  clearAllData: vi.fn(),
+}));
+vi.mock("@/lib/database/init", () => ({
+  getDatabase: vi.fn(),
+}));
+vi.mock("@/lib/supabase", () => ({
+  supabase: { auth: { onAuthStateChange: vi.fn(), getSession: vi.fn(), signOut: vi.fn() } },
+}));
+vi.mock("../oauth", () => ({
+  signInWithApple: vi.fn(),
+  signInWithFacebook: vi.fn(),
+  signInWithGoogle: vi.fn(),
+}));
+vi.mock("../secure-storage", () => ({
+  clearAllAuthData: vi.fn(),
+  clearSession: vi.fn(),
+  getStoredSession: vi.fn(),
+  storeSession: vi.fn(),
+  storeUserEmail: vi.fn(),
+}));
+
+import { isDeadSessionSignOut } from "../AuthContext";
+
+describe("isDeadSessionSignOut", () => {
+  it("is true for a library-driven SIGNED_OUT (not user-initiated)", () => {
+    expect(isDeadSessionSignOut("SIGNED_OUT", false)).toBe(true);
+  });
+  it("is false when the user initiated the sign-out", () => {
+    expect(isDeadSessionSignOut("SIGNED_OUT", true)).toBe(false);
+  });
+  it("is false for non-sign-out events", () => {
+    expect(isDeadSessionSignOut("TOKEN_REFRESHED", false)).toBe(false);
+    expect(isDeadSessionSignOut("SIGNED_IN", false)).toBe(false);
+  });
+});

--- a/apps/mobile/lib/auth/__tests__/dead-session-event.test.ts
+++ b/apps/mobile/lib/auth/__tests__/dead-session-event.test.ts
@@ -33,7 +33,7 @@ vi.mock("../secure-storage", () => ({
   storeUserEmail: vi.fn(),
 }));
 
-import { isDeadSessionSignOut } from "../AuthContext";
+import { isDeadSessionSignOut, runUserSignOut } from "../AuthContext";
 
 describe("isDeadSessionSignOut", () => {
   it("is true for a library-driven SIGNED_OUT (not user-initiated)", () => {
@@ -45,5 +45,26 @@ describe("isDeadSessionSignOut", () => {
   it("is false for non-sign-out events", () => {
     expect(isDeadSessionSignOut("TOKEN_REFRESHED", false)).toBe(false);
     expect(isDeadSessionSignOut("SIGNED_IN", false)).toBe(false);
+  });
+});
+
+describe("runUserSignOut", () => {
+  it("marks the ref, leaving it set for the SIGNED_OUT event to clear", async () => {
+    const userInitiatedRef = { current: false };
+    await runUserSignOut(userInitiatedRef, async () => {});
+    expect(userInitiatedRef.current).toBe(true);
+  });
+
+  it("clears the ref when sign-out throws, so a later eviction still warns", async () => {
+    const userInitiatedRef = { current: false };
+    const signOutError = new Error("network down");
+    await expect(
+      runUserSignOut(userInitiatedRef, async () => {
+        throw signOutError;
+      }),
+    ).rejects.toThrow(signOutError);
+    expect(userInitiatedRef.current).toBe(false);
+    // With the flag cleared, a subsequent library eviction is not suppressed.
+    expect(isDeadSessionSignOut("SIGNED_OUT", userInitiatedRef.current)).toBe(true);
   });
 });

--- a/apps/mobile/lib/data/__tests__/query-client.test.ts
+++ b/apps/mobile/lib/data/__tests__/query-client.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { ApiError, AuthRequiredError } from "@prostcounter/api-client";
+import { shouldRetryQuery, shouldRetryMutation } from "../query-client";
+
+describe("shouldRetryQuery", () => {
+  it("does not retry a 4xx ApiError", () => {
+    expect(shouldRetryQuery(0, new ApiError("UNAUTHORIZED", "no", 401))).toBe(false);
+    expect(shouldRetryQuery(0, new ApiError("CONFLICT", "dup", 409))).toBe(false);
+  });
+  it("does not retry AuthRequiredError", () => {
+    expect(shouldRetryQuery(0, new AuthRequiredError())).toBe(false);
+  });
+  it("retries a 5xx ApiError up to 2 times", () => {
+    const e = new ApiError("DATABASE_ERROR", "boom", 500);
+    expect(shouldRetryQuery(0, e)).toBe(true);
+    expect(shouldRetryQuery(1, e)).toBe(true);
+    expect(shouldRetryQuery(2, e)).toBe(false);
+  });
+  it("retries a network error (non-ApiError) up to 2 times", () => {
+    const e = new Error("Network request failed");
+    expect(shouldRetryQuery(0, e)).toBe(true);
+    expect(shouldRetryQuery(2, e)).toBe(false);
+  });
+});
+
+describe("shouldRetryMutation", () => {
+  it("never retries an ApiError (server received the request)", () => {
+    expect(shouldRetryMutation(0, new ApiError("DATABASE_ERROR", "boom", 500))).toBe(false);
+    expect(shouldRetryMutation(0, new ApiError("CONFLICT", "dup", 409))).toBe(false);
+  });
+  it("never retries AuthRequiredError", () => {
+    expect(shouldRetryMutation(0, new AuthRequiredError())).toBe(false);
+  });
+  it("retries a network error up to 2 times", () => {
+    const e = new Error("Network request failed");
+    expect(shouldRetryMutation(0, e)).toBe(true);
+    expect(shouldRetryMutation(2, e)).toBe(false);
+  });
+});

--- a/apps/mobile/lib/data/query-client.tsx
+++ b/apps/mobile/lib/data/query-client.tsx
@@ -1,5 +1,28 @@
+import { ApiError, AuthRequiredError } from "@prostcounter/api-client";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { type ReactNode, useState } from "react";
+
+const MAX_RETRIES = 2;
+
+/** 4xx and AuthRequiredError are deterministic — never retry them. */
+export function shouldRetryQuery(failureCount: number, error: unknown): boolean {
+  if (error instanceof AuthRequiredError) return false;
+  if (error instanceof ApiError && error.statusCode >= 400 && error.statusCode < 500) {
+    return false;
+  }
+  return failureCount < MAX_RETRIES;
+}
+
+/**
+ * Mutations retry ONLY on true no-response errors. Any ApiError means the
+ * server received and processed the request; re-sending a non-idempotent
+ * mutation risks duplicates.
+ */
+export function shouldRetryMutation(failureCount: number, error: unknown): boolean {
+  if (error instanceof ApiError) return false;
+  if (error instanceof AuthRequiredError) return false;
+  return failureCount < MAX_RETRIES;
+}
 
 function createQueryClient(): QueryClient {
   return new QueryClient({
@@ -8,13 +31,13 @@ function createQueryClient(): QueryClient {
         networkMode: "always", // Don't pause queries when offline - fail fast so UI shows error/cached state
         staleTime: 2 * 60 * 1000, // 2 minutes (reduced for better freshness)
         gcTime: 10 * 60 * 1000, // 10 minutes
-        retry: 2,
+        retry: shouldRetryQuery,
         refetchOnWindowFocus: false,
         refetchOnReconnect: true,
         refetchOnMount: true, // Refetch stale data when component mounts
       },
       mutations: {
-        retry: 1,
+        retry: shouldRetryMutation,
       },
     },
   });

--- a/apps/mobile/lib/logger.ts
+++ b/apps/mobile/lib/logger.ts
@@ -176,9 +176,19 @@ class Logger {
   }
 
   logApiResponse(method: string, url: string, status: number, data?: unknown) {
-    if (status >= 400) {
-      // Log error responses at error level so they're always visible
+    if (status >= 500) {
+      // Server errors are real problems -> Sentry event via error().
       this.error(`API Error Response: ${method} ${url} - ${status}`, undefined, {
+        method,
+        url,
+        status,
+        data: truncateData(data),
+      });
+    } else if (status >= 400) {
+      // Client errors (401/404/409/...) are expected outcomes. Log at warn for
+      // dev visibility; the Sentry RN integration already records the xhr as a
+      // breadcrumb, so we do NOT send a separate Sentry event.
+      this.warn(`API Error Response: ${method} ${url} - ${status}`, {
         method,
         url,
         status,

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -93,6 +93,7 @@ export type ApiQueryParams<
 export {
   createTypedApiClient,
   ApiError,
+  AuthRequiredError,
   type ApiClientConfig as TypedApiClientConfig,
   type ApiResponse as TypedApiResponse,
   type TypedApiClient,

--- a/packages/api-client/src/typed-client.ts
+++ b/packages/api-client/src/typed-client.ts
@@ -101,6 +101,18 @@ export class ApiError extends Error {
 }
 
 /**
+ * Thrown when an authenticated request cannot be made because no valid
+ * session token is available. Distinct from ApiError (which represents an
+ * HTTP response). Never retried by the client.
+ */
+export class AuthRequiredError extends Error {
+  constructor(message = "No authenticated session available") {
+    super(message);
+    this.name = "AuthRequiredError";
+  }
+}
+
+/**
  * Parse JSON response with error handling and type safety
  */
 async function parseJsonResponse<T>(response: Response): Promise<T> {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -20,7 +20,10 @@
   },
   "scripts": {
     "build": "tsc",
-    "dev": "tsc --watch"
+    "dev": "tsc --watch",
+    "test": "vitest run",
+    "test:watch": "vitest --watch",
+    "type-check": "tsc --noEmit"
   },
   "dependencies": {
     "@date-fns/tz": "^1.4.1",
@@ -33,7 +36,8 @@
     "@tanstack/react-query": "^5.100.8",
     "@types/react": "^19.2.14",
     "react": "19.2.5",
-    "typescript": "^5.9.3"
+    "typescript": "^5.9.3",
+    "vitest": "^4.1.5"
   },
   "peerDependencies": {
     "@tanstack/react-query": "^5.0.0",

--- a/packages/shared/src/data/__tests__/react-query-provider.test.ts
+++ b/packages/shared/src/data/__tests__/react-query-provider.test.ts
@@ -1,0 +1,60 @@
+import { QueryClient } from "@tanstack/react-query";
+import { describe, expect, it } from "vitest";
+
+import { mapQueryOptions } from "../react-query-provider";
+
+/**
+ * Regression test for the retry-clobber bug (PROST-COUNTER-86 follow-up).
+ *
+ * `mapQueryOptions` used to always emit `retry: options.retry`, even when the
+ * caller's `DataQueryOptions` omitted `retry` entirely. Since `options.retry`
+ * is `undefined` in that case, the resulting `retry: undefined` was spread
+ * into `useQuery(...)`'s per-query options, which React Query merges *over*
+ * the QueryClient's `defaultOptions.queries.retry`. An explicit `undefined`
+ * wins over the default, silently discarding any custom retry predicate
+ * (e.g. mobile's `shouldRetryQuery`) and falling back to React Query's
+ * built-in default of 3 retries.
+ */
+describe("mapQueryOptions", () => {
+  it("does not clobber the QueryClient's default retry predicate when retry is omitted", () => {
+    const sentinelRetry = (failureCount: number) => failureCount < 1;
+
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: sentinelRetry,
+        },
+      },
+    });
+
+    const mapped = mapQueryOptions({ staleTime: 30000 });
+
+    const resolved = queryClient.defaultQueryOptions({
+      queryKey: ["t"],
+      queryFn: async () => 1,
+      ...mapped,
+    });
+
+    expect(resolved.retry).toBe(sentinelRetry);
+  });
+
+  it("still forwards an explicit retry value, overriding the QueryClient default", () => {
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: () => true,
+        },
+      },
+    });
+
+    const mapped = mapQueryOptions({ staleTime: 30000, retry: 5 });
+
+    const resolved = queryClient.defaultQueryOptions({
+      queryKey: ["t"],
+      queryFn: async () => 1,
+      ...mapped,
+    });
+
+    expect(resolved.retry).toBe(5);
+  });
+});

--- a/packages/shared/src/data/react-query-provider.ts
+++ b/packages/shared/src/data/react-query-provider.ts
@@ -22,7 +22,11 @@ import type {
   DataMutationOptions,
 } from "./types";
 
-function mapQueryOptions(
+/**
+ * Exported for testing only; not part of the package's public API
+ * (deliberately not re-exported from `./index.ts`).
+ */
+export function mapQueryOptions(
   options?: DataQueryOptions,
 ): Omit<UseQueryOptions, "queryKey" | "queryFn"> {
   if (!options) return {};
@@ -31,7 +35,9 @@ function mapQueryOptions(
     enabled: options.enabled,
     gcTime: options.gcTime,
     staleTime: options.staleTime,
-    retry: options.retry,
+    // Only forward `retry` when explicitly set. Emitting `retry: undefined`
+    // would override the QueryClient default retry predicate.
+    ...(options.retry !== undefined ? { retry: options.retry } : {}),
     refetchOnWindowFocus: options.refetchOnWindowFocus,
     refetchOnReconnect: options.refetchOnReconnect,
   };

--- a/packages/shared/vitest.config.ts
+++ b/packages/shared/vitest.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from "vitest/config";
+import path from "path";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+    exclude: ["**/node_modules/**", "**/*.d.ts"],
+  },
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./src"),
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -771,6 +771,9 @@ importers:
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
+      vitest:
+        specifier: ^4.1.5
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(happy-dom@20.9.0)(vite@7.3.5(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/ui:
     dependencies:
@@ -6619,9 +6622,6 @@ packages:
   es-errors@1.3.0:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
-
-  es-module-lexer@2.0.0:
-    resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
 
   es-module-lexer@2.1.0:
     resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
@@ -17132,8 +17132,6 @@ snapshots:
 
   es-errors@1.3.0: {}
 
-  es-module-lexer@2.0.0: {}
-
   es-module-lexer@2.1.0: {}
 
   es-object-atoms@1.1.1:
@@ -21552,7 +21550,7 @@ snapshots:
       '@vitest/snapshot': 4.1.5
       '@vitest/spy': 4.1.5
       '@vitest/utils': 4.1.5
-      es-module-lexer: 2.0.0
+      es-module-lexer: 2.1.0
       expect-type: 1.3.0
       magic-string: 0.30.21
       obug: 2.1.1
@@ -21561,7 +21559,7 @@ snapshots:
       std-env: 4.0.0
       tinybench: 2.9.0
       tinyexec: 1.0.4
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
       vite: 7.3.5(@types/node@25.6.0)(jiti@1.21.7)(lightningcss@1.30.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
       why-is-node-running: 2.3.0
@@ -21582,7 +21580,7 @@ snapshots:
       '@vitest/snapshot': 4.1.5
       '@vitest/spy': 4.1.5
       '@vitest/utils': 4.1.5
-      es-module-lexer: 2.0.0
+      es-module-lexer: 2.1.0
       expect-type: 1.3.0
       magic-string: 0.30.21
       obug: 2.1.1
@@ -21591,7 +21589,7 @@ snapshots:
       std-env: 4.0.0
       tinybench: 2.9.0
       tinyexec: 1.0.4
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
       vite: 7.3.5(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
       why-is-node-running: 2.3.0


### PR DESCRIPTION
## What

Fixes the cold-start 401 storm in Sentry ([PROST-COUNTER-86](https://prostcounter.sentry.io/issues/PROST-COUNTER-86)): 3,557 occurrences, escalating, from the mobile app firing bursts of ~40 unauthenticated requests right after launch, each one a guaranteed 401.

## Root cause (reproduced)

`getAuthHeaders` in `apps/mobile/lib/api-client.ts` hand-rolled token refresh next to supabase-js, which already does refresh, dedup, and dead-session eviction on its own. Its failure path silently returned `BASE_HEADERS` with no `Authorization`, so when the stored token was expired and the refresh call failed (including on a transient network blip, where supabase deliberately keeps the session), every queued request went out anonymous and got 401'd. Once supabase-js's own auto-refresh eventually won, the session settled and everything went back to 200. That is exactly the recovery pattern in the incident breadcrumbs.

I reproduced it deterministically against the real client: expired token + failed refresh, and `festivals.list()` fires `GET /v1/festivals?` with no Authorization header, byte-identical to the incident.

## The fix (mostly deletion)

- `getAuthHeaders` throws a new `AuthRequiredError` when there is no session token, instead of sending anonymously. Deleted the manual refresh machinery, supabase-js owns it.
- React Query retry predicates: never retry a 4xx or `AuthRequiredError` (deterministic, retrying only multiplies noise); mutations retry only true no-response errors, so a non-idempotent join is never blind-replayed on a 5xx.
- Logger sends only 5xx to Sentry. 4xx becomes a warn, the Sentry RN integration already records the xhr as a breadcrumb.
- One Sentry event when supabase-js evicts a dead session (a SIGNED_OUT the user did not trigger), instead of the app going silent.
- Preserve the QueryClient default retry when a hook omits `retry`. The shared `mapQueryOptions` was emitting `retry: undefined`, which clobbered the default back to react-query's built-in 3. This is what made the retry predicate above actually take effect (found in the final review, verified empirically).

Net effect on the incident: no valid token means zero requests fired instead of ~40, and ~40 Sentry events collapse to 0 (or 1 if a session genuinely dies).

## Out of scope

No `enabled` gating on queries, no api-client auth state machine, no client-side rate limiting. The throw makes all three unnecessary.

## Verification

type-check 10/10, lint 0 errors, mobile 158/158, shared 2/2, api 312 pass / 2 skip. Every task was TDD with a failing test first.

I could not run the on-device smoke test: the iOS build is blocked on an unrelated expo-sqlite / Xcode 26 incompatibility (separate Expo SDK upgrade coming). The fix is fully unit-covered regardless.

## Related: the join-by-token 500

Same Sentry issue also had a `POST /groups/join-by-token` 500 (one user, June 18). I could not reproduce it: on the current schema (unchanged since April) a new-member join returns 200 and an existing-member join returns a clean 409. Most consistent with a transient DB error, and the retry amplification that turned it into a burst is already gone with the mutation retry change here. Not fixing it in this PR. If we want the next one diagnosable, wiring the API to Sentry is the real gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
