### PR TITLE
fix(wrapped): stop past-festival wrapped timing out on cache miss

### DIFF
--- a/apps/mobile/components/wrapped/slides/comparisons-slide.tsx
+++ b/apps/mobile/components/wrapped/slides/comparisons-slide.tsx
@@ -1,6 +1,7 @@
 import { Motion } from "@legendapp/motion";
 import { useTranslation } from "@prostcounter/shared/i18n";
 import type { WrappedData } from "@prostcounter/shared/wrapped";
+import { formatPercentile } from "@prostcounter/shared/wrapped";
 import { cn } from "@prostcounter/ui";
 
 import { HStack } from "@/components/ui/hstack";
@@ -28,8 +29,33 @@ function DiffIndicator({ value, suffix = "" }: { value: number; suffix?: string 
   );
 }
 
+function PercentileValue({ percentile, median }: { percentile: number; median?: number }) {
+  const { t } = useTranslation();
+
+  return (
+    <>
+      <Text className="text-center text-lg font-bold text-gray-800">
+        {t("wrapped.comparisons.betterThan", { percent: formatPercentile(percentile) })}
+      </Text>
+      {median !== undefined && (
+        <Text className="text-center text-xs text-gray-500">
+          {t("wrapped.comparisons.typical", { value: median })}
+        </Text>
+      )}
+    </>
+  );
+}
+
 export function ComparisonsSlide({ data, isActive }: ComparisonsSlideProps) {
   const { t } = useTranslation();
+
+  const vsFestivalAvg = data.comparisons?.vs_festival_avg;
+  const vsLastYear = data.comparisons?.vs_last_year;
+
+  // Percentile rank is the better statistic, but cache rows written before it was added
+  // only carry the mean-based diff, so fall back to that until they are regenerated.
+  const hasPercentile =
+    vsFestivalAvg?.beers_percentile !== undefined && vsFestivalAvg?.days_percentile !== undefined;
 
   return (
     <BaseSlide isActive={isActive} backgroundClassName={cn("bg-teal-50")}>
@@ -37,6 +63,7 @@ export function ComparisonsSlide({ data, isActive }: ComparisonsSlideProps) {
         <SlideTitle isActive={isActive}>{t("wrapped.comparisons.title")}</SlideTitle>
 
         {/* vs Festival Average */}
+        {vsFestivalAvg && (
         <VStack space="sm">
           <Motion.View
             initial={{ opacity: 0 }}
@@ -44,7 +71,11 @@ export function ComparisonsSlide({ data, isActive }: ComparisonsSlideProps) {
             transition={{ type: "timing", duration: 300, delay: 200 }}
           >
             <Text className="text-center text-sm font-semibold text-gray-600">
-              {t("wrapped.comparisons.vsFestivalAvg")}
+              {t(
+                hasPercentile
+                  ? "wrapped.comparisons.vsAttendees"
+                  : "wrapped.comparisons.vsFestivalAvg",
+              )}
             </Text>
           </Motion.View>
 
@@ -56,7 +87,14 @@ export function ComparisonsSlide({ data, isActive }: ComparisonsSlideProps) {
               className="flex-1 items-center rounded-2xl bg-white/70 p-4"
             >
               <Text className="text-sm text-gray-500">{t("wrapped.comparisons.beers")}</Text>
-              <DiffIndicator value={data.comparisons.vs_festival_avg.beers_diff_pct} suffix="%" />
+              {hasPercentile ? (
+                <PercentileValue
+                  percentile={vsFestivalAvg.beers_percentile ?? 0}
+                  median={vsFestivalAvg.median_beers}
+                />
+              ) : (
+                <DiffIndicator value={vsFestivalAvg.beers_diff_pct} suffix="%" />
+              )}
             </Motion.View>
             <Motion.View
               initial={{ opacity: 0, y: 20 }}
@@ -65,13 +103,21 @@ export function ComparisonsSlide({ data, isActive }: ComparisonsSlideProps) {
               className="flex-1 items-center rounded-2xl bg-white/70 p-4"
             >
               <Text className="text-sm text-gray-500">{t("wrapped.comparisons.days")}</Text>
-              <DiffIndicator value={data.comparisons.vs_festival_avg.days_diff_pct} suffix="%" />
+              {hasPercentile ? (
+                <PercentileValue
+                  percentile={vsFestivalAvg.days_percentile ?? 0}
+                  median={vsFestivalAvg.median_days}
+                />
+              ) : (
+                <DiffIndicator value={vsFestivalAvg.days_diff_pct} suffix="%" />
+              )}
             </Motion.View>
           </HStack>
         </VStack>
+        )}
 
         {/* vs Last Year */}
-        {data.comparisons.vs_last_year && (
+        {vsLastYear && (
           <VStack space="sm" className="mt-2">
             <Motion.View
               initial={{ opacity: 0 }}
@@ -82,7 +128,7 @@ export function ComparisonsSlide({ data, isActive }: ComparisonsSlideProps) {
                 {t("wrapped.comparisons.vsLastYear")}
               </Text>
               <Text className="text-center text-xs text-gray-400">
-                {t("wrapped.comparisons.vs")} {data.comparisons.vs_last_year.prev_festival_name}
+                {t("wrapped.comparisons.vs")} {vsLastYear.prev_festival_name}
               </Text>
             </Motion.View>
 
@@ -94,7 +140,7 @@ export function ComparisonsSlide({ data, isActive }: ComparisonsSlideProps) {
                 className="flex-1 items-center rounded-2xl bg-white/70 p-4"
               >
                 <Text className="text-sm text-gray-500">{t("wrapped.comparisons.beers")}</Text>
-                <DiffIndicator value={data.comparisons.vs_last_year.beers_diff} />
+                <DiffIndicator value={vsLastYear.beers_diff} />
               </Motion.View>
               <Motion.View
                 initial={{ opacity: 0, y: 20 }}
@@ -103,7 +149,7 @@ export function ComparisonsSlide({ data, isActive }: ComparisonsSlideProps) {
                 className="flex-1 items-center rounded-2xl bg-white/70 p-4"
               >
                 <Text className="text-sm text-gray-500">{t("wrapped.comparisons.days")}</Text>
-                <DiffIndicator value={data.comparisons.vs_last_year.days_diff} />
+                <DiffIndicator value={vsLastYear.days_diff} />
               </Motion.View>
             </HStack>
           </VStack>

--- a/apps/mobile/hooks/useWrappedData.ts
+++ b/apps/mobile/hooks/useWrappedData.ts
@@ -34,8 +34,11 @@ export function useWrappedData(festivalId?: string) {
       });
 
       if (error) {
+        // Throw rather than returning null: null is indistinguishable from "no wrapped
+        // data yet", so a real failure (e.g. the statement timeout this used to hit on
+        // uncached past festivals) silently rendered the empty state and never surfaced.
         logger.error("Failed to fetch wrapped data", error);
-        return null;
+        throw new Error(`Failed to fetch wrapped data: ${error.message}`, { cause: error });
       }
 
       logger.debug("[WrappedData] RPC response", {

--- a/apps/web/components/wrapped/slides/ComparisonsSlide.tsx
+++ b/apps/web/components/wrapped/slides/ComparisonsSlide.tsx
@@ -2,7 +2,7 @@
 
 import { useTranslation } from "@prostcounter/shared/i18n";
 import type { WrappedData } from "@prostcounter/shared/wrapped";
-import { formatPercentage, isImprovement } from "@prostcounter/shared/wrapped";
+import { formatPercentage, formatPercentile, isImprovement } from "@prostcounter/shared/wrapped";
 import { ArrowDown, ArrowUp, Minus } from "lucide-react";
 
 import { BaseSlide, SlideTitle } from "./BaseSlide";
@@ -30,6 +30,12 @@ export function ComparisonsSlide({ data, isActive = false }: ComparisonsSlidePro
   const { vs_festival_avg, vs_last_year } = data.comparisons;
   const improvement = vs_last_year ? isImprovement(vs_last_year) : null;
 
+  // Percentile rank is the better statistic, but cache rows written before it was added
+  // only carry the mean-based diff, so fall back to that until they are regenerated.
+  const hasPercentile =
+    vs_festival_avg?.beers_percentile !== undefined &&
+    vs_festival_avg?.days_percentile !== undefined;
+
   const getIcon = (diff: number) => {
     if (diff > 0) return <ArrowUp className="size-5 text-green-500" />;
     if (diff < 0) return <ArrowDown className="size-5 text-red-500" />;
@@ -45,26 +51,60 @@ export function ComparisonsSlide({ data, isActive = false }: ComparisonsSlidePro
         {vs_festival_avg && (
           <div className="rounded-xl bg-white p-6 shadow-lg">
             <h3 className="mb-4 text-center text-lg font-semibold text-gray-700">
-              {t("wrapped.comparisons.vsFestivalAvg")}
+              {t(
+                hasPercentile
+                  ? "wrapped.comparisons.vsAttendees"
+                  : "wrapped.comparisons.vsFestivalAvg",
+              )}
             </h3>
             <div className="space-y-3">
               <div className="flex items-center justify-between rounded-lg bg-gray-50 p-3">
                 <span className="text-gray-700">{t("wrapped.comparisons.beers")}</span>
-                <div className="flex items-center gap-2">
-                  {getIcon(vs_festival_avg.beers_diff_pct || 0)}
-                  <span className="font-bold text-gray-800">
-                    {formatPercentage(vs_festival_avg.beers_diff_pct || 0)}
-                  </span>
-                </div>
+                {hasPercentile ? (
+                  <div className="text-right">
+                    <span className="font-bold text-gray-800">
+                      {t("wrapped.comparisons.betterThan", {
+                        percent: formatPercentile(vs_festival_avg.beers_percentile ?? 0),
+                      })}
+                    </span>
+                    {vs_festival_avg.median_beers !== undefined && (
+                      <p className="text-xs text-gray-500">
+                        {t("wrapped.comparisons.typical", { value: vs_festival_avg.median_beers })}
+                      </p>
+                    )}
+                  </div>
+                ) : (
+                  <div className="flex items-center gap-2">
+                    {getIcon(vs_festival_avg.beers_diff_pct || 0)}
+                    <span className="font-bold text-gray-800">
+                      {formatPercentage(vs_festival_avg.beers_diff_pct || 0)}
+                    </span>
+                  </div>
+                )}
               </div>
               <div className="flex items-center justify-between rounded-lg bg-gray-50 p-3">
                 <span className="text-gray-700">{t("wrapped.comparisons.days")}</span>
-                <div className="flex items-center gap-2">
-                  {getIcon(vs_festival_avg.days_diff_pct || 0)}
-                  <span className="font-bold text-gray-800">
-                    {formatPercentage(vs_festival_avg.days_diff_pct || 0)}
-                  </span>
-                </div>
+                {hasPercentile ? (
+                  <div className="text-right">
+                    <span className="font-bold text-gray-800">
+                      {t("wrapped.comparisons.betterThan", {
+                        percent: formatPercentile(vs_festival_avg.days_percentile ?? 0),
+                      })}
+                    </span>
+                    {vs_festival_avg.median_days !== undefined && (
+                      <p className="text-xs text-gray-500">
+                        {t("wrapped.comparisons.typical", { value: vs_festival_avg.median_days })}
+                      </p>
+                    )}
+                  </div>
+                ) : (
+                  <div className="flex items-center gap-2">
+                    {getIcon(vs_festival_avg.days_diff_pct || 0)}
+                    <span className="font-bold text-gray-800">
+                      {formatPercentage(vs_festival_avg.days_diff_pct || 0)}
+                    </span>
+                  </div>
+                )}
               </div>
             </div>
           </div>

--- a/apps/web/hooks/useWrapped.ts
+++ b/apps/web/hooks/useWrapped.ts
@@ -32,9 +32,10 @@ export function useWrappedData(festivalId?: string) {
       });
 
       if (error) {
-        // eslint-disable-next-line no-console
-        console.error("Failed to fetch wrapped data:", error);
-        return null;
+        // Throw rather than returning null: null is indistinguishable from "no wrapped
+        // data yet", so a real failure (e.g. the statement timeout this used to hit on
+        // uncached past festivals) silently rendered the empty state and never surfaced.
+        throw new Error(`Failed to fetch wrapped data: ${error.message}`, { cause: error });
       }
 
       return data as unknown as WrappedData;

--- a/packages/shared/src/i18n/locales/de.json
+++ b/packages/shared/src/i18n/locales/de.json
@@ -1494,6 +1494,9 @@
     "comparisons": {
       "title": "Wie du im Vergleich abschneidest",
       "vsFestivalAvg": "vs Festivaldurchschnitt",
+      "vsAttendees": "Dein Rang",
+      "betterThan": "Besser als {{percent}} der Teilnehmenden",
+      "typical": "Typisch: {{value}}",
       "vsLastYear": "vs Letztes Jahr",
       "vs": "vs",
       "beers": "Maß",

--- a/packages/shared/src/i18n/locales/en.json
+++ b/packages/shared/src/i18n/locales/en.json
@@ -1741,6 +1741,9 @@
     "comparisons": {
       "title": "How you compare",
       "vsFestivalAvg": "vs Festival Average",
+      "vsAttendees": "How you rank",
+      "betterThan": "Better than {{percent}} of attendees",
+      "typical": "Typical: {{value}}",
       "vsLastYear": "vs Last Year",
       "vs": "vs",
       "beers": "Beers",

--- a/packages/shared/src/i18n/locales/es.json
+++ b/packages/shared/src/i18n/locales/es.json
@@ -1741,6 +1741,9 @@
     "comparisons": {
       "title": "Cómo te comparás",
       "vsFestivalAvg": "vs Promedio del Festival",
+      "vsAttendees": "Cómo te ubicás",
+      "betterThan": "Mejor que el {{percent}} de los asistentes",
+      "typical": "Típico: {{value}}",
       "vsLastYear": "vs Año Pasado",
       "vs": "vs",
       "beers": "Cervezas",

--- a/packages/shared/src/wrapped/index.ts
+++ b/packages/shared/src/wrapped/index.ts
@@ -30,6 +30,7 @@ export {
   formatCurrency,
   formatNumber,
   formatPercentage,
+  formatPercentile,
   getFestivalYear,
   calculateTotalPoints,
   hasWrappedData,

--- a/packages/shared/src/wrapped/types.ts
+++ b/packages/shared/src/wrapped/types.ts
@@ -147,6 +147,16 @@ export interface WrappedData {
       days_diff_pct: number;
       avg_beers: number;
       avg_days: number;
+      /**
+       * Percentile rank and median, preferred over the mean-based *_diff_pct above:
+       * the mean is skewed by one-day attendees and by the top of the range, so almost
+       * everyone lands "above average". Optional because cache rows written before
+       * these were added do not carry them.
+       */
+      median_beers?: number;
+      median_days?: number;
+      beers_percentile?: number;
+      days_percentile?: number;
     };
     vs_last_year: {
       beers_diff: number;

--- a/packages/shared/src/wrapped/utils.ts
+++ b/packages/shared/src/wrapped/utils.ts
@@ -42,6 +42,15 @@ export function formatPercentage(percent: number): string {
 }
 
 /**
+ * Format a percentile rank for display. Whole numbers read better than decimals
+ * here ("better than 86% of attendees"), and the extra precision is meaningless
+ * on festivals with only a few dozen attendees.
+ */
+export function formatPercentile(percent: number): string {
+  return `${Math.round(percent)}%`;
+}
+
+/**
  * Get festival year from festival name or dates
  */
 export function getFestivalYear(festivalInfo: WrappedData["festival_info"]): number {

--- a/supabase/migrations/20260726190000_fix_wrapped_rls_and_comparisons.sql
+++ b/supabase/migrations/20260726190000_fix_wrapped_rls_and_comparisons.sql
@@ -24,7 +24,7 @@
 
 -- Helper function: get effective drink count for an attendance
 -- Returns consumptions count if > 0, otherwise falls back to legacy beer_count
-CREATE OR REPLACE FUNCTION _get_effective_drink_count(p_attendance_id UUID)
+CREATE OR REPLACE FUNCTION "public"."_get_effective_drink_count"(p_attendance_id UUID)
 RETURNS INT
 LANGUAGE sql
 STABLE

--- a/supabase/migrations/20260726190000_fix_wrapped_rls_and_comparisons.sql
+++ b/supabase/migrations/20260726190000_fix_wrapped_rls_and_comparisons.sql
@@ -1,0 +1,688 @@
+-- Fix wrapped year-in-review for past festivals.
+--
+-- Three bugs, one migration:
+--
+-- 1. Timeout on cache miss. get_wrapped_data, get_wrapped_data_cached and
+--    _get_effective_drink_count were SECURITY INVOKER, so on a cache miss the whole
+--    computation ran as `authenticated` (statement_timeout = 8s) with RLS evaluated
+--    per row. Festivals with enough attendances (Oktoberfest 2024/2025) exceeded the
+--    timeout and the wrapped page rendered its error state. Same pattern as
+--    get_global_leaderboard, which is already SECURITY DEFINER.
+--
+-- 2. Wrong festival averages. Because of the same SECURITY INVOKER problem, the
+--    cross-user averages were computed over only the rows RLS let the caller see.
+--    Measured on seed data: avg_beers 10.43 as postgres vs 5.14 as authenticated.
+--
+-- 3. Missing comparisons for first-timers. previous_festival was CROSS JOINed, so a
+--    user with no earlier festival of the same type got a NULL comparisons object
+--    and lost the festival-average block too, not just the year-over-year one.
+--
+-- Also replaces the per-row _get_effective_drink_count call in the festival average
+-- with a set-based join, and adds median + percentile rank so the slide can show
+-- "you drank more than X% of attendees" instead of a mean-based diff that almost
+-- everyone beats (45 users, mean 8.31, median 6, 12 of them one-day attendees).
+
+-- Helper function: get effective drink count for an attendance
+-- Returns consumptions count if > 0, otherwise falls back to legacy beer_count
+CREATE OR REPLACE FUNCTION _get_effective_drink_count(p_attendance_id UUID)
+RETURNS INT
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT COALESCE(
+    NULLIF((SELECT COUNT(*)::int FROM consumptions WHERE attendance_id = p_attendance_id), 0),
+    (SELECT beer_count FROM attendances WHERE id = p_attendance_id)
+  );
+$$;
+
+CREATE OR REPLACE FUNCTION "public"."get_wrapped_data"("p_user_id" "uuid", "p_festival_id" "uuid") RETURNS "jsonb"
+    LANGUAGE "plpgsql"
+    SECURITY DEFINER
+    SET search_path = public
+    AS $$
+DECLARE
+  v_result JSONB := '{}'::JSONB;
+  v_festival RECORD;
+  v_user RECORD;
+  v_basic_stats JSONB;
+  v_tent_stats JSONB;
+  v_peak_moments JSONB;
+  v_social_stats JSONB;
+  v_global_positions JSONB;
+  v_achievements JSONB;
+  v_timeline JSONB;
+  v_comparisons JSONB;
+  v_personality JSONB;
+  v_drink_stats JSONB;
+  v_beer_cost DECIMAL(5,2);
+BEGIN
+  -- SECURITY DEFINER: this function reads across all users to build festival-wide
+  -- averages and rankings, so it must not be callable for someone else's user id.
+  -- auth.uid() IS NULL means there is no JWT (service_role, or the internal call from
+  -- regenerate_wrapped_data_cache), which is allowed; anon is revoked below instead.
+  IF auth.uid() IS NOT NULL
+     AND p_user_id <> auth.uid()
+     AND NOT public.is_super_admin() THEN
+    RAISE EXCEPTION 'Not authorized to read wrapped data for another user'
+      USING ERRCODE = '42501';
+  END IF;
+
+  -- Get festival info
+  SELECT * INTO v_festival FROM festivals WHERE id = p_festival_id;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Festival not found';
+  END IF;
+
+  -- Get user profile
+  SELECT * INTO v_user FROM profiles WHERE id = p_user_id;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'User not found';
+  END IF;
+
+  -- Get default beer cost from festival or use global default
+  v_beer_cost := COALESCE(v_festival.beer_cost, 16.20);
+
+  -- Build user_info
+  v_result := jsonb_build_object(
+    'user_info', jsonb_build_object(
+      'username', v_user.username,
+      'full_name', v_user.full_name,
+      'avatar_url', v_user.avatar_url
+    ),
+    'festival_info', jsonb_build_object(
+      'name', v_festival.name,
+      'start_date', v_festival.start_date,
+      'end_date', v_festival.end_date,
+      'location', v_festival.location
+    )
+  );
+
+  -- Calculate basic stats using consumptions (with beer_count fallback)
+  WITH attendance_drinks AS (
+    SELECT
+      a.id,
+      a.date,
+      _get_effective_drink_count(a.id) AS drink_count
+    FROM attendances a
+    WHERE a.user_id = p_user_id AND a.festival_id = p_festival_id
+  ),
+  attendance_agg AS (
+    SELECT
+      COUNT(DISTINCT ad.date) AS days_attended,
+      COALESCE(SUM(ad.drink_count), 0) AS total_beers,
+      CASE
+        WHEN COUNT(DISTINCT ad.date) > 0 THEN
+          ROUND(COALESCE(SUM(ad.drink_count), 0)::NUMERIC / COUNT(DISTINCT ad.date)::NUMERIC, 2)
+        ELSE 0
+      END AS avg_beers
+    FROM attendance_drinks ad
+  )
+  SELECT jsonb_build_object(
+    'total_beers', total_beers,
+    'days_attended', days_attended,
+    'avg_beers', avg_beers,
+    'total_spent', ROUND(total_beers * v_beer_cost, 2),
+    'beer_cost', v_beer_cost
+  ) INTO v_basic_stats
+  FROM attendance_agg;
+
+  v_result := v_result || jsonb_build_object('basic_stats', v_basic_stats);
+
+  -- Calculate tent stats
+  WITH tent_stats AS (
+    SELECT
+      tv.tent_id,
+      t.name as tent_name,
+      COUNT(*) AS visit_count
+    FROM tent_visits tv
+    JOIN tents t ON tv.tent_id = t.id
+    WHERE tv.user_id = p_user_id
+      AND tv.festival_id = p_festival_id
+    GROUP BY tv.tent_id, t.name
+  ),
+  tent_agg AS (
+    SELECT
+      COUNT(DISTINCT tent_id) AS unique_tents,
+      (
+        SELECT tent_name
+        FROM tent_stats ts
+        ORDER BY ts.visit_count DESC, ts.tent_name ASC
+        LIMIT 1
+      ) AS favorite_tent,
+      (
+        SELECT jsonb_agg(
+          jsonb_build_object(
+            'tent_name', tent_name,
+            'visit_count', visit_count
+          ) ORDER BY visit_count DESC, tent_name ASC
+        )
+        FROM tent_stats ts
+      ) AS tent_breakdown
+    FROM tent_stats
+  ),
+  tent_total AS (
+    SELECT COUNT(*) AS total_tents FROM tents
+  )
+  SELECT jsonb_build_object(
+    'unique_tents', COALESCE(ta.unique_tents, 0),
+    'favorite_tent', ta.favorite_tent,
+    'tent_diversity_pct', CASE
+      WHEN tt.total_tents > 0 THEN ROUND((COALESCE(ta.unique_tents, 0)::NUMERIC / tt.total_tents::NUMERIC) * 100, 1)
+      ELSE 0
+    END,
+    'tent_breakdown', COALESCE(ta.tent_breakdown, '[]'::JSONB)
+  ) INTO v_tent_stats
+  FROM tent_agg ta, tent_total tt;
+
+  v_result := v_result || jsonb_build_object('tent_stats', v_tent_stats);
+
+  -- Calculate peak moments using consumptions (with beer_count fallback)
+  WITH daily_base AS (
+    SELECT
+      a.date,
+      _get_effective_drink_count(a.id) AS drink_count,
+      COALESCE(tv.tent_count, 0) as tents_visited
+    FROM attendances a
+    LEFT JOIN (
+      SELECT
+        tv.visit_date::date as date,
+        COUNT(DISTINCT tv.tent_id) as tent_count
+      FROM tent_visits tv
+      WHERE tv.user_id = p_user_id
+        AND tv.festival_id = p_festival_id
+      GROUP BY tv.visit_date::date
+    ) tv ON a.date = tv.date
+    WHERE a.user_id = p_user_id AND a.festival_id = p_festival_id
+  ),
+  daily_scores AS (
+    SELECT
+      db.date,
+      db.drink_count,
+      db.tents_visited,
+      (db.drink_count + db.tents_visited) as combined_score,
+      ROUND(db.drink_count * v_beer_cost, 2) AS spent
+    FROM daily_base db
+  ),
+  best_day AS (
+    SELECT
+      ds.date,
+      ds.drink_count,
+      ds.tents_visited,
+      ds.spent
+    FROM daily_scores ds
+    ORDER BY ds.combined_score DESC, ds.date DESC
+    LIMIT 1
+  ),
+  max_session AS (
+    SELECT COALESCE(MAX(ds.drink_count), 0) AS max_beers
+    FROM daily_scores ds
+  ),
+  most_expensive AS (
+    SELECT
+      ds.date,
+      ds.spent AS amount
+    FROM daily_scores ds
+    ORDER BY ds.spent DESC
+    LIMIT 1
+  )
+  SELECT jsonb_build_object(
+    'best_day', CASE
+      WHEN bd.date IS NOT NULL THEN
+        jsonb_build_object(
+          'date', bd.date,
+          'beer_count', bd.drink_count,
+          'tents_visited', bd.tents_visited,
+          'spent', bd.spent
+        )
+      ELSE NULL
+    END,
+    'max_single_session', ms.max_beers,
+    'most_expensive_day', CASE
+      WHEN me.date IS NOT NULL THEN
+        jsonb_build_object(
+          'date', me.date,
+          'amount', me.amount
+        )
+      ELSE NULL
+    END
+  ) INTO v_peak_moments
+  FROM best_day bd, max_session ms, most_expensive me;
+
+  v_result := v_result || jsonb_build_object('peak_moments', v_peak_moments);
+
+  -- Calculate social stats (rankings use consumptions via helper)
+  WITH user_groups AS (
+    SELECT
+      COUNT(DISTINCT gm.group_id) AS groups_joined,
+      COUNT(DISTINCT gm2.user_id) AS total_group_members
+    FROM group_members gm
+    JOIN groups g ON gm.group_id = g.id
+    LEFT JOIN group_members gm2 ON g.id = gm2.group_id AND gm2.user_id != p_user_id
+    WHERE gm.user_id = p_user_id AND g.festival_id = p_festival_id
+  ),
+  top_rankings AS (
+    SELECT jsonb_agg(
+      jsonb_build_object(
+        'group_name', group_name,
+        'position', user_rank
+      ) ORDER BY user_rank ASC
+    ) AS rankings
+    FROM (
+      SELECT
+        g.name AS group_name,
+        wc.name AS winning_criteria,
+        CASE
+          WHEN wc.name = 'days_attended' THEN
+            ROW_NUMBER() OVER (
+              PARTITION BY g.id
+              ORDER BY COUNT(DISTINCT a.date) DESC, p.username ASC
+            )
+          WHEN wc.name = 'total_beers' THEN
+            ROW_NUMBER() OVER (
+              PARTITION BY g.id
+              ORDER BY COALESCE(SUM(_get_effective_drink_count(a.id)), 0) DESC, p.username ASC
+            )
+          WHEN wc.name = 'avg_beers' THEN
+            ROW_NUMBER() OVER (
+              PARTITION BY g.id
+              ORDER BY COALESCE(AVG(_get_effective_drink_count(a.id)), 0) DESC, p.username ASC
+            )
+          ELSE 1
+        END AS user_rank
+      FROM groups g
+      JOIN group_members gm ON g.id = gm.group_id
+      LEFT JOIN attendances a ON gm.user_id = a.user_id AND a.festival_id = p_festival_id
+      LEFT JOIN profiles p ON gm.user_id = p.id
+      LEFT JOIN winning_criteria wc ON g.winning_criteria_id = wc.id
+      WHERE g.festival_id = p_festival_id AND gm.user_id = p_user_id
+      GROUP BY g.id, g.name, wc.name, p.username
+    ) ranked
+    WHERE user_rank <= 3
+  ),
+  photo_count AS (
+    SELECT COUNT(*) AS photos_uploaded
+    FROM beer_pictures bp
+    JOIN attendances a ON bp.attendance_id = a.id
+    WHERE bp.user_id = p_user_id
+      AND a.date >= v_festival.start_date
+      AND a.date <= v_festival.end_date
+      AND a.festival_id = p_festival_id
+  ),
+  user_pictures AS (
+    SELECT
+      bp.id,
+      bp.picture_url,
+      bp.created_at,
+      a.date as attendance_date
+    FROM beer_pictures bp
+    JOIN attendances a ON bp.attendance_id = a.id
+    WHERE bp.user_id = p_user_id
+      AND a.date >= v_festival.start_date
+      AND a.date <= v_festival.end_date
+      AND a.festival_id = p_festival_id
+    ORDER BY bp.created_at DESC
+    LIMIT 20
+  )
+  SELECT jsonb_build_object(
+    'groups_joined', ug.groups_joined,
+    'top_3_rankings', COALESCE(tr.rankings, '[]'::JSONB),
+    'photos_uploaded', pc.photos_uploaded,
+    'total_group_members', ug.total_group_members,
+    'pictures', COALESCE(
+      (SELECT jsonb_agg(
+        jsonb_build_object(
+          'id', up.id,
+          'picture_url', up.picture_url,
+          'created_at', up.created_at,
+          'attendance_date', up.attendance_date
+        )
+      ) FROM user_pictures up),
+      '[]'::JSONB
+    )
+  ) INTO v_social_stats
+  FROM user_groups ug, top_rankings tr, photo_count pc;
+
+  v_result := v_result || jsonb_build_object('social_stats', v_social_stats);
+
+  -- Calculate global leaderboard positions for days_attended, total_beers, and avg_beers
+  -- Note: get_global_leaderboard uses its own logic; wrapped-specific positions calculated here
+  WITH global_positions AS (
+    SELECT
+      'days_attended' as criteria,
+      CASE
+        WHEN array_length(array_agg(gl.user_id ORDER BY gl.days_attended DESC, gl.username ASC), 1) > 0
+        THEN array_position(array_agg(gl.user_id ORDER BY gl.days_attended DESC, gl.username ASC), p_user_id)
+        ELSE NULL
+      END as position
+    FROM get_global_leaderboard(1, p_festival_id) gl
+    UNION ALL
+    SELECT
+      'total_beers' as criteria,
+      CASE
+        WHEN array_length(array_agg(gl.user_id ORDER BY gl.total_beers DESC, gl.username ASC), 1) > 0
+        THEN array_position(array_agg(gl.user_id ORDER BY gl.total_beers DESC, gl.username ASC), p_user_id)
+        ELSE NULL
+      END as position
+    FROM get_global_leaderboard(2, p_festival_id) gl
+    UNION ALL
+    SELECT
+      'avg_beers' as criteria,
+      CASE
+        WHEN array_length(array_agg(gl.user_id ORDER BY gl.avg_beers DESC, gl.username ASC), 1) > 0
+        THEN array_position(array_agg(gl.user_id ORDER BY gl.avg_beers DESC, gl.username ASC), p_user_id)
+        ELSE NULL
+      END as position
+    FROM get_global_leaderboard(3, p_festival_id) gl
+  )
+  SELECT jsonb_build_object(
+    'days_attended', MAX(CASE WHEN criteria = 'days_attended' THEN position END),
+    'total_beers', MAX(CASE WHEN criteria = 'total_beers' THEN position END),
+    'avg_beers', MAX(CASE WHEN criteria = 'avg_beers' THEN position END)
+  ) INTO v_global_positions
+  FROM global_positions;
+
+  v_result := v_result || jsonb_build_object('global_leaderboard_positions', v_global_positions);
+
+  -- Get achievements
+  SELECT COALESCE(
+    jsonb_agg(
+      jsonb_build_object(
+        'id', a.id,
+        'name', a.name,
+        'description', a.description,
+        'icon', a.icon,
+        'points', a.points,
+        'rarity', a.rarity,
+        'unlocked_at', ua.unlocked_at
+      ) ORDER BY ua.unlocked_at DESC
+    ),
+    '[]'::JSONB
+  ) INTO v_achievements
+  FROM user_achievements ua
+  JOIN achievements a ON ua.achievement_id = a.id
+  WHERE ua.user_id = p_user_id AND ua.festival_id = p_festival_id;
+
+  v_result := v_result || jsonb_build_object('achievements', v_achievements);
+
+  -- Build timeline (daily progression) using consumptions
+  SELECT COALESCE(
+    jsonb_agg(
+      jsonb_build_object(
+        'date', a.date,
+        'beer_count', _get_effective_drink_count(a.id),
+        'spent', ROUND(_get_effective_drink_count(a.id) * v_beer_cost, 2),
+        'tents_visited', (
+          SELECT COUNT(DISTINCT tent_id)
+          FROM tent_visits tv
+          WHERE tv.user_id = p_user_id
+            AND tv.festival_id = p_festival_id
+            AND tv.visit_date::date = a.date
+        )
+      ) ORDER BY a.date ASC
+    ),
+    '[]'::JSONB
+  ) INTO v_timeline
+  FROM attendances a
+  WHERE a.user_id = p_user_id AND a.festival_id = p_festival_id;
+
+  v_result := v_result || jsonb_build_object('timeline', v_timeline);
+
+  -- Calculate comparisons using consumptions.
+  -- Set-based rather than per-row _get_effective_drink_count: that helper re-reads the
+  -- attendances row by id even though we already have it here, which cost ~600 extra
+  -- buffer hits per festival. COUNT(*) rather than COUNT(DISTINCT a.date) is safe
+  -- because of the unique_user_date_festival index on (user_id, date, festival_id).
+  WITH festival_user_stats AS (
+    SELECT
+      a.user_id,
+      COUNT(*) AS days_attended,
+      COALESCE(SUM(COALESCE(NULLIF(c.drink_count, 0), a.beer_count)), 0) AS total_drinks
+    FROM attendances a
+    LEFT JOIN (
+      SELECT cc.attendance_id, COUNT(*)::int AS drink_count
+      FROM consumptions cc
+      JOIN attendances aa ON aa.id = cc.attendance_id
+      WHERE aa.festival_id = p_festival_id
+      GROUP BY cc.attendance_id
+    ) c ON c.attendance_id = a.id
+    WHERE a.festival_id = p_festival_id
+    GROUP BY a.user_id
+  ),
+  festival_avg AS (
+    SELECT
+      ROUND(AVG(total_drinks), 2) AS avg_beers,
+      ROUND(AVG(days_attended), 2) AS avg_days,
+      ROUND(PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY total_drinks)::NUMERIC, 2) AS median_beers,
+      ROUND(PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY days_attended)::NUMERIC, 2) AS median_days
+    FROM festival_user_stats
+  ),
+  -- Percentile rank: share of attendees strictly below the user. More meaningful than
+  -- the mean diff, which is skewed by one-day attendees and by the top of the range.
+  user_percentile AS (
+    SELECT
+      COUNT(*) AS total_users,
+      COUNT(*) FILTER (
+        WHERE fus.total_drinks < (v_basic_stats->>'total_beers')::NUMERIC
+      ) AS below_beers,
+      COUNT(*) FILTER (
+        WHERE fus.days_attended < (v_basic_stats->>'days_attended')::NUMERIC
+      ) AS below_days
+    FROM festival_user_stats fus
+  ),
+  user_current AS (
+    SELECT
+      (v_basic_stats->>'total_beers')::NUMERIC AS user_beers,
+      (v_basic_stats->>'days_attended')::NUMERIC AS user_days
+  ),
+  previous_festival AS (
+    SELECT
+      f.id as festival_id,
+      f.name as festival_name,
+      COUNT(DISTINCT a.date) AS prev_days,
+      COALESCE(SUM(_get_effective_drink_count(a.id)), 0) AS prev_beers,
+      COALESCE(SUM(_get_effective_drink_count(a.id)) * v_beer_cost, 0) AS prev_spent
+    FROM attendances a
+    JOIN festivals f ON a.festival_id = f.id
+    WHERE a.user_id = p_user_id
+      AND f.festival_type = v_festival.festival_type
+      AND f.start_date < v_festival.start_date
+      AND f.id != p_festival_id
+    GROUP BY f.id, f.name, f.start_date
+    ORDER BY f.start_date DESC
+    LIMIT 1
+  )
+  SELECT jsonb_build_object(
+    'vs_festival_avg', jsonb_build_object(
+      'beers_diff_pct', CASE
+        WHEN fa.avg_beers > 0 THEN ROUND(((uc.user_beers - fa.avg_beers) / fa.avg_beers) * 100, 1)
+        ELSE 0
+      END,
+      'days_diff_pct', CASE
+        WHEN fa.avg_days > 0 THEN ROUND(((uc.user_days - fa.avg_days) / fa.avg_days) * 100, 1)
+        ELSE 0
+      END,
+      'avg_beers', fa.avg_beers,
+      'avg_days', fa.avg_days,
+      'median_beers', fa.median_beers,
+      'median_days', fa.median_days,
+      'beers_percentile', CASE
+        WHEN up.total_users > 0 THEN ROUND((up.below_beers::NUMERIC / up.total_users) * 100, 1)
+        ELSE 0
+      END,
+      'days_percentile', CASE
+        WHEN up.total_users > 0 THEN ROUND((up.below_days::NUMERIC / up.total_users) * 100, 1)
+        ELSE 0
+      END
+    ),
+    'vs_last_year', CASE
+      WHEN pf.prev_beers > 0 THEN
+        jsonb_build_object(
+          'beers_diff', uc.user_beers - pf.prev_beers,
+          'days_diff', uc.user_days - pf.prev_days,
+          'spent_diff', ROUND((uc.user_beers * v_beer_cost) - pf.prev_spent, 2),
+          'prev_beers', pf.prev_beers,
+          'prev_days', pf.prev_days,
+          'prev_festival_name', pf.festival_name
+        )
+      ELSE NULL
+    END
+  ) INTO v_comparisons
+  -- festival_avg / user_percentile / user_current are unGROUPed aggregates or constant
+  -- selects, so they always yield exactly one row. previous_festival yields zero rows for
+  -- a first-time attendee, which under the old CROSS JOIN collapsed the whole comparisons
+  -- object to NULL and hid the festival average too.
+  FROM festival_avg fa
+  CROSS JOIN user_percentile up
+  CROSS JOIN user_current uc
+  LEFT JOIN previous_festival pf ON TRUE;
+
+  v_result := v_result || jsonb_build_object('comparisons', v_comparisons);
+
+  -- Calculate personality type using consumptions
+  WITH attendance_drinks AS (
+    SELECT
+      a.id,
+      a.date,
+      _get_effective_drink_count(a.id) AS drink_count
+    FROM attendances a
+    WHERE a.user_id = p_user_id AND a.festival_id = p_festival_id
+  ),
+  user_patterns AS (
+    SELECT
+      (v_basic_stats->>'total_beers')::INT AS total_beers,
+      (v_basic_stats->>'days_attended')::INT AS days_attended,
+      (v_basic_stats->>'avg_beers')::NUMERIC AS avg_beers,
+      (v_tent_stats->>'unique_tents')::INT AS unique_tents,
+      (SELECT COUNT(*) FROM tents) AS total_tents,
+      EXISTS (
+        SELECT 1 FROM attendances
+        WHERE user_id = p_user_id
+          AND festival_id = p_festival_id
+          AND date = v_festival.start_date
+      ) AS attended_first_day,
+      COALESCE(STDDEV(ad.drink_count), 0) AS beer_variance
+    FROM attendance_drinks ad
+  )
+  SELECT jsonb_build_object(
+    'type', CASE
+      WHEN up.unique_tents >= up.total_tents * 0.7 THEN 'Explorer'
+      WHEN up.avg_beers >= 8 THEN 'Champion'
+      WHEN up.days_attended >= (v_festival.end_date - v_festival.start_date + 1) * 0.8 THEN 'Loyalist'
+      WHEN up.avg_beers <= 3 AND up.days_attended >= 5 THEN 'Social Butterfly'
+      WHEN up.beer_variance < 2 THEN 'Consistent'
+      ELSE 'Casual Enjoyer'
+    END,
+    'traits', jsonb_build_array(
+      CASE WHEN up.attended_first_day THEN 'Early Bird' END,
+      CASE WHEN up.beer_variance < 2 THEN 'Steady Pace' ELSE 'Variable' END,
+      CASE WHEN up.unique_tents >= up.total_tents * 0.5 THEN 'Tent Explorer' ELSE 'Tent Loyalist' END,
+      CASE WHEN up.avg_beers >= 6 THEN 'Heavy Hitter'
+           WHEN up.avg_beers >= 4 THEN 'Moderate'
+           ELSE 'Light Drinker' END
+    ) - ARRAY[NULL]::TEXT[]
+  ) INTO v_personality
+  FROM user_patterns up;
+
+  v_result := v_result || jsonb_build_object('personality', v_personality);
+
+  -- Calculate drink stats from consumptions table (type breakdown)
+  WITH drink_breakdown AS (
+    SELECT
+      c.drink_type::text AS drink_type,
+      COUNT(*) AS count
+    FROM consumptions c
+    JOIN attendances a ON c.attendance_id = a.id
+    WHERE a.user_id = p_user_id
+      AND a.festival_id = p_festival_id
+    GROUP BY c.drink_type
+  ),
+  totals AS (
+    SELECT SUM(count) AS total FROM drink_breakdown
+  )
+  SELECT jsonb_build_object(
+    'total_drinks', COALESCE((SELECT total FROM totals), 0),
+    'top_drink_type', (SELECT drink_type FROM drink_breakdown ORDER BY count DESC LIMIT 1),
+    'breakdown', COALESCE(
+      (SELECT jsonb_agg(
+         jsonb_build_object(
+           'drink_type', db.drink_type,
+           'count', db.count,
+           'percentage', CASE WHEN t.total > 0
+             THEN ROUND((db.count::numeric / t.total::numeric) * 100, 1)
+             ELSE 0 END
+         ) ORDER BY db.count DESC
+       ) FROM drink_breakdown db, totals t),
+      '[]'::jsonb
+    )
+  ) INTO v_drink_stats;
+
+  v_result := v_result || jsonb_build_object('drink_stats', v_drink_stats);
+
+  RETURN v_result;
+END;
+$$;
+
+
+COMMENT ON FUNCTION "public"."get_wrapped_data"("p_user_id" "uuid", "p_festival_id" "uuid") IS 'Returns comprehensive wrapped statistics for a user''s festival experience. Uses consumptions table as source of truth for drink counts, with fallback to legacy attendances.beer_count for backwards compatibility. SECURITY DEFINER because it aggregates across all festival attendees; callers are restricted to their own user id unless super admin.';
+
+-- Same SECURITY DEFINER treatment for the cached entry point. This is the function the
+-- web and mobile clients call directly, so it carries the same ownership guard.
+CREATE OR REPLACE FUNCTION "public"."get_wrapped_data_cached"("p_user_id" "uuid", "p_festival_id" "uuid") RETURNS "jsonb"
+    LANGUAGE "plpgsql"
+    SECURITY DEFINER
+    SET search_path = public
+    AS $$
+DECLARE
+  v_cached_data JSONB;
+  v_calculated_data JSONB;
+BEGIN
+  IF auth.uid() IS NOT NULL
+     AND p_user_id <> auth.uid()
+     AND NOT public.is_super_admin() THEN
+    RAISE EXCEPTION 'Not authorized to read wrapped data for another user'
+      USING ERRCODE = '42501';
+  END IF;
+
+  -- Try to get cached data first
+  SELECT wrapped_data INTO v_cached_data
+  FROM wrapped_data_cache
+  WHERE user_id = p_user_id AND festival_id = p_festival_id;
+
+  -- If cached data exists, return it
+  IF v_cached_data IS NOT NULL THEN
+    RETURN v_cached_data;
+  END IF;
+
+  -- Otherwise, calculate fresh data
+  SELECT get_wrapped_data(p_user_id, p_festival_id) INTO v_calculated_data;
+
+  -- If calculation returned data, cache it
+  IF v_calculated_data IS NOT NULL THEN
+    INSERT INTO wrapped_data_cache (user_id, festival_id, wrapped_data, generated_by)
+    VALUES (p_user_id, p_festival_id, v_calculated_data, 'system')
+    ON CONFLICT (user_id, festival_id)
+    DO UPDATE SET
+      wrapped_data = EXCLUDED.wrapped_data,
+      generated_by = EXCLUDED.generated_by,
+      updated_at = NOW();
+  END IF;
+
+  RETURN v_calculated_data;
+END;
+$$;
+
+COMMENT ON FUNCTION "public"."get_wrapped_data_cached"("p_user_id" "uuid", "p_festival_id" "uuid") IS 'Returns cached wrapped data if available, otherwise calculates and caches fresh data. SECURITY DEFINER; callers are restricted to their own user id unless super admin.';
+
+-- Tighten grants. These were GRANT ALL to PUBLIC/anon; wrapped data is per-user and now
+-- runs with definer rights, so anon and PUBLIC have no business executing it.
+REVOKE EXECUTE ON FUNCTION "public"."get_wrapped_data"("uuid", "uuid") FROM PUBLIC, "anon";
+REVOKE EXECUTE ON FUNCTION "public"."get_wrapped_data_cached"("uuid", "uuid") FROM PUBLIC, "anon";
+GRANT EXECUTE ON FUNCTION "public"."get_wrapped_data"("uuid", "uuid") TO "authenticated", "service_role";
+GRANT EXECUTE ON FUNCTION "public"."get_wrapped_data_cached"("uuid", "uuid") TO "authenticated", "service_role";
+
+-- Internal helper only: get_wrapped_data is SECURITY DEFINER so it executes this as the
+-- owner regardless. No client needs to call it directly.
+REVOKE EXECUTE ON FUNCTION "public"."_get_effective_drink_count"("uuid") FROM PUBLIC, "anon", "authenticated";
+GRANT EXECUTE ON FUNCTION "public"."_get_effective_drink_count"("uuid") TO "service_role";


### PR DESCRIPTION
## What happened

Trying to open Wrapped for a past festival failed. Postgres logs show two `canceling statement due to statement timeout` errors 28 seconds apart, matching the `retry: 2` on the query. Nothing in Sentry, because the hook swallowed the error into `console.error` and returned `null`.

## Root cause

`get_wrapped_data`, `get_wrapped_data_cached` and `_get_effective_drink_count` were all SECURITY INVOKER. On a cache miss the whole computation ran as `authenticated`, which has `statement_timeout = 8s`, with RLS evaluated per row. The `festival_avg` CTE called `_get_effective_drink_count(a.id)` once per attendance across every user of the festival, and each call ran two RLS-checked subqueries (the `consumptions` policy is a 4-table EXISTS join, the `attendances` policy joins a view plus `is_friend()`).

Measured:

| | |
|---|---|
| As `postgres` (RLS bypassed) | 30 ms |
| Uncached via PostgREST (`pg_stat_statements`) | 646 ms mean, 4454 ms max |
| Cached via PostgREST | 3 ms mean |

Which matches exactly which festivals worked: the two with a cache row rendered fine, the big uncached ones (Oktoberfest 2024 and 2025, 130 and 148 attendances) timed out.

## The fix

Makes all three SECURITY DEFINER with `SET search_path`, the same treatment `get_global_leaderboard` already has. Because they take `p_user_id` as a parameter, they get an `auth.uid()` ownership guard, and grants are tightened (`anon` and PUBLIC revoked, the helper limited to `service_role`).

That guard also closes a pre-existing hole: `regenerate_wrapped_data_cache` only checked admin rights when `p_admin_user_id` was non-null, so any authenticated user calling it with NULL regenerated everyone's cache.

## Two more bugs the same change surfaced

- **Averages were wrong.** Being SECURITY INVOKER meant the cross-user averages were computed over only the rows RLS let the caller see. On seed data: `avg_beers` 10.43 as postgres vs 5.14 as authenticated. Cached rows happened to be correct only because an admin generated them with RLS bypassed.
- **First-timers got no comparisons at all.** `previous_festival` was CROSS JOINed, so a user with no earlier festival of the same type got a NULL `comparisons` object, losing the festival average too, not just the year-over-year block. The mobile slide read that path unguarded and would crash on it.

## Better comparison stat

The mean is a weak statistic here. Across 45 users on Oktoberfest 2025: mean 8.31 drinks, median 6, and 12 of them attended exactly one day. That's how the slide ended up saying "+212.9% vs average", a bar almost everyone clears.

Replaced with percentile rank plus median, consistent with the `global_leaderboard_positions` ranks already in the payload. The new fields are optional, so the 15 existing cache rows keep rendering the old diff until they're regenerated.

I looked at an index and at precomputing the average first. Neither is worth it: `idx_consumptions_attendance` already exists, the aggregate runs in 4.5 ms, and planning time (4.9 ms) is longer than execution. The timeout was never the aggregate math. I did drop the per-row helper call in that CTE for a set-based join (it re-read the `attendances` row it was already handed) and a `COUNT(DISTINCT date)` made redundant by `unique_user_date_festival`.

Errors from the RPC now propagate instead of becoming `null`, so the next one reaches Sentry rather than looking like "no data yet".

## Verification

- Local DB rebuilt from scratch with `sup:db:reset`, full migration chain applies clean
- As `authenticated`, `vs_festival_avg` now matches the `postgres` result exactly (was 5.14 vs 10.43)
- Cached entry point, the call the app actually makes, works as `authenticated`
- Reading another user's wrapped is denied; admin and service_role regeneration still work; non-admin regeneration is now blocked
- `pnpm type-check` clean, `pnpm lint` 0 errors, `pnpm test` 312 passed / 2 skipped

## After merge

Worth running the admin cache regeneration so the existing rows pick up the percentile fields. Note `regenerate_wrapped_data_cache` only UPDATEs rows that already exist, which is why the cache is only 15 rows across all users and festivals, so most users will still hit the (now fast) uncached path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)