### PR TITLE
fix(ios): add NSMotionUsageDescription for CoreMotion (ITMS-90683)

### DIFF
--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -29,6 +29,8 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
         "ProstCounter uses your location to share with friends and show nearby tents",
       NSLocationAlwaysAndWhenInUseUsageDescription:
         "Allow background location to keep sharing your location with friends while using other apps",
+      NSMotionUsageDescription:
+        "ProstCounter uses device motion to power smooth, responsive animations as you interact with the app.",
       UIBackgroundModes: ["remote-notification", "location", "fetch", "processing"],
       BGTaskSchedulerPermittedIdentifiers: [
         "PROSTCOUNTER_BACKGROUND_SYNC",

--- a/apps/mobile/ios/ProstCounter/Info.plist
+++ b/apps/mobile/ios/ProstCounter/Info.plist
@@ -74,6 +74,8 @@
 	<string>Allow $(PRODUCT_NAME) to access your location</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>ProstCounter uses your location to share with friends and show nearby tents</string>
+	<key>NSMotionUsageDescription</key>
+	<string>ProstCounter uses device motion to power smooth, responsive animations as you interact with the app.</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>ProstCounter needs access to your photo library to let you upload beer pictures to your daily attendance log and share them with your group members in the gallery. For example, you can select a photo of your beer to document your Oktoberfest experience.</string>
 	<key>NSUserActivityTypes</key>


### PR DESCRIPTION
## What

App Store Connect rejected the 1.5.2 delivery (build 79) with ITMS-90683: missing `NSMotionUsageDescription` in Info.plist.

## Why

reanimated 4 (new with the SDK 57 migration) and expo-location link CoreMotion. Apple requires a purpose string for any binary that references the motion APIs, even when the app never calls them directly.

## Changes

- Add `NSMotionUsageDescription` to `app.config.ts` `ios.infoPlist` (source of truth for prebuild).
- Mirror it into the tracked `ios/ProstCounter/Info.plist`.

Version stays 1.5.2 (build 79 was rejected at delivery, so a new build under the same version is fine). EAS `autoIncrement` bumps the build number.

## Verification

New iOS production build in progress: https://expo.dev/accounts/pepegrillo/projects/prostcounter/builds/3c494628-37f2-49e7-a985-f8aec9d09e38

🤖 Generated with [Claude Code](https://claude.com/claude-code)