### PR TITLE
feat: Oktoberfest 2026 data, beer price post, bulletin campaign tracking

### DIFF
--- a/apps/web/content/blog/de/fruehlingsfest-guide.mdx
+++ b/apps/web/content/blog/de/fruehlingsfest-guide.mdx
@@ -123,7 +123,7 @@ Das Essen auf dem Fruehlingsfest spiegelt das wider, was du auch auf dem Oktober
 
 Einer der groessten Vorteile des Fruehlingsfests sind die Kosten. Zwar ist es nicht gerade billig (das ist schliesslich Muenchen), aber die Preise sind insgesamt spuerbar niedriger als beim Oktoberfest:
 
-- **Bier (1 Mass)**: 13 - 14,50 EUR (vs. 15,50 - 16,50 EUR beim Oktoberfest)
+- **Bier (1 Mass)**: 13 - 14,50 EUR (vs. 15,80 EUR in den meisten Oktoberfest-Zelten)
 - **Halbes Hendl**: 14 - 16 EUR (vs. 16 - 18 EUR)
 - **Fahrten**: 3 - 6 EUR pro Fahrt (mit Rabatt am Familientag)
 - **Hotels**: Normale Muenchner Preise, nicht der 2-3-fache Aufschlag, den das Oktoberfest mit sich bringt

--- a/apps/web/content/blog/de/oktoberfest-2026-beer-prices.mdx
+++ b/apps/web/content/blog/de/oktoberfest-2026-beer-prices.mdx
@@ -1,0 +1,113 @@
+---
+title: "Oktoberfest 2026 Bierpreise: Was jedes Zelt verlangt"
+description: "Bestätigte Maßpreise 2026 für alle 40 Oktoberfestzelte, vom günstigsten Großzelt bis zum teuersten. Und was ein Tag auf der Wiesn wirklich kostet."
+date: "2026-08-05"
+lastModified: "2026-08-05"
+author: "ProstCounter Team"
+category: "news"
+tags:
+  ["oktoberfest", "2026", "bierpreise", "zelte", "münchen", "budget", "maß"]
+featuredImage: "/images/prost-counter-og-1.jpg"
+locale: "de"
+---
+
+# Oktoberfest 2026 Bierpreise: Was jedes Zelt verlangt
+
+Die Preise für 2026 stehen fest. Fast das ganze Jahr über haben wir alle mit Schätzungen gearbeitet, aber die Wirte haben inzwischen bestätigt, was eine Maß kosten wird, wenn die Wiesn am 19. September öffnet.
+
+Kurz gesagt: **die meisten Zelte verlangen 15,80 €**. Die Spanne reicht von **14,80 € bis 17,80 €**, der Durchschnitt über alle 40 Zelte liegt bei **15,70 €**.
+
+Hier sind alle Zelte, gruppiert so, wie die Wiesn selbst sie gruppiert.
+
+## Die großen Zelte
+
+Das sind die vierzehn Großzelte, die mit den Blaskapellen und den Wartelisten für Reservierungen. Ihre Preise werden einzeln veröffentlicht, es sind also belastbare Zahlen.
+
+| Zelt                       | Maß        |
+| -------------------------- | ---------- |
+| Kufflers Weinzelt          | 17,80 €    |
+| Armbrustschützen Festzelt  | 15,90 €    |
+| Löwenbräu-Festzelt         | 15,90 €    |
+| Pschorr-Festzelt Bräurosl  | 15,90 €    |
+| Festhalle Schottenhamel    | 15,80 €    |
+| Hacker-Festzelt            | 15,80 €    |
+| Hofbräu-Festzelt           | 15,80 €    |
+| Käfer Wiesn-Schänke        | 15,80 €    |
+| Marstall-Festzelt          | 15,80 €    |
+| Ochsenbraterei             | 15,80 €    |
+| Paulaner Festzelt          | 15,80 €    |
+| Schützen-Festzelt          | 15,80 €    |
+| Fischer-Vroni              | 15,75 €    |
+| **Augustiner-Festhalle**   | **14,90 €**|
+
+Zwei davon verdienen eine Anmerkung.
+
+**Die Augustiner-Festhalle ist wieder das günstigste Großzelt**, wie fast jedes Jahr. Mit 14,90 € liegt sie neunzig Cent unter dem Feld, was über vier Maß gerechnet fast ein fünftes Bier ausmacht. Augustiner zapft außerdem weiterhin aus Holzfässern statt aus Stahltanks, was viele Münchner (ausführlich) als geschmacklichen Unterschied verteidigen.
+
+**Kufflers Weinzelt ist mit 17,80 € der Ausreißer**, und der Vergleich hinkt ein wenig. Das Weinzelt ist das Weinzelt: Sein Kerngeschäft sind fränkischer Wein und Sekt, und das Bier, das dort ausgeschenkt wird, ist ein hochwertiges Weißbier und kein normales Festbier. Wer eine gewöhnliche Maß zum gewöhnlichen Preis will, ist hier falsch.
+
+## Die Oide Wiesn
+
+Die Oide Wiesn ist der historische Teil im Süden des Geländes, mit den alten Fahrgeschäften, der traditionellen Musik und einem ruhigeren Publikum. Sie kostet rund 4 € Eintritt, dafür ist das Bier dort günstiger als fast überall sonst auf der Theresienwiese.
+
+| Zelt                         | Maß         |
+| ---------------------------- | ----------- |
+| Festzelt Tradition           | 15,80 €     |
+| Boandlkramerei               | 15,30 €     |
+| Volkssängerzelt Schützenlisl | 14,90 €     |
+| **Museumszelt**              | **14,80 €** |
+
+**Das Museumszelt ist mit 14,80 € das günstigste Bier auf dem Oktoberfest 2026.** Selbst mit den 4 € Eintritt lohnt sich die Oide Wiesn ab der fünften Maß gegenüber dem Hauptgelände. Und sie ist, nebenbei bemerkt, ein deutlich angenehmerer Ort für ein Gespräch.
+
+## Die kleinen Zelte
+
+Es gibt zweiundzwanzig kleine Zelte: die Hühnerbratereien, die Käse- und Weinstubn, die Kaffee- und Kaiserschmarrn-Betriebe. Sie sind meist ruhiger, auch ohne Reservierung zugänglich und zum Essen die bessere Wahl.
+
+Die Preise sind hier weniger einheitlich dokumentiert. Diese sechs haben eigene bestätigte Zahlen:
+
+| Zelt                            | Maß         |
+| ------------------------------- | ----------- |
+| Bartls Flößerstadl              | 15,70 €     |
+| Hochreiters Haxnbraterei        | 15,70 €     |
+| Zur Bratwurst                   | 15,70 €     |
+| Hühner- und Entenbraterei Ammer | 14,95 €     |
+| Wirtshaus im Schichtl           | 14,90 €     |
+| **Münchner Weißbiergarten**     | **14,80 €** |
+
+Die übrigen kleinen Zelte sind mit dem Standardpreis von 15,80 € gelistet. Für nicht jedes dieser Zelte wird ein eigener Preis veröffentlicht, betrachte das also als Standardwert und nicht als bestätigte Angabe des jeweiligen Wirts.
+
+Eine echte Neuheit in diesem Jahr: **Bartls Flößerstadl**, ein Zelt mit 398 Plätzen, das den Platz der früheren Münchner Stubn übernimmt. Die 15,70 € stammen aus einer einzigen Quelle und sind damit die Zahl auf dieser Seite, der wir am wenigsten trauen.
+
+## Was das konkret kostet
+
+Drei oder vier Maß sind für die meisten ein normaler Nachmittag. Bei den 15,80 €, die die meisten Zelte verlangen:
+
+| Maß | Kosten  | Mit 10 % Trinkgeld |
+| --- | ------- | ------------------ |
+| 2   | 31,60 € | 34,76 €            |
+| 3   | 47,40 € | 52,14 €            |
+| 4   | 63,20 € | 69,52 €            |
+| 5   | 79,00 € | 86,90 €            |
+
+Trinkgeld wird erwartet. Die Bedienungen tragen zehn volle Maßkrüge gleichzeitig durch die Menge, Aufrunden auf den nächsten Euro oder zehn Prozent sind üblich.
+
+Zwei praktische Hinweise zu den Kosten:
+
+- **Radler zählt mit.** Ein Radler ist halb Bier, halb Limonade und kostet genauso viel wie eine Maß. Wer sich Zeit lässt, fährt damit pro Stunde besser, auch wenn der Literpreis derselbe ist.
+- **Wo du sitzt, zählt mehr als in welchem Zelt.** Zwischen dem günstigsten und dem teuersten normalen Zelt liegt etwa ein Euro. Zwischen einem Zeltnachmittag und einem Zeltnachmittag samt Essen, Fahrgeschäften und Taxi liegen fünfzig. Am Bier scheitert das Budget selten.
+
+Das ganze Bild findest du in unserer [Oktoberfest-Kostenübersicht](/blog/de/oktoberfest-cost-budget).
+
+## Woher diese Zahlen stammen
+
+Die Preise stammen aus den 2026er Tabellen von [wiesnkini.de](https://wiesnkini.de/zelte/bierpreis/) und [in-muenchen.de](https://www.in-muenchen.de/stadtleben/oktoberfest-wiesn-preise.html). Die Zeltaufstellung samt der diesjährigen Änderungen kommt von [oktoberfest.de](https://www.oktoberfest.de/en/beer-tents/small-tents), der [Übersicht zur Oide Wiesn](https://www.oktoberfest.de/en/tents/tents-oide-wiesn/festival-tents-oide-wiesn-event-glance) und dem [Artikel zu den Neuerungen 2026 auf muenchen.de](https://www.muenchen.de/veranstaltungen/oktoberfest/aktuell/oktoberfest-2026-das-ist-neu-auf-der-wiesn). Termine und offizielle Informationen stammen von [muenchen.de](https://www.muenchen.de/en/events/oktoberfest).
+
+Wo sich Quellen widersprachen, haben wir das an der betreffenden Stelle vermerkt. Die Preise legen die Wirte fest und können sich bis zum Anstich noch ändern.
+
+## Behalte den Überblick
+
+Die Preise zu kennen ist eine Sache. Zu wissen, dass es schon sechs waren, eine andere, und spätestens bei der sechsten funktioniert das Kopfrechnen nicht mehr. ProstCounter erfasst jede Maß direkt beim Bestellen und führt eine laufende Summe in Euro, pro Zelt, damit die Zahl am Ende des Tages die richtige ist. Das funktioniert auch für die ganze Gruppe und klärt die meisten Diskussionen darüber, wer wem was schuldet.
+
+Alle 40 Zelte von oben sind mit ihren Preisen für 2026 bereits in der App hinterlegt, die Summen stimmen also ab dem ersten Tag.
+
+<CTA />

--- a/apps/web/content/blog/de/oktoberfest-2026-guide.mdx
+++ b/apps/web/content/blog/de/oktoberfest-2026-guide.mdx
@@ -2,7 +2,7 @@
 title: "Der komplette Oktoberfest-Guide 2026: Termine, Tipps & was dich erwartet"
 description: "Alles, was du zum Oktoberfest 2026 wissen musst -- Termine, Bierpreise, Zeltreservierungen und Insider-Tipps zum groessten Volksfest der Welt."
 date: "2026-03-15"
-lastModified: "2026-03-15"
+lastModified: "2026-08-05"
 author: "ProstCounter Team"
 category: "festivals"
 tags: ["oktoberfest", "2026", "munich", "beer festival", "guide"]
@@ -16,7 +16,7 @@ Das Oktoberfest ist das groesste Volksfest der Welt und lockt jedes Jahr ueber s
 
 ## Offizielle Termine: 19. September - 4. Oktober 2026
 
-Das Oktoberfest 2026 dauert **16 Tage** -- Eroeffnung am Samstag, den 19. September, letzter Tag am Sonntag, den 4. Oktober. Traditionell beginnt das Fest am dritten Samstag im September und endet am ersten Sonntag im Oktober. Faellt der 3. Oktober (Tag der Deutschen Einheit) in diesen Zeitraum, wird das Fest manchmal um einen Tag verlaengert -- und 2026 ist das der Fall, was dir einen zusaetzlichen Feiertag beschert.
+Das Oktoberfest 2026 dauert **16 Tage**: Eröffnung am Samstag, den 19. September, letzter Tag am Sonntag, den 4. Oktober. Traditionell beginnt das Fest am dritten Samstag im September und endet am ersten Sonntag im Oktober. Länger dauert es nur, wenn der 3. Oktober (Tag der Deutschen Einheit) auf einen Montag oder Dienstag fällt, dann wird bis zum Feiertag verlängert. 2026 ist der 3. Oktober ein Samstag, es ist also eine ganz normale 16-tägige Wiesn.
 
 ### Wichtige Termine zum Vormerken
 
@@ -45,7 +45,7 @@ Die Theresienwiese ist hervorragend an den oeffentlichen Nahverkehr angebunden:
 
 Die Preise auf dem Oktoberfest sind ueber die Jahre stetig gestiegen, und 2026 wird da keine Ausnahme sein. Basierend auf den letzten Trends kannst du ungefaehr mit folgenden Preisen rechnen:
 
-- **Eine Mass Bier (1 Liter)**: 15,50 - 16,50 EUR je nach Zelt
+- **Eine Maß Bier (1 Liter)**: 15,80 € in den meisten Zelten, insgesamt zwischen 14,80 € und 17,80 € ([komplette Preisliste nach Zelt](/blog/de/oktoberfest-2026-beer-prices))
 - **Halbes Hendl**: 16 - 18 EUR
 - **Schweinshaxe**: 20 - 25 EUR
 - **Grosse Breze**: 6 - 8 EUR

--- a/apps/web/content/blog/de/oktoberfest-2026-news.mdx
+++ b/apps/web/content/blog/de/oktoberfest-2026-news.mdx
@@ -2,7 +2,7 @@
 title: "Oktoberfest 2026: Termine, neue Regeln & was sich geändert hat"
 description: "Alle Neuigkeiten zum Oktoberfest 2026 -- Termine, Bierpreise, neue Vorschriften, Nachhaltigkeitsmaßnahmen und Tipps fuer das diesjährige Fest."
 date: "2026-03-15"
-lastModified: "2026-03-15"
+lastModified: "2026-08-05"
 author: "ProstCounter Team"
 category: "news"
 tags: ["oktoberfest", "2026", "news", "beer prices", "regulations", "munich", "sustainability"]
@@ -34,9 +34,9 @@ Die jährliche Bekanntgabe der Bierpreise ist eines der meistbeachteten Oktoberf
 
 - **Preise 2024**: 13,60 - 15,30 Euro pro Maßkrug
 - **Preise 2025**: 14,90 - 15,90 Euro pro Maßkrug
-- **Prognostizierte Spanne 2026**: circa 15,50 - 16,50 Euro pro Maßkrug
+- **Bestätigte Spanne 2026**: 14,80 - 17,80 Euro pro Maßkrug, in den meisten Zelten 15,80
 
-Der Durchschnittspreis einer Maß wird 2026 voraussichtlich bei etwa **16 Euro** liegen. Die stetigen Erhöhungen spiegeln steigende Rohstoffkosten, Energiepreise, Personalkosten und die allgemeine Inflation wider. Für eine detaillierte Aufschlüsselung aller Kosten, lies unseren [Oktoberfest Budget-Guide](/blog/de/oktoberfest-cost-budget).
+Der Durchschnitt über alle 40 Zelte liegt bei **15,70 Euro**. Die stetigen Erhöhungen spiegeln steigende Rohstoffkosten, Energiepreise, Personalkosten und die allgemeine Inflation wider. Was die einzelnen Zelte verlangen, steht in unserer [Bierpreisliste 2026](/blog/de/oktoberfest-2026-beer-prices), und für eine detaillierte Aufschlüsselung aller Kosten lies unseren [Oktoberfest Budget-Guide](/blog/de/oktoberfest-cost-budget).
 
 Obwohl die Preiserhöhungen unwillkommen sind, ist zu beachten, dass das Oktoberfest-Bier ein spezielles Gebräu ist -- stärker als normales Lager (5,8-6,3% Vol.), speziell für das Fest von den sechs zugelassenen Brauereien gebraut und in einem vollen Literkrug serviert.
 

--- a/apps/web/content/blog/de/oktoberfest-cost-budget.mdx
+++ b/apps/web/content/blog/de/oktoberfest-cost-budget.mdx
@@ -2,7 +2,7 @@
 title: "Was kostet das Oktoberfest? Eine Budget-Aufstellung"
 description: "Plane dein Oktoberfest-Budget mit echten Preisen fuer Bier, Essen, Unterkunft und Transport. Tipps fuer jedes Budget vom Backpacker bis Luxus."
 date: "2026-03-15"
-lastModified: "2026-03-15"
+lastModified: "2026-08-05"
 author: "ProstCounter Team"
 category: "tips"
 tags: ["oktoberfest", "budget", "beer prices", "munich", "travel tips", "cost"]
@@ -20,12 +20,14 @@ Hier ist eine detaillierte Aufschlüsselung, was dich 2026 erwartet, zusammen mi
 
 Der Maßkrug -- ein voller Liter Festbier -- ist die Währung des Oktoberfests. Die Preise sind über die Jahre stetig gestiegen, und 2026 solltest du mit folgenden Kosten rechnen:
 
-- **Eine Maß (1L Bier)**: circa 15,50 bis 16,50 Euro, je nach Zelt
-- **Durchschnitt über alle Zelte**: rund 16 Euro
+- **Eine Maß (1L Bier)**: 15,80 Euro in den meisten Zelten, je nach Platz zwischen 14,80 und 17,80
+- **Durchschnitt über alle 40 Zelte**: 15,70 Euro
+
+Was die einzelnen Zelte verlangen, steht in unserer [Bierpreisliste 2026](/blog/de/oktoberfest-2026-beer-prices).
 
 Zum Vergleich: Derselbe Liter Bier kostet in einem normalen Münchner Biergarten etwa 8 bis 10 Euro. Der Aufpreis spiegelt das Festivalerlebnis wider -- die Live-Musik, die Atmosphäre und die Tatsache, dass es sich um speziell gebrautes Bier mit etwas höherem Alkoholgehalt handelt (typischerweise 5,8% bis 6,3% Vol.).
 
-Die meisten Besucher trinken zwischen 2 und 4 Maß pro Besuch. Bei 16 Euro pro Stück sind das 32 bis 64 Euro allein fürs Bier an einem einzigen Tag.
+Die meisten Besucher trinken zwischen 2 und 4 Maß pro Besuch. Bei 15,80 Euro pro Stück sind das 31,60 bis 63,20 Euro allein fürs Bier an einem einzigen Tag.
 
 **Tipp**: Vergiss das Trinkgeld nicht. Die Bedienungen auf dem Oktoberfest tragen unglaublich schwere Lasten -- Aufrunden auf den nächsten Euro oder 10% draufgeben ist üblich und wird geschätzt.
 

--- a/apps/web/content/blog/en/fruehlingsfest-guide.mdx
+++ b/apps/web/content/blog/en/fruehlingsfest-guide.mdx
@@ -123,7 +123,7 @@ The food at Frühlingsfest mirrors what you'd find at Oktoberfest, with all the 
 
 One of Frühlingsfest's biggest advantages is cost. While it's not exactly cheap (this is Munich, after all), prices across the board are noticeably lower than Oktoberfest:
 
-- **Beer (1 Masskrug)**: €13 - €14.50 (vs. €15.50 - €16.50 at Oktoberfest)
+- **Beer (1 Masskrug)**: €13 - €14.50 (vs. €15.80 at most Oktoberfest tents)
 - **Half chicken**: €14 - €16 (vs. €16 - €18)
 - **Ride tickets**: €3 - €6 per ride (with discounts on Family Day)
 - **Hotels**: Standard Munich rates, not the 2-3x markup that Oktoberfest brings

--- a/apps/web/content/blog/en/oktoberfest-2026-beer-prices.mdx
+++ b/apps/web/content/blog/en/oktoberfest-2026-beer-prices.mdx
@@ -1,0 +1,113 @@
+---
+title: "Oktoberfest 2026 Beer Prices: What Every Tent Charges"
+description: "Confirmed 2026 Masskrug prices for all 40 Oktoberfest tents, from the cheapest big tent to the most expensive. Plus what a day of drinking actually costs."
+date: "2026-08-05"
+lastModified: "2026-08-05"
+author: "ProstCounter Team"
+category: "news"
+tags:
+  ["oktoberfest", "2026", "beer prices", "tents", "munich", "budget", "masskrug"]
+featuredImage: "/images/prost-counter-og-1.jpg"
+locale: "en"
+---
+
+# Oktoberfest 2026 Beer Prices: What Every Tent Charges
+
+The 2026 prices are set. For most of the year we were all working from projections, but the tent operators have now confirmed what a Masskrug will cost when the Wiesn opens on September 19.
+
+Here's the short version: **most tents charge €15.80**. The full spread runs from **€14.80 to €17.80**, and the average across all 40 tents comes out at **€15.70**.
+
+Below is every tent, grouped the way the festival groups them.
+
+## The Big Tents
+
+These are the fourteen large tents, the ones with the brass bands and the reservation waiting lists. Their prices are published individually, so these are firm numbers.
+
+| Tent                       | Masskrug   |
+| -------------------------- | ---------- |
+| Kufflers Weinzelt          | €17.80     |
+| Armbrustschützen Festzelt  | €15.90     |
+| Löwenbräu-Festzelt         | €15.90     |
+| Pschorr-Festzelt Bräurosl  | €15.90     |
+| Festhalle Schottenhamel    | €15.80     |
+| Hacker-Festzelt            | €15.80     |
+| Hofbräu-Festzelt           | €15.80     |
+| Käfer Wiesn-Schänke        | €15.80     |
+| Marstall-Festzelt          | €15.80     |
+| Ochsenbraterei             | €15.80     |
+| Paulaner Festzelt          | €15.80     |
+| Schützen-Festzelt          | €15.80     |
+| Fischer-Vroni              | €15.75     |
+| **Augustiner-Festhalle**   | **€14.90** |
+
+Two of these deserve a note.
+
+**Augustiner-Festhalle is the cheapest big tent again**, as it is nearly every year. At €14.90 it undercuts the field by ninety cents, which over four Masskrugs is most of a fifth beer. Augustiner also still serves from wooden barrels rather than steel tanks, which a lot of locals will tell you (at length) makes a difference.
+
+**Kufflers Weinzelt is the outlier at €17.80**, and it's a slightly unfair comparison. The Weinzelt is the wine tent: its main business is Franconian wine and sparkling wine, and the beer it pours is a premium Weissbier rather than the standard festival lager. If you want a normal Mass at a normal price, this is not the tent.
+
+## The Oide Wiesn
+
+The Oide Wiesn is the historical section at the south end of the grounds, with the old-fashioned rides, the traditional music, and a calmer crowd. It charges a small entry fee of around €4, and in exchange the beer is cheaper than almost anywhere else on the Theresienwiese.
+
+| Tent                         | Masskrug   |
+| ---------------------------- | ---------- |
+| Festzelt Tradition           | €15.80     |
+| Boandlkramerei               | €15.30     |
+| Volkssängerzelt Schützenlisl | €14.90     |
+| **Museumszelt**              | **€14.80** |
+
+**The Museumszelt at €14.80 is the cheapest beer at Oktoberfest 2026.** Even after the €4 entry fee, if you're planning more than four beers the Oide Wiesn works out cheaper than the main grounds. It's also, for what it's worth, a much nicer place to have a conversation.
+
+## The Small Tents
+
+There are twenty-two small tents: the chicken roasters, the cheese and wine stubn, the coffee and Kaiserschmarrn places. They tend to be quieter, easier to get into without a reservation, and better for actually eating.
+
+Prices here are less uniformly reported. These six have their own confirmed figures:
+
+| Tent                            | Masskrug   |
+| ------------------------------- | ---------- |
+| Bartls Flößerstadl              | €15.70     |
+| Hochreiters Haxnbraterei        | €15.70     |
+| Zur Bratwurst                   | €15.70     |
+| Hühner- und Entenbraterei Ammer | €14.95     |
+| Wirtshaus im Schichtl           | €14.90     |
+| **Münchner Weißbiergarten**     | **€14.80** |
+
+The remaining small tents are listed at the €15.80 standard. Munich doesn't publish a separate figure for every one of them, so treat that as the default rather than a confirmed quote from each operator.
+
+One genuinely new arrival this year: **Bartls Flößerstadl**, a 398-seat tent that takes over the spot previously held by Münchner Stubn. Its €15.70 comes from a single source, so it's the number we'd trust least on this page.
+
+## What This Actually Costs You
+
+Three or four Masskrugs is a normal afternoon for most people. At the €15.80 that most tents charge:
+
+| Beers | Cost   | Plus a 10% tip |
+| ----- | ------ | -------------- |
+| 2     | €31.60 | €34.76         |
+| 3     | €47.40 | €52.14         |
+| 4     | €63.20 | €69.52         |
+| 5     | €79.00 | €86.90         |
+
+Tipping is expected. The servers are carrying ten full Masskrugs at a time through a crowd, and rounding up to the next euro or adding ten percent is standard.
+
+Two practical notes on cost:
+
+- **Radler counts.** A Radler is half beer, half lemonade, and it costs the same as a Mass. If you're pacing yourself it's the better value per hour, even though it's the same price per litre.
+- **Where you sit matters more than which tent.** The price gap between the cheapest and dearest normal tent is about a euro. The gap between a tent afternoon and a tent afternoon plus food, rides, and a taxi home is fifty. Beer is rarely what breaks the budget.
+
+For the full picture, see our [Oktoberfest budget breakdown](/blog/oktoberfest-cost-budget).
+
+## How These Numbers Were Gathered
+
+Prices come from the 2026 tables published by [wiesnkini.de](https://wiesnkini.de/zelte/bierpreis/) and [in-muenchen.de](https://www.in-muenchen.de/stadtleben/oktoberfest-wiesn-preise.html). The tent lineup, including this year's changes, comes from [oktoberfest.de](https://www.oktoberfest.de/en/beer-tents/small-tents), its [Oide Wiesn listing](https://www.oktoberfest.de/en/tents/tents-oide-wiesn/festival-tents-oide-wiesn-event-glance), and [muenchen.de's 2026 changes article](https://www.muenchen.de/veranstaltungen/oktoberfest/aktuell/oktoberfest-2026-das-ist-neu-auf-der-wiesn). Dates and official festival information come from [muenchen.de](https://www.muenchen.de/en/events/oktoberfest).
+
+Where sources disagreed we've said so on the line in question. Prices are set by the operators and can still change before opening day.
+
+## Track What You Actually Drink
+
+Knowing the prices is one thing. Knowing you've had six is another, and by the sixth the arithmetic has stopped working. ProstCounter logs each Mass as you go and keeps a running total in euros, per tent, so the number you see at the end of the day is the real one. It works across your whole group too, which settles most arguments about who owes what.
+
+All 40 tents above are already in the app with their 2026 prices, so your totals are right from opening day.
+
+<CTA />

--- a/apps/web/content/blog/en/oktoberfest-2026-guide.mdx
+++ b/apps/web/content/blog/en/oktoberfest-2026-guide.mdx
@@ -2,7 +2,7 @@
 title: "The Complete Guide to Oktoberfest 2026: Dates, Tips & What to Expect"
 description: "Everything you need to know about Oktoberfest 2026 — dates, beer prices, tent reservations, and insider tips for the world's largest beer festival."
 date: "2026-03-15"
-lastModified: "2026-03-15"
+lastModified: "2026-08-05"
 author: "ProstCounter Team"
 category: "festivals"
 tags: ["oktoberfest", "2026", "munich", "beer festival", "guide"]
@@ -16,7 +16,7 @@ Oktoberfest is the world's largest beer festival, drawing over six million visit
 
 ## Official Dates: September 19 - October 4, 2026
 
-Oktoberfest 2026 runs for **16 days**, opening on Saturday, September 19 and closing on Sunday, October 4. The festival traditionally begins on the third Saturday of September and ends on the first Sunday of October. If October 3 (German Unity Day) falls within that window, the festival sometimes extends by a day — and in 2026, it does, giving you an extra day of celebration.
+Oktoberfest 2026 runs for **16 days**, opening on Saturday, September 19 and closing on Sunday, October 4. The festival traditionally begins on the third Saturday of September and ends on the first Sunday of October. It only runs longer when October 3 (German Unity Day) falls on a Monday or Tuesday, in which case it stretches to cover the holiday. In 2026 October 3 is a Saturday, so this is a standard 16-day Wiesn.
 
 ### Key Dates to Mark
 
@@ -45,7 +45,7 @@ The Theresienwiese is extremely well-connected by public transit:
 
 Prices at Oktoberfest have steadily climbed over the years, and 2026 will be no exception. Based on recent trends, expect to pay approximately:
 
-- **One Masskrug (1 liter of beer)**: €15.50 - €16.50 depending on the tent
+- **One Masskrug (1 liter of beer)**: €15.80 at most tents, ranging from €14.80 to €17.80 ([full price list by tent](/blog/oktoberfest-2026-beer-prices))
 - **Half chicken (Hendl)**: €16 - €18
 - **Pork knuckle (Schweinshaxe)**: €20 - €25
 - **Large pretzel (Breze)**: €6 - €8

--- a/apps/web/content/blog/en/oktoberfest-2026-news.mdx
+++ b/apps/web/content/blog/en/oktoberfest-2026-news.mdx
@@ -2,7 +2,7 @@
 title: "Oktoberfest 2026: Dates, New Rules & What's Changed"
 description: "Get the latest on Oktoberfest 2026 — dates, beer prices, new regulations, sustainability measures, and tips for this year's festival."
 date: "2026-03-15"
-lastModified: "2026-03-15"
+lastModified: "2026-08-05"
 author: "ProstCounter Team"
 category: "news"
 tags: ["oktoberfest", "2026", "news", "beer prices", "regulations", "munich", "sustainability"]
@@ -34,9 +34,9 @@ The annual beer price announcement is one of Oktoberfest's most closely watched 
 
 - **2024 prices**: 13.60 - 15.30 euros per Masskrug
 - **2025 prices**: 14.90 - 15.90 euros per Masskrug
-- **2026 projected range**: approximately 15.50 - 16.50 euros per Masskrug
+- **2026 confirmed range**: 14.80 - 17.80 euros per Masskrug, with most tents at 15.80
 
-The average price of a Masskrug will likely land around **16 euros** in 2026. The steady increases reflect rising ingredient costs, energy prices, staffing expenses, and general inflation. For a detailed breakdown of all costs, see our [Oktoberfest budget guide](/blog/oktoberfest-cost-budget).
+The average across all 40 tents comes out at **15.70 euros**. The steady increases reflect rising ingredient costs, energy prices, staffing expenses, and general inflation. For what each individual tent charges, see our [2026 beer price list](/blog/oktoberfest-2026-beer-prices), and for a detailed breakdown of all costs, see our [Oktoberfest budget guide](/blog/oktoberfest-cost-budget).
 
 While the price increases are unwelcome, it's worth noting that Oktoberfest beer is a special brew — stronger than standard lager (5.8-6.3% ABV), brewed specifically for the festival by the six permitted breweries, and served in a full one-liter glass.
 

--- a/apps/web/content/blog/en/oktoberfest-cost-budget.mdx
+++ b/apps/web/content/blog/en/oktoberfest-cost-budget.mdx
@@ -2,7 +2,7 @@
 title: "How Much Does Oktoberfest Cost? A Budget Breakdown"
 description: "Plan your Oktoberfest budget with real prices for beer, food, accommodation, and transport. Tips for every budget from backpacker to luxury."
 date: "2026-03-15"
-lastModified: "2026-03-15"
+lastModified: "2026-08-05"
 author: "ProstCounter Team"
 category: "tips"
 tags: ["oktoberfest", "budget", "beer prices", "munich", "travel tips", "cost"]
@@ -20,12 +20,14 @@ Here's a detailed breakdown of what to expect in 2026, along with strategies for
 
 The Masskrug — a full liter of festival beer — is the currency of Oktoberfest. Prices have climbed steadily over the years, and in 2026, you should expect to pay:
 
-- **One Masskrug (1L beer)**: approximately 15.50 to 16.50 euros, depending on the tent
-- **Average across all tents**: around 16 euros
+- **One Masskrug (1L beer)**: 15.80 euros at most tents, from 14.80 to 17.80 depending on where you sit
+- **Average across all 40 tents**: 15.70 euros
+
+See our [2026 beer price list](/blog/oktoberfest-2026-beer-prices) for what each tent charges.
 
 For context, that same liter of beer costs roughly 8 to 10 euros at a regular Munich beer garden. The premium reflects the festival setting, the live music, the atmosphere, and the fact that these are special-brew beers with slightly higher alcohol content (typically 5.8% to 6.3% ABV).
 
-Most visitors drink between 2 and 4 Masskrugs per visit. At 16 euros each, that's 32 to 64 euros just on beer for a single day.
+Most visitors drink between 2 and 4 Masskrugs per visit. At 15.80 euros each, that's 31.60 to 63.20 euros just on beer for a single day.
 
 **Tip**: Don't forget to tip your server. Waitstaff at Oktoberfest carry impossibly heavy loads — rounding up to the next euro or adding 10% is standard and appreciated.
 

--- a/apps/web/content/blog/es/fruehlingsfest-guide.mdx
+++ b/apps/web/content/blog/es/fruehlingsfest-guide.mdx
@@ -123,7 +123,7 @@ La comida en el Frühlingsfest es similar a la que encontrarías en el Oktoberfe
 
 Una de las mayores ventajas del Frühlingsfest es el coste. Aunque no es exactamente barato (estamos en Múnich, al fin y al cabo), los precios en todos los aspectos son notablemente más bajos que en el Oktoberfest:
 
-- **Cerveza (1 Masskrug)**: 13 € - 14,50 € (vs. 15,50 € - 16,50 € en el Oktoberfest)
+- **Cerveza (1 Masskrug)**: 13 € - 14,50 € (vs. 15,80 € en la mayoría de las carpas del Oktoberfest)
 - **Medio pollo**: 14 € - 16 € (vs. 16 € - 18 €)
 - **Tickets de atracciones**: 3 € - 6 € por atracción (con descuentos el Día Familiar)
 - **Hoteles**: Tarifas normales de Múnich, no el sobrecoste del 2-3x que trae el Oktoberfest

--- a/apps/web/content/blog/es/oktoberfest-2026-beer-prices.mdx
+++ b/apps/web/content/blog/es/oktoberfest-2026-beer-prices.mdx
@@ -1,0 +1,121 @@
+---
+title: "Precios de la cerveza en el Oktoberfest 2026: cuánto cobra cada carpa"
+description: "Precios confirmados de la Maß 2026 para las 40 carpas del Oktoberfest, de la carpa grande más barata a la más cara. Y lo que cuesta de verdad un día en la Wiesn."
+date: "2026-08-05"
+lastModified: "2026-08-05"
+author: "ProstCounter Team"
+category: "news"
+tags:
+  [
+    "oktoberfest",
+    "2026",
+    "precios cerveza",
+    "carpas",
+    "múnich",
+    "presupuesto",
+    "maß",
+  ]
+featuredImage: "/images/prost-counter-og-1.jpg"
+locale: "es"
+---
+
+# Precios de la cerveza en el Oktoberfest 2026: cuánto cobra cada carpa
+
+Los precios de 2026 ya están cerrados. Durante casi todo el año trabajamos con estimaciones, pero los responsables de las carpas ya han confirmado lo que costará una Maß cuando la Wiesn abra el 19 de septiembre.
+
+En resumen: **la mayoría de las carpas cobra 15,80 €**. El rango completo va de **14,80 € a 17,80 €**, y la media de las 40 carpas queda en **15,70 €**.
+
+Abajo están todas, agrupadas como las agrupa el propio festival.
+
+## Las carpas grandes
+
+Son las catorce carpas grandes, las de las bandas de metales y las listas de espera para reservar. Sus precios se publican de forma individual, así que estas cifras son firmes.
+
+| Carpa                      | Maß         |
+| -------------------------- | ----------- |
+| Kufflers Weinzelt          | 17,80 €     |
+| Armbrustschützen Festzelt  | 15,90 €     |
+| Löwenbräu-Festzelt         | 15,90 €     |
+| Pschorr-Festzelt Bräurosl  | 15,90 €     |
+| Festhalle Schottenhamel    | 15,80 €     |
+| Hacker-Festzelt            | 15,80 €     |
+| Hofbräu-Festzelt           | 15,80 €     |
+| Käfer Wiesn-Schänke        | 15,80 €     |
+| Marstall-Festzelt          | 15,80 €     |
+| Ochsenbraterei             | 15,80 €     |
+| Paulaner Festzelt          | 15,80 €     |
+| Schützen-Festzelt          | 15,80 €     |
+| Fischer-Vroni              | 15,75 €     |
+| **Augustiner-Festhalle**   | **14,90 €** |
+
+Dos de ellas merecen un comentario.
+
+**La Augustiner-Festhalle vuelve a ser la carpa grande más barata**, como casi todos los años. Con 14,90 € se queda noventa céntimos por debajo del resto, que a lo largo de cuatro Maß es casi una quinta cerveza. Augustiner además sigue sirviendo desde barriles de madera en lugar de tanques de acero, algo que muchos muniqueses defenderán (largo y tendido) como una diferencia real de sabor.
+
+**Kufflers Weinzelt es la excepción con 17,80 €**, y la comparación es algo injusta. La Weinzelt es la carpa del vino: su negocio principal son los vinos de Franconia y los espumosos, y la cerveza que sirve es una Weissbier premium, no la lager habitual del festival. Si buscas una Maß normal a precio normal, esta no es tu carpa.
+
+## La Oide Wiesn
+
+La Oide Wiesn es la zona histórica, al sur del recinto, con las atracciones antiguas, la música tradicional y un ambiente más tranquilo. Cobra una entrada de unos 4 € y, a cambio, la cerveza es más barata que en casi cualquier otro punto de la Theresienwiese.
+
+| Carpa                        | Maß         |
+| ---------------------------- | ----------- |
+| Festzelt Tradition           | 15,80 €     |
+| Boandlkramerei               | 15,30 €     |
+| Volkssängerzelt Schützenlisl | 14,90 €     |
+| **Museumszelt**              | **14,80 €** |
+
+**La Museumszelt, con 14,80 €, tiene la cerveza más barata del Oktoberfest 2026.** Incluso contando los 4 € de entrada, si piensas tomar más de cuatro cervezas la Oide Wiesn sale más a cuenta que el recinto principal. Y es, dicho sea de paso, un sitio bastante mejor para mantener una conversación.
+
+## Las carpas pequeñas
+
+Hay veintidós carpas pequeñas: los asadores de pollo, las tabernas de queso y vino, los sitios de café y Kaiserschmarrn. Suelen ser más tranquilas, más fáciles de pillar sin reserva y mejores para comer de verdad.
+
+Aquí los precios están documentados de forma más desigual. Estas seis tienen cifra propia confirmada:
+
+| Carpa                           | Maß         |
+| ------------------------------- | ----------- |
+| Bartls Flößerstadl              | 15,70 €     |
+| Hochreiters Haxnbraterei        | 15,70 €     |
+| Zur Bratwurst                   | 15,70 €     |
+| Hühner- und Entenbraterei Ammer | 14,95 €     |
+| Wirtshaus im Schichtl           | 14,90 €     |
+| **Münchner Weißbiergarten**     | **14,80 €** |
+
+El resto de carpas pequeñas figuran con el precio estándar de 15,80 €. Múnich no publica una cifra propia para cada una, así que tómalo como el valor por defecto y no como un precio confirmado por cada responsable.
+
+Una novedad real de este año: **Bartls Flößerstadl**, una carpa de 398 plazas que ocupa el sitio de la antigua Münchner Stubn. Sus 15,70 € vienen de una sola fuente, así que es la cifra de esta página de la que menos nos fiamos.
+
+## Lo que esto te cuesta en la práctica
+
+Tres o cuatro Maß son una tarde normal para la mayoría. A los 15,80 € que cobran casi todas las carpas:
+
+| Cervezas | Coste   | Con un 10 % de propina |
+| -------- | ------- | ---------------------- |
+| 2        | 31,60 € | 34,76 €                |
+| 3        | 47,40 € | 52,14 €                |
+| 4        | 63,20 € | 69,52 €                |
+| 5        | 79,00 € | 86,90 €                |
+
+La propina se da por hecha. Los camareros cargan diez Maß llenas a la vez entre la multitud, y redondear al euro siguiente o dejar un diez por ciento es lo normal.
+
+Dos apuntes prácticos sobre el gasto:
+
+- **El Radler cuenta.** Un Radler es mitad cerveza, mitad limonada, y cuesta lo mismo que una Maß. Si vas a ritmo tranquilo te renta más por hora, aunque el precio por litro sea el mismo.
+- **Importa más dónde te sientas que en qué carpa.** Entre la carpa normal más barata y la más cara hay como un euro de diferencia. Entre una tarde de carpa y una tarde de carpa con comida, atracciones y taxi de vuelta hay cincuenta. El presupuesto rara vez se rompe por la cerveza.
+
+Para el panorama completo, mira nuestro [desglose de costes del Oktoberfest](/blog/es/oktoberfest-cost-budget).
+
+## De dónde salen estas cifras
+
+Los precios vienen de las tablas de 2026 de [wiesnkini.de](https://wiesnkini.de/zelte/bierpreis/) e [in-muenchen.de](https://www.in-muenchen.de/stadtleben/oktoberfest-wiesn-preise.html). La lista de carpas, incluidos los cambios de este año, sale de [oktoberfest.de](https://www.oktoberfest.de/en/beer-tents/small-tents), de su [listado de la Oide Wiesn](https://www.oktoberfest.de/en/tents/tents-oide-wiesn/festival-tents-oide-wiesn-event-glance) y del [artículo de muenchen.de sobre las novedades de 2026](https://www.muenchen.de/veranstaltungen/oktoberfest/aktuell/oktoberfest-2026-das-ist-neu-auf-der-wiesn). Las fechas y la información oficial vienen de [muenchen.de](https://www.muenchen.de/en/events/oktoberfest).
+
+Donde las fuentes no coincidían, lo hemos indicado en la línea correspondiente. Los precios los fijan los responsables de cada carpa y pueden cambiar todavía antes del día de apertura.
+
+## Lleva la cuenta de lo que bebes
+
+Saber los precios es una cosa. Saber que ya llevas seis es otra, y para la sexta las cuentas mentales ya no salen. ProstCounter registra cada Maß sobre la marcha y lleva el total en euros, por carpa, para que la cifra del final del día sea la de verdad. Funciona también para todo el grupo, lo que zanja la mayoría de las discusiones sobre quién le debe qué a quién.
+
+Las 40 carpas de arriba ya están en la app con sus precios de 2026, así que los totales cuadran desde el primer día.
+
+<CTA />

--- a/apps/web/content/blog/es/oktoberfest-2026-guide.mdx
+++ b/apps/web/content/blog/es/oktoberfest-2026-guide.mdx
@@ -2,7 +2,7 @@
 title: "La guía completa del Oktoberfest 2026: fechas, consejos y qué esperar"
 description: "Todo lo que necesitas saber sobre el Oktoberfest 2026: fechas, precios de la cerveza, reservas en las carpas y consejos de expertos para la fiesta de la cerveza más grande del mundo."
 date: "2026-03-15"
-lastModified: "2026-03-15"
+lastModified: "2026-08-05"
 author: "ProstCounter Team"
 category: "festivals"
 tags: ["oktoberfest", "2026", "munich", "beer festival", "guide"]
@@ -16,7 +16,7 @@ El Oktoberfest es la fiesta de la cerveza más grande del mundo, y atrae a más 
 
 ## Fechas oficiales: 19 de septiembre - 4 de octubre de 2026
 
-El Oktoberfest 2026 dura **16 días**, abriendo el sábado 19 de septiembre y cerrando el domingo 4 de octubre. El festival tradicionalmente comienza el tercer sábado de septiembre y termina el primer domingo de octubre. Si el 3 de octubre (Día de la Unidad Alemana) cae dentro de ese período, el festival a veces se extiende un día más, y en 2026 así es, dándote un día extra de celebración.
+El Oktoberfest 2026 dura **16 días**, abriendo el sábado 19 de septiembre y cerrando el domingo 4 de octubre. El festival tradicionalmente comienza el tercer sábado de septiembre y termina el primer domingo de octubre. Solo se alarga cuando el 3 de octubre (Día de la Unidad Alemana) cae en lunes o martes, y entonces se estira hasta cubrir el festivo. En 2026 el 3 de octubre es sábado, así que es una Wiesn normal de 16 días.
 
 ### Fechas clave para apuntar
 
@@ -45,7 +45,7 @@ La Theresienwiese está muy bien conectada por transporte público:
 
 Los precios en el Oktoberfest han subido constantemente a lo largo de los años, y 2026 no será la excepción. Según las tendencias recientes, espera pagar aproximadamente:
 
-- **Una Masskrug (1 litro de cerveza)**: 15,50 € - 16,50 € dependiendo de la carpa
+- **Una Maß (1 litro de cerveza)**: 15,80 € en la mayoría de las carpas, con un rango de 14,80 € a 17,80 € ([lista completa de precios por carpa](/blog/es/oktoberfest-2026-beer-prices))
 - **Medio pollo (Hendl)**: 16 € - 18 €
 - **Codillo de cerdo (Schweinshaxe)**: 20 € - 25 €
 - **Pretzel grande (Breze)**: 6 € - 8 €

--- a/apps/web/content/blog/es/oktoberfest-2026-news.mdx
+++ b/apps/web/content/blog/es/oktoberfest-2026-news.mdx
@@ -2,7 +2,7 @@
 title: "Oktoberfest 2026: Fechas, nuevas normas y novedades"
 description: "Toda la información sobre el Oktoberfest 2026 — fechas, precios de cerveza, nuevas regulaciones, medidas de sostenibilidad y consejos para este año."
 date: "2026-03-15"
-lastModified: "2026-03-15"
+lastModified: "2026-08-05"
 author: "ProstCounter Team"
 category: "news"
 tags: ["oktoberfest", "2026", "news", "beer prices", "regulations", "munich", "sustainability"]
@@ -34,9 +34,9 @@ El anuncio anual del precio de la cerveza es uno de los eventos más seguidos de
 
 - **Precios en 2024**: 13,60 - 15,30 euros por Masskrug
 - **Precios en 2025**: 14,90 - 15,90 euros por Masskrug
-- **Rango proyectado para 2026**: aproximadamente 15,50 - 16,50 euros por Masskrug
+- **Rango confirmado para 2026**: 14,80 - 17,80 euros por Masskrug, con la mayoría de las carpas en 15,80
 
-El precio medio de un Masskrug probablemente rondará los **16 euros** en 2026. Los aumentos constantes reflejan el encarecimiento de ingredientes, precios de la energía, costes de personal y la inflación general. Para un desglose detallado de todos los costes, consulta nuestra [guía de presupuesto del Oktoberfest](/blog/es/oktoberfest-cost-budget).
+La media de las 40 carpas queda en **15,70 euros**. Los aumentos constantes reflejan el encarecimiento de ingredientes, precios de la energía, costes de personal y la inflación general. Para ver lo que cobra cada carpa, consulta nuestra [lista de precios 2026](/blog/es/oktoberfest-2026-beer-prices), y para un desglose detallado de todos los costes, nuestra [guía de presupuesto del Oktoberfest](/blog/es/oktoberfest-cost-budget).
 
 Aunque las subidas de precio no son bienvenidas, vale la pena señalar que la cerveza del Oktoberfest es una elaboración especial — más fuerte que la lager estándar (5,8-6,3% ABV), elaborada específicamente para el festival por las seis cervecerías autorizadas, y servida en un vaso de un litro completo.
 

--- a/apps/web/content/blog/es/oktoberfest-cost-budget.mdx
+++ b/apps/web/content/blog/es/oktoberfest-cost-budget.mdx
@@ -2,7 +2,7 @@
 title: "¿Cuánto cuesta el Oktoberfest? Desglose de presupuesto"
 description: "Planifica tu presupuesto para el Oktoberfest con precios reales de cerveza, comida, alojamiento y transporte. Consejos para todos los bolsillos."
 date: "2026-03-15"
-lastModified: "2026-03-15"
+lastModified: "2026-08-05"
 author: "ProstCounter Team"
 category: "tips"
 tags: ["oktoberfest", "budget", "beer prices", "munich", "travel tips", "cost"]
@@ -20,12 +20,14 @@ Aquí tienes un desglose detallado de lo que puedes esperar en 2026, junto con e
 
 El Masskrug — un litro completo de cerveza del festival — es la moneda del Oktoberfest. Los precios han subido constantemente a lo largo de los años, y en 2026 deberías esperar pagar:
 
-- **Un Masskrug (1L de cerveza)**: aproximadamente 15,50 a 16,50 euros, dependiendo de la carpa
-- **Media entre todas las carpas**: alrededor de 16 euros
+- **Una Maß (1L de cerveza)**: 15,80 euros en la mayoría de las carpas, de 14,80 a 17,80 según dónde te sientes
+- **Media de las 40 carpas**: 15,70 euros
+
+Consulta nuestra [lista de precios 2026](/blog/es/oktoberfest-2026-beer-prices) para ver lo que cobra cada carpa.
 
 Para ponerlo en contexto, ese mismo litro de cerveza cuesta aproximadamente 8 a 10 euros en un Biergarten normal de Múnich. El sobreprecio refleja el entorno del festival, la música en vivo, el ambiente y el hecho de que son cervezas especiales con un contenido de alcohol ligeramente mayor (normalmente 5,8% a 6,3% ABV).
 
-La mayoría de los visitantes beben entre 2 y 4 Masskrugs por visita. A 16 euros cada uno, eso son 32 a 64 euros solo en cerveza para un solo día.
+La mayoría de los visitantes beben entre 2 y 4 Maß por visita. A 15,80 euros cada una, eso son 31,60 a 63,20 euros solo en cerveza para un solo día.
 
 **Consejo**: No olvides dar propina a tu camarero. El personal del Oktoberfest carga con pesos increíbles — redondear al siguiente euro o añadir un 10% es lo habitual y muy apreciado.
 

--- a/docs/email/2026-08-bulletin.html
+++ b/docs/email/2026-08-bulletin.html
@@ -1,0 +1,121 @@
+<!--
+  Snapshot of the August 2026 "what's new" bulletin, as sent.
+  Resend is the source of truth for what actually shipped; this file is a
+  point-in-time copy kept so a future bulletin starts from an edit rather than
+  a rebuild. It is not read by any code and is not kept in sync automatically.
+
+  Campaign: aug2026-whatsnew
+  Sent from: ignacio@account.prostcounter.fun
+  Broadcasts: d193c030-d7a4-4ff9-b42c-93dc3bdf2940 (batch 1, 96 recipients),
+              455968b3-3358-46fa-95c6-bc01fe2dae87 (batch 2, 43 recipients)
+
+  Tracking: none at the provider. Resend open/click tracking is OFF on
+            account.prostcounter.fun and must stay off, because that domain also
+            sends Supabase Auth mail and click tracking rewrites links, which can
+            let a mail scanner consume a one-time password-reset token.
+            Attribution is via URL parameters only:
+              utm_*     -> GA4 (web and blog links)
+              referrer  -> Play Console acquisition reports
+              pt / ct   -> App Store Connect campaigns (pt=128467983)
+
+  Template tokens: {{{FIRST_NAME|there}}} and {{{RESEND_UNSUBSCRIBE_URL}}} are
+  resolved by Resend at broadcast send time. They only work for broadcasts, not
+  for one-off send-email calls, so substitute them by hand when sending tests.
+
+  Gotcha: mcp__resend__update-broadcast treats an omitted `name` as "clear it"
+  and silently renames the broadcast to "Untitled". Always pass `name`.
+
+  Split into two batches because the Resend free plan caps sending at 100
+  emails/day and pauses rather than queueing once the cap is hit.
+-->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
+<title>What's new in ProstCounter</title>
+</head>
+<body style="margin:0; padding:0; background-color:#f5f5f4;">
+<table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="background-color:#f5f5f4;">
+<tr>
+<td align="center" style="padding:24px 16px;">
+<table role="presentation" width="600" cellpadding="0" cellspacing="0" border="0" style="max-width:600px; width:100%; background-color:#ffffff; border-radius:8px; overflow:hidden;">
+<tr>
+<td align="center" bgcolor="#F59E0B" style="background-color:#F59E0B; padding:24px;">
+<img src="https://prostcounter.fun/apple-touch-icon.png" width="56" height="56" alt="ProstCounter" border="0" style="display:block; margin:0 auto 10px auto; border-radius:12px;">
+<div style="font-family:Arial, Helvetica, sans-serif; font-size:22px; font-weight:bold; letter-spacing:0.3px; color:#ffffff; text-shadow:0 1px 2px rgba(0,0,0,0.15);">ProstCounter</div>
+</td>
+</tr>
+<tr>
+<td style="padding:32px 32px 8px 32px; font-family:Arial, Helvetica, sans-serif;">
+<p style="margin:0 0 16px 0; font-size:16px; line-height:24px; color:#1c1917;">Hey {{{FIRST_NAME|there}}},</p>
+<p style="margin:0 0 20px 0; font-size:16px; line-height:24px; color:#1c1917;">It's been a while since you last checked in. Here's what's changed:</p>
+</td>
+</tr>
+<tr>
+<td style="padding:0 32px; font-family:Arial, Helvetica, sans-serif;">
+<table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+<tr><td style="padding:0 0 14px 0; font-size:15px; line-height:22px; color:#1c1917;"><strong>Native apps for iOS and Android.</strong> No more relying on the web version: get the real thing from the App Store or Google Play.</td></tr>
+<tr><td style="padding:0 0 14px 0; font-size:15px; line-height:22px; color:#1c1917;"><strong>Live location sharing.</strong> Opt in with your group and see who's nearby on a map, handy for finding each other in a packed tent.</td></tr>
+<tr><td style="padding:0 0 14px 0; font-size:15px; line-height:22px; color:#1c1917;"><strong>Friends.</strong> Add friends and see their activity, not just your group's.</td></tr>
+<tr><td style="padding:0 0 14px 0; font-size:15px; line-height:22px; color:#1c1917;"><strong>Unified feed.</strong> One place for everything happening across your groups.</td></tr>
+<tr><td style="padding:0 0 14px 0; font-size:15px; line-height:22px; color:#1c1917;"><strong>Wrapped.</strong> An end-of-festival recap of your drinking (or restraint).</td></tr>
+<tr><td style="padding:0 0 14px 0; font-size:15px; line-height:22px; color:#1c1917;">Smaller stuff: configurable tips, and radler now counts as half a beer.</td></tr>
+<tr><td style="padding:0 0 8px 0; font-size:15px; line-height:22px; color:#1c1917;"><strong>Guides.</strong> There's <a href="https://prostcounter.fun/blog?utm_source=email&utm_medium=bulletin&utm_campaign=aug2026-whatsnew&utm_content=blog" style="color:#D97706; text-decoration:underline;">a blog</a> now: tent guides, what a day on the Wiesn actually costs, traditions, and a full rundown on Oktoberfest 2026.</td></tr>
+</table>
+</td>
+</tr>
+<tr>
+<td style="padding:24px 32px 8px 32px;">
+<table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%">
+<tr>
+<td align="center" style="padding:0 0 12px 0;">
+<!--[if mso]>
+<v:roundrect xmlns:v="urn:schemas-microsoft-com:vml" href="https://apps.apple.com/app/apple-store/id6758376527?pt=128467983&ct=aug2026-whatsnew&mt=8" style="height:44px;v-text-anchor:middle;width:260px;" arcsize="12%" fillcolor="#D97706">
+<w:anchorlock/>
+<center style="color:#ffffff;font-family:Arial,sans-serif;font-size:15px;">Get it on the App Store</center>
+</v:roundrect>
+<![endif]-->
+<!--[if !mso]><!-->
+<a href="https://apps.apple.com/app/apple-store/id6758376527?pt=128467983&ct=aug2026-whatsnew&mt=8" style="display:inline-block; width:260px; background-color:#D97706; color:#ffffff; font-family:Arial, Helvetica, sans-serif; font-size:15px; line-height:44px; text-align:center; text-decoration:none; border-radius:6px;">Get it on the App Store</a>
+<!--<![endif]-->
+</td>
+</tr>
+<tr>
+<td align="center" style="padding:0 0 12px 0;">
+<!--[if mso]>
+<v:roundrect xmlns:v="urn:schemas-microsoft-com:vml" href="https://play.google.com/store/apps/details?id=com.prostcounter.app&referrer=utm_source%3Demail%26utm_medium%3Dbulletin%26utm_campaign%3Daug2026-whatsnew" style="height:44px;v-text-anchor:middle;width:260px;" arcsize="12%" fillcolor="#D97706">
+<w:anchorlock/>
+<center style="color:#ffffff;font-family:Arial,sans-serif;font-size:15px;">Get it on Google Play</center>
+</v:roundrect>
+<![endif]-->
+<!--[if !mso]><!-->
+<a href="https://play.google.com/store/apps/details?id=com.prostcounter.app&referrer=utm_source%3Demail%26utm_medium%3Dbulletin%26utm_campaign%3Daug2026-whatsnew" style="display:inline-block; width:260px; background-color:#D97706; color:#ffffff; font-family:Arial, Helvetica, sans-serif; font-size:15px; line-height:44px; text-align:center; text-decoration:none; border-radius:6px;">Get it on Google Play</a>
+<!--<![endif]-->
+</td>
+</tr>
+<tr>
+<td align="center">
+<a href="https://prostcounter.fun/?utm_source=email&utm_medium=bulletin&utm_campaign=aug2026-whatsnew&utm_content=web" style="display:inline-block; width:260px; background-color:#ffffff; color:#D97706; font-family:Arial, Helvetica, sans-serif; font-size:15px; line-height:42px; text-align:center; text-decoration:none; border-radius:6px; border:1px solid #D97706;">Open ProstCounter on the web</a>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td style="padding:24px 32px 32px 32px; font-family:Arial, Helvetica, sans-serif;">
+<p style="margin:0; font-size:15px; line-height:22px; color:#1c1917;">Cheers,<br>Ignacio (ProstCounter)</p>
+</td>
+</tr>
+<tr>
+<td style="padding:16px 32px; background-color:#fafaf9; border-top:1px solid #e7e5e4; font-family:Arial, Helvetica, sans-serif;">
+<p style="margin:0; font-size:12px; line-height:18px; color:#78716c;">Don't want emails like this? <a href="{{{RESEND_UNSUBSCRIBE_URL}}}" style="color:#78716c; text-decoration:underline;">Unsubscribe</a></p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+</table>
+</body>
+</html>

--- a/docs/plans/2026-08-04-oktoberfest-2026-and-bulletin-tracking-design.md
+++ b/docs/plans/2026-08-04-oktoberfest-2026-and-bulletin-tracking-design.md
@@ -96,6 +96,33 @@ Verified during design; the implementation depends on these.
   `prostcounter.fun` links are captured automatically with no code change.
 - Nothing in CI applies migrations. Production is reached with `pnpm sup:db:push`.
 
+## Revision, 2026-08-04: sections 2 and 5 partly void
+
+Section 2 (split the sending domain) could not be built. Resend's free plan permits exactly one
+custom domain and `account.prostcounter.fun` holds the slot, so creating `news.prostcounter.fun`
+returns `403 "Your plan includes 1 domain. Upgrade to add more."`
+
+Three routes were weighed: Resend Pro at 20 USD/month, a separate provider for marketing mail, or
+dropping click tracking. On the provider option, Brevo, Kit, EmailOctopus and MailerLite were all
+checked and every free tier stamps its own branding onto the email, which is a poor fit for a
+customer-facing product announcement; the paid tiers cost about the same as Resend Pro while also
+requiring a full re-setup and leaving the stack split across two dashboards.
+
+The decision was to stay free and drop click tracking. Consequences:
+
+- No `news.prostcounter.fun`. The sender remains `ignacio@account.prostcounter.fun`, which is what the
+  two approved test sends already used. Resend open and click tracking stay off everywhere.
+- Section 5's "per-link clicks and opens: Resend broadcast detail" no longer holds. Resend reports
+  delivery, bounces and complaints only.
+- The two-batch send stays: the 100-per-day cap is a plan limit independent of domains.
+- The transactional/marketing reputation split described in section 2 is not achieved. Acceptable for
+  a one-off send to an opted-in-by-signup list, but it is a real reason to revisit if recurring
+  bulletins ever happen.
+- The store-side parameters in section 3 become the only per-channel signal, which makes the Apple
+  provider token more valuable, not less.
+
+Sections 1, 3, 4 and 6 are unaffected.
+
 ## Design
 
 ### 1. Oktoberfest 2026 data

--- a/docs/plans/2026-08-04-oktoberfest-2026-and-bulletin-tracking-design.md
+++ b/docs/plans/2026-08-04-oktoberfest-2026-and-bulletin-tracking-design.md
@@ -1,0 +1,248 @@
+# Oktoberfest 2026 data + bulletin email tracking
+
+**Date:** 2026-08-04
+**Status:** Approved design
+
+## Goal
+
+Send a one-off "what's new" bulletin to 139 existing/lapsed users, and be able to measure
+whether it worked. Two prerequisites turned out to be blocking, and they are the bulk of this
+spec:
+
+1. Oktoberfest 2026 does not exist in the database, and the currently active festival is a
+   festival that ended in May 2026. Anyone who follows the email into the app today lands on a
+   finished Frühlingsfest.
+2. Tent coordinates in production are fabricated. The email's headline feature after the native
+   apps is "see who's nearby on a map", so shipping the email before fixing coordinates would
+   drive users at a map that is wrong by up to ~900 m.
+
+The email itself is already written, approved, and sitting in two draft Resend broadcasts. What
+is missing is tracking.
+
+## Non-goals
+
+- No marketing-consent or email-preference UI. This send remains a one-time legitimate-interest
+  service update with a working unsubscribe link. If recurring email becomes a thing, real opt-in
+  gets built first.
+- No routing email through Novu. Novu keeps handling push and in-app only. Revisit only if
+  recurring automated email tied to Novu's subscriber/preference infrastructure is wanted.
+- No new redirect slugs under `/r/`. Resend click tracking already yields per-link counts, and an
+  extra JS interstitial between an email tap and the App Store only loses people.
+- No custom Resend tracking subdomain (branded click links). Extra DNS plus re-verification risk
+  for a marginal deliverability gain at 139 recipients.
+- No changes to how the app picks the active festival. The existing `is_active` lookup is fine.
+
+## Established facts
+
+Verified during design; the implementation depends on these.
+
+### Festival
+
+- Oktoberfest 2026 is the 191st Wiesn: **19 September to 4 October 2026** (16 days).
+- Maß prices run **EUR 14.80 to 15.90**. Most large tents are EUR 15.80. Armbrustschützen,
+  Bräurosl and Löwenbräu are EUR 15.90. Augustiner is EUR 14.90. Museumszelt is EUR 14.80, the
+  cheapest on the grounds.
+- Festival base price is therefore **EUR 15.80 / 1580 cents**, the modal large-tent price.
+- The Oide Wiesn runs in 2026 (the Zentral-Landwirtschaftsfest that displaces it is not due until
+  2028).
+
+### Schema constraints
+
+- `CREATE UNIQUE INDEX idx_festivals_single_active ON festivals (is_active) WHERE is_active = true`.
+  Only one festival can be active. The currently active row must be deactivated in the same
+  transaction as the insert, or the insert raises a unique violation.
+- `festivals.short_name` is unique. Convention from prior rows: `oktoberfest-2026`.
+- `festivals.status` is an enum: `upcoming | active | ended`.
+- `tents` is shared across festivals and carries `latitude`, `longitude` and a PostGIS `location`
+  column. `festival_tents` links tents to a festival and holds `beer_price` / `beer_price_cents`.
+- `drink_type_prices` holds either a `festival_id` (festival-level default) or a
+  `festival_tent_id` (per-tent override).
+
+### Existing data problems
+
+- **Fabricated coordinates.** Sorted by position, every tent falls on an evenly spaced diagonal
+  line across Theresienwiese. Spot-checked against OSM: Marstall-Festzelt is off by ~900 m,
+  Museumzelt by ~650 m, Hofbräu-Festzelt by ~235 m.
+- **Incomplete 2025 lineup.** Only 27 tents were linked to `oktoberfest-2025`, while 13 further
+  real Oktoberfest venues already exist in `tents` with coordinates and were never linked:
+  Café Theres', Fisch-Bäda, Goldener Hahn, Heimer, Heinz, Hochreiters Haxnbraterei, Münchner
+  Knödelei, Schiebl's Kaffeehaferl, Vinzenzmurr Metzger Stubn, Wiesn Guglhupf, Wirtshaus im
+  Schichtl, plus Oide Wiesn's Boandlkramerei and Volkssängerzelt Schützenlisl.
+- **Typo.** `Museumzelt` should be `Museumszelt`.
+- **Name drift** from official 2026 naming, e.g. `Paulaner Festzelt` vs `Winzerer Fähndl`,
+  `Pschorr-Festzelt Bräurosl` vs `Bräurosl`, `Armbrustschützen Festzelt` vs `Armbrustschützenzelt`.
+- **Stale Oide Wiesn set.** The 2025 `old` tents include `Herzkasperlzelt` and
+  `Zur Schönheitskönigin`, which do not match the 2026 lineup.
+
+### 2026 lineup changes
+
+- **Bartls Flößerstadl** is new, a small tent (398 seats) that **replaces Münchner Stubn at the
+  same location**, so it inherits Münchner Stubn's position.
+- **Hühner und Entenbraterei Poschner** is in the official small-tent list but absent from `tents`
+  entirely.
+- One price source lists Flößerstadl among the large tents. That is wrong; it is small. This is
+  the concrete reason the data table gets human review before any write.
+
+### Resend / sending
+
+- Domain `account.prostcounter.fun` is verified, has **open tracking and click tracking both off**,
+  and also sends Supabase Auth transactional email. Tracking is a per-domain setting, so enabling
+  click tracking there would rewrite links inside password-reset and confirm-signup emails. A mail
+  scanner prefetching a rewritten one-time link is a realistic way to break a reset.
+- DNS for `prostcounter.fun` is on Vercel (`ns1/ns2.vercel-dns.com`, scope
+  `ignacio-guris-projects`). The Vercel MCP has no DNS tooling, but the Vercel CLI is installed and
+  authenticated, so records go in via `vercel dns add`.
+- Web analytics is **GA4** via `@next/third-parties/google`, production only. `utm_*` params on
+  `prostcounter.fun` links are captured automatically with no code change.
+- Nothing in CI applies migrations. Production is reached with `pnpm sup:db:push`.
+
+## Design
+
+### 1. Oktoberfest 2026 data
+
+**Sourcing rule:** coordinates come from OpenStreetMap via the Overpass API (ODbL), not from the
+existing rows and not from guesswork. Tent lineup and prices come from the published 2026 sources.
+Anything that cannot be verified is flagged rather than invented.
+
+OSM does not cover `Wiesn Guglhupf`, `Zur Schönheitskönigin`, or `Bartls Flößerstadl` (not yet
+mapped). Flößerstadl takes Münchner Stubn's OSM position. The other two are placed manually from
+the official festival map, or left out if they are not part of the 2026 lineup.
+
+OSM also contains near-duplicate names (`Haxenbraterei` and `Haxnbraterei`, `Café Kaiserschmarrn`
+and `Rischart's Café Kaiserschmarrn`). The name-to-tent mapping is therefore a reviewed pass, never
+a blind join.
+
+**Review gate:** the research produces a reference table of one row per tent with name, category,
+Maß price, latitude, longitude, source, and a verified/unverified marker. That table is approved
+before a single row is written to production. A wrong price is visible to every user and corrupts
+their spend statistics, so this gate is not optional.
+
+**Migration** `supabase/migrations/<timestamp>_add_oktoberfest_2026.sql`, following the structure of
+`20260409174404_add_fruehlingsfest_2026.sql`:
+
+1. Deactivate the currently active festival (`UPDATE festivals SET is_active = false WHERE is_active = true`).
+   Must precede the insert because of `idx_festivals_single_active`.
+2. Insert `Bartls Flößerstadl` and `Hühner und Entenbraterei Poschner` into `tents`.
+3. Correct coordinates on existing tents. Scope: every tent in the approved 2026 lineup. Tents that
+   belong only to other festivals (Augustinerkeller, Löwenbräukeller, Paulaner am Nockherberg,
+   Festhalle Bayernland, Hippodrom, Ayinger Braustuberl, Giesinger Bräu) are left alone; they have
+   null coordinates today and fixing them is separate work. Also fix `Museumzelt` to `Museumszelt`
+   and align the remaining names with official 2026 naming.
+4. Insert the `oktoberfest-2026` festival: 19 Sep to 4 Oct 2026, `status: 'upcoming'`,
+   `is_active: true`, base EUR 15.80 / 1580 cents, Theresienwiese coordinates, `map_url` and
+   description.
+5. Link every tent in the approved 2026 lineup via `festival_tents` with its per-tent price.
+6. Insert festival-level `drink_type_prices` from the 1580-cent base, using the same per-drink
+   ratios as the Frühlingsfest migration: `beer` and `radler` and `other` at the base,
+   `alcohol_free` at 0.90, `wine` at 0.85, `soft_drink` at 0.40. Then per-tent overrides
+   (`beer` and `radler`) wherever a tent's price differs from the base.
+
+The migration is idempotent where the precedent allows it (`ON CONFLICT (id) DO NOTHING` on tent
+inserts) so a partial failure can be retried.
+
+**Renaming existing tents** changes only display names and positions. `tent_visits` references tent
+ids, so historical data stays valid. The side effect is that last year's map becomes retroactively
+correct rather than staying consistent with what users saw at the time. Accepted deliberately.
+
+**Verification:** apply to local, then a full `pnpm sup:db:reset` to prove the whole migration chain,
+then `pnpm sup:db:push` to production. Confirm afterwards that exactly one festival is active, that
+it is `oktoberfest-2026`, and that every linked tent has a price and non-null coordinates.
+
+### 2. Split the sending domain
+
+New Resend domain **`news.prostcounter.fun`**, region `eu-west-1` to match the existing one, with
+`openTracking` and `clickTracking` both enabled **on that domain only**. `account.prostcounter.fun`
+keeps both off, so Supabase Auth links are never rewritten.
+
+DKIM, SPF and MX records are added with `vercel dns add` and then verified in Resend. The broadcast
+`from` becomes `Ignacio from ProstCounter <ignacio@news.prostcounter.fun>`.
+
+This also buys the standard transactional/marketing reputation split: unsubscribes and complaints
+from bulletins stop counting against the domain that has to deliver password resets.
+
+Risk: a fresh subdomain has no sending reputation. At 139 emails to people who signed up
+themselves this is negligible, and `_dmarc` is `p=none` so there are no alignment failures. SPF and
+DKIM must both read verified before sending.
+
+Contacts and segments are account-level in Resend and carry over untouched.
+
+### 3. Link parameters
+
+Convention: `utm_source=email`, `utm_medium=bulletin`, `utm_campaign=aug2026-whatsnew`,
+`utm_content=<web|app-store|play-store>`.
+
+- **Web** gets plain UTMs on `prostcounter.fun`. GA4 captures them automatically.
+- **Google Play** carries the UTMs inside a URL-encoded `referrer` param, which surfaces in Play
+  Console acquisition reports.
+- **Apple** uses the link App Store Connect generates for a campaign named `aug2026-whatsnew`,
+  carrying `pt`, `ct` and `mt=8`. The `pt` provider token only exists inside App Store Connect, so
+  it is produced by driving the already-authenticated Chrome session to App Analytics, Acquisition,
+  Campaigns.
+
+Parameters go into the plain-text body as well as the HTML, so text-only readers are still
+attributed.
+
+Resend's click tracking rewrites each href and then redirects to the full original URL, query string
+intact, so store-side attribution survives the rewrite.
+
+### 4. Version-control the email
+
+The bulletin HTML currently exists only inside Resend. A copy is committed to the repo as a
+reference so a future bulletin starts from an edit rather than a rebuild. Resend stays the source of
+truth for what actually ships; the repo copy is explicitly a snapshot, noted as such in the file, to
+keep the drift risk honest.
+
+### 5. Where results are read
+
+- Per-link clicks and opens: Resend broadcast detail.
+- Web sessions and downstream behaviour: GA4, Traffic acquisition, filtered to `email / bulletin`.
+- Android installs: Play Console acquisition reports, filtered by `utm_campaign`.
+- iOS installs: App Store Connect, App Analytics, Campaigns.
+
+### 6. Sending
+
+One test send to `ignacioguri@gmail.com` from the new domain, confirming: renders as before, header
+icon loads, Resend's rewritten links still reach the right destinations with parameters intact, and
+unsubscribe works.
+
+Then Batch 1 (96 recipients), then Batch 2 (43 recipients) scheduled roughly 26 hours later. The
+gap exists because the Resend free tier caps at 100 emails per day and **pauses** rather than
+queueing once the cap is hit.
+
+After both, verify delivery health (no mass bounces or complaints) before calling it done.
+
+## Sequencing
+
+Phase 0 must complete before Phase 3. The email tells people to come back and look, so the festival
+has to be live and the map has to be correct before anyone clicks. Phases 1 and 2 are independent of
+Phase 0 and can proceed in parallel with it.
+
+## Open items
+
+- Exact Maß prices for several small tents are published only as "under EUR 15" and need pinning
+  down, or flagging as unverified in the reference table.
+- Whether `Zur Schönheitskönigin` and `Wiesn Guglhupf` are part of the 2026 lineup at all.
+- Confirmation that logging a drink against an `upcoming` festival behaves sensibly in the UI, given
+  the festival goes active six weeks before it starts.
+
+## Existing state, for reference
+
+- Resend segments: General (`2c3159c7-ccfc-4b5b-9be3-b73522702336`), Bulletin Aug 2026 Batch 1
+  (`ab9269de-d777-42e3-a22e-3c67fe0d589b`, 96 contacts), Batch 2
+  (`e998142d-d562-4a5a-8778-8a582253ec20`, 43 contacts).
+- Draft broadcasts: Batch 1 `d193c030-d7a4-4ff9-b42c-93dc3bdf2940`, Batch 2
+  `455968b3-3358-46fa-95c6-bc01fe2dae87`.
+- Recipients were derived from `auth.users` where `email_confirmed_at is not null` (158 confirmed of
+  377 registered), then filtered to 139 by removing store review bots, Apple private relay
+  addresses, test and placeholder accounts, a disposable-domain address, and several unrelated
+  corporate domains that looked like bot signups.
+
+## Sources
+
+- <https://www.oktoberfest.de/en>
+- <https://www.munichtourism.org/oktoberfest-dates-schedule/>
+- <https://wiesnkini.de/zelte/bierpreis/>
+- <https://www.oktoberfest.de/en/beer-tents/small-tents>
+- <https://www.falstaff.com/de/news/neuer-wiesn-wirt-floesserstadl-ersetzt-muenchner-stubn-auf-dem-oktoberfest>
+- <https://www.muenchen.de/veranstaltungen/wiesn-kleine-zelte/bartls-floesserstadl>
+- OpenStreetMap via the Overpass API, ODbL

--- a/docs/plans/2026-08-04-oktoberfest-2026-and-bulletin-tracking-plan.md
+++ b/docs/plans/2026-08-04-oktoberfest-2026-and-bulletin-tracking-plan.md
@@ -245,6 +245,9 @@ UPDATE festivals SET is_active = false WHERE is_active = true;
 INSERT INTO tents (id, name, category, latitude, longitude) VALUES
   ('c0000000-0000-4000-b000-000000000001', 'Bartls Flößerstadl', 'small', 48.13138, 11.54925),
   ('c0000000-0000-4000-b000-000000000002', 'Hühnerbraterei Poschner', 'small', 48.13266, 11.54864)
+-- ON CONFLICT guard matches the Frühlingsfest precedent. Note the whole migration is wrapped in
+-- a transaction, so a failure rolls back entirely and there is no partial state to retry over.
+-- The guard only matters if someone deletes the festival row by hand and re-runs this file.
 ON CONFLICT (id) DO NOTHING;
 
 -- Step 3: Fix the long-standing misspelling.
@@ -493,6 +496,10 @@ Expected exactly:
 
 Any mismatch: STOP and report which column differed.
 
+Caveat on `active_count`: the local Supabase instance is shared, and its seed data may carry
+additional festivals. If `active_count` is not 1, report which other festival is active rather
+than assuming the migration failed. `active_festival` must still be `oktoberfest-2026`.
+
 - [ ] **Step 4: Confirm the trigger populated PostGIS geometry**
 
 ```sql
@@ -668,16 +675,15 @@ If a link was obtained, Task 7 uses it verbatim. If the campaign generator is no
 
 ---
 
-## Task 7: Add campaign parameters to both broadcasts and snapshot the HTML
+## Task 7: Add campaign parameters to both broadcasts
 
 **Pre-check:** Task 5 finished with `news.prostcounter.fun` verified and tracking enabled. Confirm both draft broadcasts still exist and are `status: draft` via `mcp__resend__list-broadcasts`. If either is `sent`, STOP.
 
-**Files:**
-- Create: `docs/email/2026-08-bulletin.html`
+**Files:** none. The HTML snapshot file is created in Task 8.
 
 **Interfaces:**
 - Consumes: the Apple link decision from Task 6, the verified domain from Task 5.
-- Produces: two updated draft broadcasts, ready to send in Tasks 8 and 9.
+- Produces: two updated draft broadcasts, ready to send in Tasks 8 and 9. The final HTML body, consumed by Task 8 Step 5.
 
 The three URLs, used in both the HTML and plain-text bodies:
 
@@ -727,30 +733,9 @@ Same call, with:
 
 Call `mcp__resend__get-broadcast` for each ID. Confirm for both: `from` is the `news.` address, the subject is unchanged (`ProstCounter now has real apps (and a few other things worth checking out)`), all five HTML URLs carry parameters, and status is still `draft`.
 
-- [ ] **Step 6: Write the HTML snapshot to the repo**
-
-Create `docs/email/2026-08-bulletin.html` containing the final HTML, prefixed with:
-
-```html
-<!--
-  Snapshot of the August 2026 "what's new" bulletin, as sent.
-  Resend is the source of truth for what actually shipped; this file is a
-  point-in-time copy kept so a future bulletin starts from an edit rather than
-  a rebuild. It is not read by any code and is not kept in sync automatically.
-
-  Campaign: aug2026-whatsnew
-  Sent from: ignacio@news.prostcounter.fun
-  Broadcasts: d193c030-d7a4-4ff9-b42c-93dc3bdf2940 (batch 1),
-              455968b3-3358-46fa-95c6-bc01fe2dae87 (batch 2)
--->
-```
-
-- [ ] **Step 7: Commit**
-
-```bash
-git add docs/email/2026-08-bulletin.html
-git commit -m "docs(email): snapshot Aug 2026 bulletin with campaign params"
-```
+The HTML snapshot is deliberately NOT written in this task. It lives in Task 8 Steps 5 and 6, after
+the test send has proven the HTML renders, so the committed snapshot can never be a version that was
+found broken and then changed.
 
 ---
 
@@ -760,7 +745,8 @@ Human-gated: requires reading a real inbox and judging rendering.
 
 **Pre-check:** Task 7 Step 5 passed. If not, STOP.
 
-**Files:** none.
+**Files:**
+- Create: `docs/email/2026-08-bulletin.html`
 
 - [ ] **Step 1: Send a test to the author's own address**
 
@@ -781,6 +767,35 @@ If a link lands without its parameters, STOP. Store-side attribution would be si
 - [ ] **Step 4: Confirm the send is healthy in Resend**
 
 Call `mcp__resend__list-emails` with `limit: 5`. Expected: the test email present with status `delivered`. If `bounced` or `complained`, STOP.
+
+- [ ] **Step 5: Write the HTML snapshot to the repo**
+
+Only now that the HTML is proven to render. Use the broadcast HTML from Task 7, with the template
+tokens `{{{FIRST_NAME|there}}}` and `{{{RESEND_UNSUBSCRIBE_URL}}}` intact — NOT the substituted
+test-send variant from Step 1.
+
+Create `docs/email/2026-08-bulletin.html` prefixed with:
+
+```html
+<!--
+  Snapshot of the August 2026 "what's new" bulletin, as sent.
+  Resend is the source of truth for what actually shipped; this file is a
+  point-in-time copy kept so a future bulletin starts from an edit rather than
+  a rebuild. It is not read by any code and is not kept in sync automatically.
+
+  Campaign: aug2026-whatsnew
+  Sent from: ignacio@news.prostcounter.fun
+  Broadcasts: d193c030-d7a4-4ff9-b42c-93dc3bdf2940 (batch 1),
+              455968b3-3358-46fa-95c6-bc01fe2dae87 (batch 2)
+-->
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add docs/email/2026-08-bulletin.html
+git commit -m "docs(email): snapshot Aug 2026 bulletin with campaign params"
+```
 
 ---
 

--- a/docs/plans/2026-08-04-oktoberfest-2026-and-bulletin-tracking-plan.md
+++ b/docs/plans/2026-08-04-oktoberfest-2026-and-bulletin-tracking-plan.md
@@ -1,0 +1,834 @@
+# Oktoberfest 2026 Data + Bulletin Email Tracking Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Get Oktoberfest 2026 into production with correct tent data and coordinates, then send the already-drafted bulletin to 139 users with per-link and store-side attribution.
+
+**Architecture:** One SQL migration creates the festival, inserts two new tents, replaces every fabricated tent coordinate with an OpenStreetMap-sourced one, and links 40 tents with 2026 prices. Separately, a new Resend sending subdomain (`news.prostcounter.fun`) carries open/click tracking so the existing `account.prostcounter.fun` domain, which sends Supabase Auth mail, is never touched. Campaign parameters go on the three links in the two existing draft broadcasts.
+
+**Tech Stack:** Supabase (Postgres + PostGIS), Supabase CLI, Resend MCP, Vercel CLI (DNS), Chrome DevTools MCP (App Store Connect), GA4.
+
+**Stop-and-ask protocol:** If at any step you encounter state that contradicts the plan — file missing, function signature differs, test passes when expected to fail, unfamiliar code in target lines, dependency version unavailable, or any expectation in this plan does not match reality — STOP. Do not improvise, do not work around it, do not pick the closest interpretation. Report the discrepancy and wait for guidance.
+
+## Global Constraints
+
+- Design doc: `docs/plans/2026-08-04-oktoberfest-2026-and-bulletin-tracking-design.md`. Read it before starting.
+- Branch: `feat/oktoberfest-2026-and-bulletin-tracking`. Already created. Never commit to `main`.
+- Do NOT push to the remote unless explicitly asked.
+- Commit message titles are capped at 72 characters; the pre-commit hook enforces it.
+- `pnpm lint` and `pnpm type-check` must pass before any commit. The pre-commit hook runs both.
+- Festival dates are exactly `2026-09-19` to `2026-10-04`.
+- Festival base beer price is exactly `1580` cents / `15.80` EUR.
+- Campaign name is exactly `aug2026-whatsnew` everywhere it appears.
+- No em-dashes in any user-facing copy (email body, subject, preview text). Use commas, colons, parentheses or hyphens.
+- Existing email copy is already approved. Do not reword it. The only content change in this plan is adding parameters to three URLs.
+
+## Open Questions Resolved
+
+- **Question:** The spec said "align the remaining names with official 2026 naming", which is open-ended.
+  **Decision:** Only fix the outright typo `Museumzelt` to `Museumszelt`. Leave all other tent names as they are, including `Paulaner Festzelt` (not `Winzerer Fähndl`) and `Pschorr-Festzelt Bräurosl` (not `Bräurosl`).
+  **Why:** muenchen.de's own 2026 coverage uses "Paulaner-Festzelt", so our name is not wrong, just one of two accepted names. Renaming rows users already recognise has no functional benefit and risks confusing them. `Museumzelt` is a genuine misspelling with no defence.
+  **If wrong:** STOP and ask. Do not rename additional tents on your own judgement.
+
+- **Question:** The spec did not say what to do for tents with no published 2026 Maß price.
+  **Decision:** They get NO row in `drink_type_prices` and therefore fall through to the festival default of 1580 cents. Their `festival_tents.beer_price_cents` is set to 1580.
+  **Why:** A fabricated per-tent price is worse than an honest default, and `get_drink_price_cents` already falls back to the festival level.
+  **If wrong:** STOP and ask.
+
+- **Question:** The spec did not say what to do about the two tents with no coordinate source (`Münchner Weißbiergarten`, `Wiesn Guglhupf`).
+  **Decision:** Set their `latitude` and `longitude` to `NULL`.
+  **Why:** `get_nearby_tents` filters on `WHERE t.location IS NOT NULL`, so a NULL tent is silently excluded from proximity results. A wrong coordinate actively misleads someone standing on the Wiesn; an absent one just does not appear. Task 9 offers an optional manual placement.
+  **If wrong:** STOP and ask. Do not invent coordinates for them.
+
+- **Question:** Which UUIDs for the two new tents?
+  **Decision:** `c0000000-0000-4000-b000-000000000001` (Bartls Flößerstadl) and `c0000000-0000-4000-b000-000000000002` (Hühnerbraterei Poschner).
+  **Why:** Mirrors the deterministic-ID convention of `20260409174404_add_fruehlingsfest_2026.sql`, which used the `b0000000-...-b000-...` block. Deterministic IDs make the migration re-runnable and reviewable. The `4` version nibble and `b` variant nibble keep these valid UUIDs.
+  **If wrong:** STOP and ask.
+
+- **Question:** Is it safe to set `is_active = true` six weeks before the festival starts?
+  **Decision:** Yes. Set `is_active = true` and `status = 'upcoming'` now.
+  **Why:** Verified in code: `packages/shared/src/utils/festival-status.ts` derives status from dates at runtime, and `apps/web/app/(private)/home/FestivalStatus.tsx` renders a "starts in N days" info alert for a future festival. The DB `status` column is advisory (set by the admin UI), not the source of truth for display. The resulting UX is the desired "ready for the next Wiesn" state.
+  **If wrong:** STOP and ask.
+
+- **Question:** Which tents are in the 2026 lineup, given sources disagree?
+  **Decision:** 40 tents, exactly as listed in the Task 1 table. Notably EXCLUDED: `Herzkasperlzelt` and `Zur Schönheitskönigin` (absent from the 2026 Oide Wiesn lineup), `Münchner Stubn` (replaced by Bartls Flößerstadl), and all venues belonging to other festivals (`Augustinerkeller`, `Löwenbräukeller`, `Paulaner am Nockherberg`, `Festhalle Bayernland`, `Hippodrom`, `Ayinger Braustuberl`, `Giesinger Bräu`).
+  **Why:** Cross-referenced oktoberfest.de's official small-tent and Oide Wiesn pages against muenchen.de's 2026 changes article.
+  **If wrong:** STOP and ask.
+
+- **Question:** One price source lists `Bartls Flößerstadl` as a large tent at 15.70.
+  **Decision:** Category `small`, price 1570.
+  **Why:** muenchen.de and Falstaff both describe it as a small tent with 398 seats replacing Münchner Stubn. The price is single-sourced, hence the Task 1 human review.
+  **If wrong:** STOP and ask.
+
+- **Question:** Should `radler` be priced the same as `beer` per tent?
+  **Decision:** Yes. Every per-tent override inserts both a `beer` and a `radler` row at the same price, which is why Task 3 expects 30 override rows for 15 differing tents.
+  **Why:** This is exactly what `20260409174404_add_fruehlingsfest_2026.sql` did for Hippodrom. Note this is the per-tent *price* only; the separate rule that a radler counts as half a beer for leaderboard purposes lives in `20260325120000_radler_half_beer_leaderboard.sql` and is untouched here.
+  **If wrong:** STOP and ask.
+
+- **Question:** The spec did not name a `map_url` for the festival row.
+  **Decision:** `https://www.muenchen.de/en/events/oktoberfest`.
+  **Why:** Prior festival rows use muenchen.de event pages, and this URL was confirmed live during research. A deep link to a year-specific map page risks 404ing later.
+  **If wrong:** STOP and ask.
+
+- **Question:** The spec did not name a path for the committed email HTML snapshot.
+  **Decision:** `docs/email/2026-08-bulletin.html`, with an HTML comment at the top stating that Resend is the source of truth and this is a point-in-time snapshot.
+  **Why:** `docs/` is tracked and already holds reference material. The comment keeps the drift risk explicit rather than implied.
+  **If wrong:** STOP and ask.
+
+- **Question:** What if the Apple provider token cannot be obtained in Task 6?
+  **Decision:** Use the bare URL `https://apps.apple.com/app/prostcounter/id6758376527` with no query parameters at all.
+  **Why:** Apple campaign attribution requires both `pt` and `ct`. A `ct` without `pt` attributes nothing while making the URL look tampered with. Per-link click counts still come from Resend regardless.
+  **If wrong:** STOP and ask.
+
+- **Question:** The plan writes a migration but there are no DB-level tests in this repo.
+  **Decision:** Task 3's red/green cycle uses verification SQL rather than a test framework: the same query is run before the migration (expected: empty / wrong) and after (expected: exact values).
+  **Why:** `packages/api/src/routes/__tests__/festival.route.test.ts` mocks Supabase entirely, so it cannot detect data problems. Verification SQL is the only thing that actually proves the migration. This is a deliberate deviation from strict TDD, noted per the discipline-drift rule.
+  **If wrong:** STOP and ask.
+
+## Out of Scope
+
+- Marketing-consent or email-preference UI. Not built here.
+- Routing any email through Novu. Novu keeps push and in-app only.
+- New `/r/<slug>` redirect entries in `apps/web/app/(public)/r/[slug]/page.tsx`. Do not touch that file.
+- A custom Resend tracking subdomain (branded click links).
+- Enabling open or click tracking on `account.prostcounter.fun`. That domain must be left exactly as it is.
+- Fixing coordinates for tents belonging to other festivals (`Augustinerkeller`, `Löwenbräukeller`, `Paulaner am Nockherberg`, `Festhalle Bayernland`, `Hippodrom`, `Ayinger Braustuberl`, `Giesinger Bräu`). They have NULL coordinates today. Leave them.
+- Fixing `Starkbierfest 2026`'s inconsistent `short_name` ("Starkbierfest") or its NULL `default_beer_price_cents`.
+- Rewording any approved email copy.
+- Refactoring the duplicated `RedirectSlug` type across the three `/r/[slug]` files.
+- Do not add features not listed in this plan, even if related code is nearby.
+
+## Conventions
+
+- Follow conventions established in `supabase/migrations/20260409174404_add_fruehlingsfest_2026.sql` and any `CLAUDE.md` in the project.
+- SQL: lowercase keywords are NOT used in this repo's migrations; use uppercase `INSERT`/`UPDATE`/`SELECT` as the existing migrations do.
+- Every migration statement gets a `-- Step N:` comment describing intent, matching the Frühlingsfest precedent.
+- Apply migration SQL to the LOCAL database with the `mcp__supabase-local__execute_sql` tool during development. Do NOT run `pnpm sup:db:reset` casually; it wipes other agents' work on the shared local instance. The one full reset in Task 4 is deliberate and gated.
+
+---
+
+## File Structure
+
+- `supabase/migrations/<generated_timestamp>_add_oktoberfest_2026.sql` — created in Task 2. The entire database change. Single transaction.
+- `docs/email/2026-08-bulletin.html` — created in Task 7. Snapshot of the sent HTML.
+- No application code changes. No TypeScript changes. `pnpm sup:db:types` is NOT needed because the schema does not change, only data.
+
+---
+
+## Task 1: [HUMAN] Approve the Oktoberfest 2026 reference table
+
+No code. This is the review gate from the design doc. A wrong price is visible to every user and corrupts their spend statistics, so nothing may be written until a human signs off on this table.
+
+**Files:** none.
+
+**Interfaces:**
+- Produces: an approved/rejected decision. Task 2 must not start until approval is explicit.
+
+**Provenance:** prices from wiesnkini.de and in-muenchen.de (2026 tables); lineup from oktoberfest.de's small-tent and Oide Wiesn pages plus muenchen.de's 2026 changes article; coordinates from OpenStreetMap via the Overpass API (ODbL), `timestamp_osm_base: 2026-08-04`.
+
+- [ ] **Step 1: Present the table below to the human and get explicit approval**
+
+Flag these specific uncertainties out loud when presenting:
+
+1. `Bartls Flößerstadl` price 15.70 is single-sourced, and that source miscategorised it as a large tent.
+2. 25 of 40 tents have no published 2026 price and will inherit the 1580 base. They are marked `(base)`.
+3. `Münchner Weißbiergarten` and `Wiesn Guglhupf` have no coordinate source and will be set to NULL.
+4. `Museumszelt` price is 14.80 per the 2026 source, but a separate table listed 14.60 for 2025. Using 14.80.
+
+**Large tents (14)**
+
+| Tent ID | Name | Lat | Lon | Price |
+|---|---|---|---|---|
+| `55ff3af6-f1d6-481a-a8f4-58fa23f00f68` | Armbrustschützen Festzelt | 48.13474 | 11.54871 | 15.90 |
+| `631abb99-4237-4bbc-94d7-2a6c18e11e25` | Augustiner-Festhalle | 48.13286 | 11.55006 | 14.90 |
+| `9eb72005-8026-4665-be77-4a61fbcc3fa1` | Festhalle Schottenhamel | 48.13217 | 11.54814 | 15.80 (base) |
+| `da36b13f-1e75-4299-9f75-1de4eb38b416` | Fischer-Vroni | 48.13484 | 11.55018 | 15.75 |
+| `282d326c-0e14-43e2-b8c6-9bf098a0fde6` | Hacker-Festzelt | 48.13305 | 11.54816 | 15.80 (base) |
+| `253eb29d-8efe-4095-9671-4eff02704c4a` | Hofbräu-Festzelt | 48.13390 | 11.54841 | 15.80 (base) |
+| `37ad3fc4-9d52-4e19-91c7-a01ed11c6854` | Käfer Wiesn-Schänke | 48.13030 | 11.54729 | 15.80 (base) |
+| `2661d289-5ecd-42a0-9a59-eaf5ef94f92d` | Kufflers Weinzelt | 48.13006 | 11.54988 | 17.80 |
+| `dd7b4b6d-7a57-411a-baf8-8c0d20682b64` | Löwenbräu-Festzelt | 48.13098 | 11.54969 | 15.90 |
+| `49449d2f-c9b7-4b8b-9ed7-889690493c3d` | Marstall-Festzelt | 48.13537 | 11.54906 | 15.80 (base) |
+| `017977ea-a9c3-4865-b494-edc49efc6212` | Ochsenbraterei | 48.13412 | 11.55041 | 15.80 (base) |
+| `0935a117-4fe2-46fb-b8fa-fc45d9496af9` | Paulaner Festzelt | 48.13117 | 11.54788 | 15.80 (base) |
+| `4d140654-f235-44b8-8d6e-8f23e57274a2` | Pschorr-Festzelt Bräurosl | 48.13195 | 11.54992 | 15.90 |
+| `5deac267-6401-437f-adae-e81769e4e781` | Schützen-Festzelt | 48.13124 | 11.54692 | 15.80 (base) |
+
+**Oide Wiesn / `old` (4)**
+
+| Tent ID | Name | Lat | Lon | Price |
+|---|---|---|---|---|
+| `907342a2-ab22-4b27-8ebd-f7225a4d13e7` | Boandlkramerei | 48.12876 | 11.54607 | 15.30 |
+| `f2df3186-ec0d-467f-a560-fffa48a72897` | Festzelt Tradition | 48.12863 | 11.54748 | 15.80 (base) |
+| `655190b1-ca0d-4d5a-8def-74f8a20f1e2b` | Museumszelt *(renamed)* | 48.12781 | 11.54727 | 14.80 |
+| `e61d04d2-6a16-4069-bf79-85dcf4827c94` | Volkssängerzelt Schützenlisl | 48.12837 | 11.54617 | 14.90 |
+
+**Small tents (22)**
+
+| Tent ID | Name | Lat | Lon | Price |
+|---|---|---|---|---|
+| `c0000000-0000-4000-b000-000000000001` | Bartls Flößerstadl *(NEW)* | 48.13138 | 11.54925 | 15.70 |
+| `bbbf2c29-7b2e-487a-bcfc-c4b75547f83a` | Bodo's Cafézelt & Cocktailbar | 48.13340 | 11.55039 | 15.80 (base) |
+| `1764c5e2-6f01-4119-a55a-7d0efe3ae861` | Café Theres' | 48.13222 | 11.55073 | 15.80 (base) |
+| `28a517af-f440-4102-9ad3-beaed8347061` | Feisingers Kas- und Weinstubn | 48.13135 | 11.54857 | 15.80 (base) |
+| `f8e94181-3a63-4e68-9285-588038be343f` | Fisch-Bäda | 48.13144 | 11.55080 | 15.80 (base) |
+| `6fcea9eb-c5c5-4d8f-9363-cbd86119128e` | Glöckle-Wirt | 48.13147 | 11.54852 | 15.80 (base) |
+| `f02ae7eb-3c8c-4e38-ae4a-7b0f9fc5e404` | Goldener Hahn | 48.13325 | 11.54892 | 15.80 (base) |
+| `6d4e022d-c033-4a56-a19b-441dfe8430fd` | Heimer Enten- und Hühnerbraterei | 48.13325 | 11.55104 | 15.80 (base) |
+| `e2eae4f6-8da8-46db-b76a-d1fb50eca8f6` | Heinz Wurst- und Hühnerbraterei | 48.13171 | 11.54857 | 15.80 (base) |
+| `ecaae5eb-9745-4359-826a-9a14aa91591b` | Hochreiters Haxnbraterei | 48.13343 | 11.54889 | 15.70 |
+| `24b50db1-f7c1-4132-a07c-00ad2cb8c2e1` | Hühner- und Entenbraterei Ammer | 48.13345 | 11.54979 | 14.95 |
+| `c0000000-0000-4000-b000-000000000002` | Hühnerbraterei Poschner *(NEW)* | 48.13266 | 11.54864 | 15.80 (base) |
+| `2196e0ea-1262-4f2c-97ef-bcd67104ae72` | Kalbsbraterei | 48.13232 | 11.54938 | 15.80 (base) |
+| `0898010d-693f-47be-b8f2-5916ad5a56d0` | Münchner Knödelei | 48.12919 | 11.54917 | 15.80 (base) |
+| `a20effb6-612e-4085-8de0-6fbc0dff1dc1` | Münchner Weißbiergarten | NULL | NULL | 14.80 |
+| `cb0a2849-159f-48f6-902f-fba73ae9c9a2` | Rischart's Café Kaiserschmarrn | 48.13067 | 11.55050 | 15.80 (base) |
+| `014c7c7e-f904-4fcc-931f-2b80c9ceff2b` | Schiebl's Kaffeehaferl | 48.13416 | 11.54924 | 15.80 (base) |
+| `949ee890-ee80-406c-af23-ded34e838b44` | Vinzenzmurr Metzger Stubn | 48.13437 | 11.54922 | 15.80 (base) |
+| `7b91d421-5052-4109-b47f-8136f3bb9a89` | Wiesn Guglhupf | NULL | NULL | 15.80 (base) |
+| `5162f382-2321-495c-b723-942a4708811e` | Wildstuben | 48.13008 | 11.55243 | 15.80 (base) |
+| `b349fe59-e104-42f1-9157-1859d829c1fa` | Wirtshaus im Schichtl | 48.13387 | 11.55242 | 14.90 |
+| `387574a0-8c63-4bf0-a4d0-a0bc37158ddd` | Zur Bratwurst | 48.13029 | 11.55261 | 15.70 |
+
+**Sanity check to state when presenting:** the OSM coordinates put the Oide Wiesn tents (48.1278 to 48.1288) south of the main tents (48.1300 to 48.1354), which matches the real layout. The existing fabricated coordinates put them to the east, which is wrong.
+
+- [ ] **Step 2: Record the outcome**
+
+If approved, proceed to Task 2. If any cell is corrected, update the table in this plan file first, then proceed. If rejected, STOP.
+
+---
+
+## Task 2: Write the migration
+
+**Pre-check:** Verify `supabase/migrations/20260409174404_add_fruehlingsfest_2026.sql` exists and `git branch --show-current` prints `feat/oktoberfest-2026-and-bulletin-tracking`. If not, STOP.
+
+**Files:**
+- Create: `supabase/migrations/<generated_timestamp>_add_oktoberfest_2026.sql`
+
+**Interfaces:**
+- Consumes: the approved table from Task 1.
+- Produces: a migration file path, used by Tasks 3, 4 and 5.
+
+- [ ] **Step 1: Generate the migration file**
+
+```bash
+pnpm sup:mig:new add_oktoberfest_2026
+```
+
+This prints the created path. Use that exact path for the next step. Do not rename it.
+
+- [ ] **Step 2: Write the full migration**
+
+Write exactly this content into the generated file:
+
+```sql
+-- Add Oktoberfest 2026 (191st Wiesn) and replace fabricated tent coordinates.
+-- Dates: 19 September to 4 October 2026 (16 days).
+--
+-- Coordinates come from OpenStreetMap via the Overpass API (ODbL, snapshot 2026-08-04).
+-- They replace the placeholder coordinates added in
+-- 20260126000000_postgis_tent_coordinates.sql, which that migration's own comment called
+-- "approximate": they were laid out along a synthetic diagonal and were wrong by up to ~900 m.
+-- The existing tent_location_trigger keeps the PostGIS `location` column in sync from
+-- latitude/longitude, so no geometry is written by hand here.
+
+BEGIN;
+
+-- Step 1: Only one festival may be active (idx_festivals_single_active is a unique partial
+-- index), so clear the current holder before inserting. Frühlingsfest 2026 is active today
+-- despite having ended in May.
+UPDATE festivals SET is_active = false WHERE is_active = true;
+
+-- Step 2: New tents for 2026.
+-- Bartls Flößerstadl (398 seats) takes over the Münchner Stubn plot, so it inherits that
+-- position. Münchner Stubn itself is not linked to 2026.
+INSERT INTO tents (id, name, category, latitude, longitude) VALUES
+  ('c0000000-0000-4000-b000-000000000001', 'Bartls Flößerstadl', 'small', 48.13138, 11.54925),
+  ('c0000000-0000-4000-b000-000000000002', 'Hühnerbraterei Poschner', 'small', 48.13266, 11.54864)
+ON CONFLICT (id) DO NOTHING;
+
+-- Step 3: Fix the long-standing misspelling.
+UPDATE tents SET name = 'Museumszelt'
+WHERE id = '655190b1-ca0d-4d5a-8def-74f8a20f1e2b';
+
+-- Step 4: Replace fabricated coordinates with OSM-sourced ones, for the 2026 lineup only.
+-- Tents belonging to other festivals are deliberately untouched.
+UPDATE tents AS t SET latitude = v.lat, longitude = v.lon
+FROM (VALUES
+  -- Large tents
+  ('55ff3af6-f1d6-481a-a8f4-58fa23f00f68'::uuid, 48.13474, 11.54871), -- Armbrustschützen Festzelt
+  ('631abb99-4237-4bbc-94d7-2a6c18e11e25'::uuid, 48.13286, 11.55006), -- Augustiner-Festhalle
+  ('9eb72005-8026-4665-be77-4a61fbcc3fa1'::uuid, 48.13217, 11.54814), -- Festhalle Schottenhamel
+  ('da36b13f-1e75-4299-9f75-1de4eb38b416'::uuid, 48.13484, 11.55018), -- Fischer-Vroni
+  ('282d326c-0e14-43e2-b8c6-9bf098a0fde6'::uuid, 48.13305, 11.54816), -- Hacker-Festzelt
+  ('253eb29d-8efe-4095-9671-4eff02704c4a'::uuid, 48.13390, 11.54841), -- Hofbräu-Festzelt
+  ('37ad3fc4-9d52-4e19-91c7-a01ed11c6854'::uuid, 48.13030, 11.54729), -- Käfer Wiesn-Schänke
+  ('2661d289-5ecd-42a0-9a59-eaf5ef94f92d'::uuid, 48.13006, 11.54988), -- Kufflers Weinzelt
+  ('dd7b4b6d-7a57-411a-baf8-8c0d20682b64'::uuid, 48.13098, 11.54969), -- Löwenbräu-Festzelt
+  ('49449d2f-c9b7-4b8b-9ed7-889690493c3d'::uuid, 48.13537, 11.54906), -- Marstall-Festzelt
+  ('017977ea-a9c3-4865-b494-edc49efc6212'::uuid, 48.13412, 11.55041), -- Ochsenbraterei
+  ('0935a117-4fe2-46fb-b8fa-fc45d9496af9'::uuid, 48.13117, 11.54788), -- Paulaner Festzelt
+  ('4d140654-f235-44b8-8d6e-8f23e57274a2'::uuid, 48.13195, 11.54992), -- Pschorr-Festzelt Bräurosl
+  ('5deac267-6401-437f-adae-e81769e4e781'::uuid, 48.13124, 11.54692), -- Schützen-Festzelt
+  -- Oide Wiesn
+  ('907342a2-ab22-4b27-8ebd-f7225a4d13e7'::uuid, 48.12876, 11.54607), -- Boandlkramerei
+  ('f2df3186-ec0d-467f-a560-fffa48a72897'::uuid, 48.12863, 11.54748), -- Festzelt Tradition
+  ('655190b1-ca0d-4d5a-8def-74f8a20f1e2b'::uuid, 48.12781, 11.54727), -- Museumszelt
+  ('e61d04d2-6a16-4069-bf79-85dcf4827c94'::uuid, 48.12837, 11.54617), -- Volkssängerzelt Schützenlisl
+  -- Small tents
+  ('bbbf2c29-7b2e-487a-bcfc-c4b75547f83a'::uuid, 48.13340, 11.55039), -- Bodo's Cafézelt
+  ('1764c5e2-6f01-4119-a55a-7d0efe3ae861'::uuid, 48.13222, 11.55073), -- Café Theres'
+  ('28a517af-f440-4102-9ad3-beaed8347061'::uuid, 48.13135, 11.54857), -- Feisingers Kas- und Weinstubn
+  ('f8e94181-3a63-4e68-9285-588038be343f'::uuid, 48.13144, 11.55080), -- Fisch-Bäda
+  ('6fcea9eb-c5c5-4d8f-9363-cbd86119128e'::uuid, 48.13147, 11.54852), -- Glöckle-Wirt
+  ('f02ae7eb-3c8c-4e38-ae4a-7b0f9fc5e404'::uuid, 48.13325, 11.54892), -- Goldener Hahn
+  ('6d4e022d-c033-4a56-a19b-441dfe8430fd'::uuid, 48.13325, 11.55104), -- Heimer Enten- und Hühnerbraterei
+  ('e2eae4f6-8da8-46db-b76a-d1fb50eca8f6'::uuid, 48.13171, 11.54857), -- Heinz Wurst- und Hühnerbraterei
+  ('ecaae5eb-9745-4359-826a-9a14aa91591b'::uuid, 48.13343, 11.54889), -- Hochreiters Haxnbraterei
+  ('24b50db1-f7c1-4132-a07c-00ad2cb8c2e1'::uuid, 48.13345, 11.54979), -- Hühner- und Entenbraterei Ammer
+  ('2196e0ea-1262-4f2c-97ef-bcd67104ae72'::uuid, 48.13232, 11.54938), -- Kalbsbraterei
+  ('0898010d-693f-47be-b8f2-5916ad5a56d0'::uuid, 48.12919, 11.54917), -- Münchner Knödelei
+  ('cb0a2849-159f-48f6-902f-fba73ae9c9a2'::uuid, 48.13067, 11.55050), -- Rischart's Café Kaiserschmarrn
+  ('014c7c7e-f904-4fcc-931f-2b80c9ceff2b'::uuid, 48.13416, 11.54924), -- Schiebl's Kaffeehaferl
+  ('949ee890-ee80-406c-af23-ded34e838b44'::uuid, 48.13437, 11.54922), -- Vinzenzmurr Metzger Stubn
+  ('5162f382-2321-495c-b723-942a4708811e'::uuid, 48.13008, 11.55243), -- Wildstuben
+  ('b349fe59-e104-42f1-9157-1859d829c1fa'::uuid, 48.13387, 11.55242), -- Wirtshaus im Schichtl
+  ('387574a0-8c63-4bf0-a4d0-a0bc37158ddd'::uuid, 48.13029, 11.55261)  -- Zur Bratwurst
+) AS v(id, lat, lon)
+WHERE t.id = v.id;
+
+-- Step 5: Two 2026 tents have no trustworthy coordinate source. NULL them rather than keep
+-- fabricated values: get_nearby_tents filters on `location IS NOT NULL`, so they are simply
+-- omitted from proximity results instead of pointing users at the wrong place.
+UPDATE tents SET latitude = NULL, longitude = NULL
+WHERE id IN (
+  'a20effb6-612e-4085-8de0-6fbc0dff1dc1', -- Münchner Weißbiergarten
+  '7b91d421-5052-4109-b47f-8136f3bb9a89'  -- Wiesn Guglhupf
+);
+
+-- Step 6: The festival itself. status 'upcoming' matches the runtime value that
+-- packages/shared/src/utils/festival-status.ts derives from the dates.
+INSERT INTO festivals (
+  name, short_name, festival_type, location,
+  start_date, end_date, map_url,
+  is_active, status, description,
+  beer_cost, default_beer_price_cents,
+  latitude, longitude
+) VALUES (
+  'Oktoberfest 2026',
+  'oktoberfest-2026',
+  'oktoberfest',
+  'Munich, Germany',
+  '2026-09-19',
+  '2026-10-04',
+  'https://www.muenchen.de/en/events/oktoberfest',
+  true,
+  'upcoming',
+  'The 191st Oktoberfest on the Theresienwiese, 16 days from 19 September to 4 October 2026',
+  15.80,
+  1580,
+  48.1314,
+  11.5498
+);
+
+-- Step 7: Link the 40 tents of the 2026 lineup with their Maß prices. Tents with no published
+-- 2026 price carry the 1580 base.
+INSERT INTO festival_tents (festival_id, tent_id, beer_price, beer_price_cents)
+SELECT
+  (SELECT id FROM festivals WHERE short_name = 'oktoberfest-2026'),
+  v.tent_id,
+  v.cents / 100.0,
+  v.cents
+FROM (VALUES
+  -- Large tents
+  ('55ff3af6-f1d6-481a-a8f4-58fa23f00f68'::uuid, 1590), -- Armbrustschützen Festzelt
+  ('631abb99-4237-4bbc-94d7-2a6c18e11e25'::uuid, 1490), -- Augustiner-Festhalle
+  ('9eb72005-8026-4665-be77-4a61fbcc3fa1'::uuid, 1580), -- Festhalle Schottenhamel
+  ('da36b13f-1e75-4299-9f75-1de4eb38b416'::uuid, 1575), -- Fischer-Vroni
+  ('282d326c-0e14-43e2-b8c6-9bf098a0fde6'::uuid, 1580), -- Hacker-Festzelt
+  ('253eb29d-8efe-4095-9671-4eff02704c4a'::uuid, 1580), -- Hofbräu-Festzelt
+  ('37ad3fc4-9d52-4e19-91c7-a01ed11c6854'::uuid, 1580), -- Käfer Wiesn-Schänke
+  ('2661d289-5ecd-42a0-9a59-eaf5ef94f92d'::uuid, 1780), -- Kufflers Weinzelt
+  ('dd7b4b6d-7a57-411a-baf8-8c0d20682b64'::uuid, 1590), -- Löwenbräu-Festzelt
+  ('49449d2f-c9b7-4b8b-9ed7-889690493c3d'::uuid, 1580), -- Marstall-Festzelt
+  ('017977ea-a9c3-4865-b494-edc49efc6212'::uuid, 1580), -- Ochsenbraterei
+  ('0935a117-4fe2-46fb-b8fa-fc45d9496af9'::uuid, 1580), -- Paulaner Festzelt
+  ('4d140654-f235-44b8-8d6e-8f23e57274a2'::uuid, 1590), -- Pschorr-Festzelt Bräurosl
+  ('5deac267-6401-437f-adae-e81769e4e781'::uuid, 1580), -- Schützen-Festzelt
+  -- Oide Wiesn
+  ('907342a2-ab22-4b27-8ebd-f7225a4d13e7'::uuid, 1530), -- Boandlkramerei
+  ('f2df3186-ec0d-467f-a560-fffa48a72897'::uuid, 1580), -- Festzelt Tradition
+  ('655190b1-ca0d-4d5a-8def-74f8a20f1e2b'::uuid, 1480), -- Museumszelt
+  ('e61d04d2-6a16-4069-bf79-85dcf4827c94'::uuid, 1490), -- Volkssängerzelt Schützenlisl
+  -- Small tents
+  ('c0000000-0000-4000-b000-000000000001'::uuid, 1570), -- Bartls Flößerstadl
+  ('bbbf2c29-7b2e-487a-bcfc-c4b75547f83a'::uuid, 1580), -- Bodo's Cafézelt
+  ('1764c5e2-6f01-4119-a55a-7d0efe3ae861'::uuid, 1580), -- Café Theres'
+  ('28a517af-f440-4102-9ad3-beaed8347061'::uuid, 1580), -- Feisingers Kas- und Weinstubn
+  ('f8e94181-3a63-4e68-9285-588038be343f'::uuid, 1580), -- Fisch-Bäda
+  ('6fcea9eb-c5c5-4d8f-9363-cbd86119128e'::uuid, 1580), -- Glöckle-Wirt
+  ('f02ae7eb-3c8c-4e38-ae4a-7b0f9fc5e404'::uuid, 1580), -- Goldener Hahn
+  ('6d4e022d-c033-4a56-a19b-441dfe8430fd'::uuid, 1580), -- Heimer Enten- und Hühnerbraterei
+  ('e2eae4f6-8da8-46db-b76a-d1fb50eca8f6'::uuid, 1580), -- Heinz Wurst- und Hühnerbraterei
+  ('ecaae5eb-9745-4359-826a-9a14aa91591b'::uuid, 1570), -- Hochreiters Haxnbraterei
+  ('24b50db1-f7c1-4132-a07c-00ad2cb8c2e1'::uuid, 1495), -- Hühner- und Entenbraterei Ammer
+  ('c0000000-0000-4000-b000-000000000002'::uuid, 1580), -- Hühnerbraterei Poschner
+  ('2196e0ea-1262-4f2c-97ef-bcd67104ae72'::uuid, 1580), -- Kalbsbraterei
+  ('0898010d-693f-47be-b8f2-5916ad5a56d0'::uuid, 1580), -- Münchner Knödelei
+  ('a20effb6-612e-4085-8de0-6fbc0dff1dc1'::uuid, 1480), -- Münchner Weißbiergarten
+  ('cb0a2849-159f-48f6-902f-fba73ae9c9a2'::uuid, 1580), -- Rischart's Café Kaiserschmarrn
+  ('014c7c7e-f904-4fcc-931f-2b80c9ceff2b'::uuid, 1580), -- Schiebl's Kaffeehaferl
+  ('949ee890-ee80-406c-af23-ded34e838b44'::uuid, 1580), -- Vinzenzmurr Metzger Stubn
+  ('7b91d421-5052-4109-b47f-8136f3bb9a89'::uuid, 1580), -- Wiesn Guglhupf
+  ('5162f382-2321-495c-b723-942a4708811e'::uuid, 1580), -- Wildstuben
+  ('b349fe59-e104-42f1-9157-1859d829c1fa'::uuid, 1490), -- Wirtshaus im Schichtl
+  ('387574a0-8c63-4bf0-a4d0-a0bc37158ddd'::uuid, 1570)  -- Zur Bratwurst
+) AS v(tent_id, cents);
+
+-- Step 8: Festival-level drink prices from the 1580 base, using the same ratios as
+-- 20260409174404_add_fruehlingsfest_2026.sql.
+DO $$
+DECLARE
+  v_festival_id uuid;
+  v_base_price integer := 1580;
+BEGIN
+  SELECT id INTO v_festival_id FROM festivals WHERE short_name = 'oktoberfest-2026';
+
+  INSERT INTO drink_type_prices (festival_id, drink_type, price_cents) VALUES
+    (v_festival_id, 'beer', v_base_price),
+    (v_festival_id, 'radler', v_base_price),
+    (v_festival_id, 'alcohol_free', ROUND(v_base_price * 0.90)::integer),
+    (v_festival_id, 'wine', ROUND(v_base_price * 0.85)::integer),
+    (v_festival_id, 'soft_drink', ROUND(v_base_price * 0.40)::integer),
+    (v_festival_id, 'other', v_base_price);
+END $$;
+
+-- Step 9: Per-tent beer and radler overrides, only where the tent price differs from the base.
+INSERT INTO drink_type_prices (festival_tent_id, drink_type, price_cents)
+SELECT ft.id, d.drink_type, ft.beer_price_cents
+FROM festival_tents ft
+CROSS JOIN (VALUES ('beer'::drink_type), ('radler'::drink_type)) AS d(drink_type)
+WHERE ft.festival_id = (SELECT id FROM festivals WHERE short_name = 'oktoberfest-2026')
+  AND ft.beer_price_cents <> 1580;
+
+COMMIT;
+```
+
+- [ ] **Step 3: Commit the migration file**
+
+```bash
+git add supabase/migrations
+git commit -m "feat(db): add Oktoberfest 2026 with OSM tent coordinates"
+```
+
+---
+
+## Task 3: Verify the migration against local
+
+**Pre-check:** Verify local Supabase is running (`pnpm sup:start` if not) and that the migration file from Task 2 exists. If not, STOP.
+
+**Files:** none created. Read-only verification plus one migration application.
+
+**Interfaces:**
+- Consumes: the migration file from Task 2.
+- Produces: confirmation that the SQL is correct. Task 4 depends on this passing.
+
+- [ ] **Step 1: Run the verification query BEFORE applying, to confirm it fails**
+
+Run with `mcp__supabase-local__execute_sql`:
+
+```sql
+SELECT
+  (SELECT count(*) FROM festivals WHERE short_name = 'oktoberfest-2026') AS festival_exists,
+  (SELECT count(*) FROM festival_tents ft JOIN festivals f ON f.id = ft.festival_id
+   WHERE f.short_name = 'oktoberfest-2026') AS linked_tents;
+```
+
+Expected: `festival_exists = 0`, `linked_tents = 0`.
+
+If `festival_exists` is already 1, the migration was partly applied. STOP.
+
+- [ ] **Step 2: Apply the migration to local**
+
+Paste the full migration body from Task 2 Step 2 into `mcp__supabase-local__execute_sql`.
+
+Expected: success, no error. If it raises a unique violation on `idx_festivals_single_active`, Step 1 of the migration did not run; STOP and report.
+
+- [ ] **Step 3: Run the verification query again, expecting exact values**
+
+```sql
+SELECT
+  (SELECT count(*) FROM festivals WHERE short_name = 'oktoberfest-2026') AS festival_exists,
+  (SELECT count(*) FROM festivals WHERE is_active) AS active_count,
+  (SELECT short_name FROM festivals WHERE is_active) AS active_festival,
+  (SELECT count(*) FROM festival_tents ft JOIN festivals f ON f.id = ft.festival_id
+   WHERE f.short_name = 'oktoberfest-2026') AS linked_tents,
+  (SELECT count(*) FROM festival_tents ft JOIN festivals f ON f.id = ft.festival_id
+   WHERE f.short_name = 'oktoberfest-2026' AND ft.beer_price_cents IS NULL) AS tents_missing_price,
+  (SELECT count(*) FROM drink_type_prices dtp JOIN festivals f ON f.id = dtp.festival_id
+   WHERE f.short_name = 'oktoberfest-2026') AS festival_drink_prices,
+  (SELECT count(*) FROM drink_type_prices dtp JOIN festival_tents ft ON ft.id = dtp.festival_tent_id
+   JOIN festivals f ON f.id = ft.festival_id WHERE f.short_name = 'oktoberfest-2026') AS tent_overrides,
+  (SELECT count(*) FROM tents WHERE name = 'Museumzelt') AS old_typo_remaining,
+  (SELECT count(*) FROM tents t JOIN festival_tents ft ON ft.tent_id = t.id
+   JOIN festivals f ON f.id = ft.festival_id
+   WHERE f.short_name = 'oktoberfest-2026' AND t.location IS NULL) AS tents_without_geometry;
+```
+
+Expected exactly:
+
+| Column | Expected |
+|---|---|
+| `festival_exists` | 1 |
+| `active_count` | 1 |
+| `active_festival` | `oktoberfest-2026` |
+| `linked_tents` | 40 |
+| `tents_missing_price` | 0 |
+| `festival_drink_prices` | 6 |
+| `tent_overrides` | 30 |
+| `old_typo_remaining` | 0 |
+| `tents_without_geometry` | 2 |
+
+`tent_overrides` is 30 because 15 tents differ from the 1580 base and each gets a `beer` and a `radler` row. `tents_without_geometry` is 2: Münchner Weißbiergarten and Wiesn Guglhupf.
+
+Any mismatch: STOP and report which column differed.
+
+- [ ] **Step 4: Confirm the trigger populated PostGIS geometry**
+
+```sql
+SELECT t.name, t.latitude, t.longitude,
+       extensions.ST_AsText(t.location) AS geom
+FROM tents t
+WHERE t.id IN (
+  '49449d2f-c9b7-4b8b-9ed7-889690493c3d',
+  'c0000000-0000-4000-b000-000000000001'
+);
+```
+
+Expected: Marstall-Festzelt at `48.13537, 11.54906` with geom `POINT(11.54906 48.13537)`, and Bartls Flößerstadl at `48.13138, 11.54925` with geom `POINT(11.54925 48.13138)`. Note longitude comes first in WKT.
+
+If `geom` is NULL, `tent_location_trigger` did not fire. STOP.
+
+- [ ] **Step 5: Confirm price resolution works end to end**
+
+```sql
+SELECT
+  t.name,
+  ft.beer_price_cents,
+  public.get_drink_price_cents(f.id, t.id, 'beer'::drink_type) AS resolved_beer,
+  public.get_drink_price_cents(f.id, t.id, 'soft_drink'::drink_type) AS resolved_soft
+FROM festival_tents ft
+JOIN tents t ON t.id = ft.tent_id
+JOIN festivals f ON f.id = ft.festival_id
+WHERE f.short_name = 'oktoberfest-2026'
+  AND t.id IN (
+    '2661d289-5ecd-42a0-9a59-eaf5ef94f92d', -- Kufflers Weinzelt, override 1780
+    '9eb72005-8026-4665-be77-4a61fbcc3fa1'  -- Schottenhamel, base 1580
+  )
+ORDER BY t.name;
+```
+
+Expected: Kufflers Weinzelt `resolved_beer = 1780`, Schottenhamel `resolved_beer = 1580`, both `resolved_soft = 632`.
+
+The signature was verified against production during planning as
+`get_drink_price_cents(p_festival_id uuid, p_tent_id uuid DEFAULT NULL, p_drink_type drink_type DEFAULT 'beer')`,
+so the positional call above is correct. If local reports a different signature, STOP and report it rather than guessing.
+
+---
+
+## Task 4: [HUMAN] Prove the full migration chain, then push to production
+
+Human-gated because `pnpm sup:db:reset` wipes the shared local instance other agents may be using, and `pnpm sup:db:push` writes to production.
+
+**Pre-check:** Task 3 passed with every expected value matching. If not, STOP.
+
+**Files:** none.
+
+**Interfaces:**
+- Consumes: verified migration from Task 3.
+- Produces: Oktoberfest 2026 live in production.
+
+- [ ] **Step 1: [HUMAN] Confirm nobody else is using the local Supabase instance**
+
+Ask before running the reset. If unsure, STOP.
+
+- [ ] **Step 2: Prove the whole chain replays cleanly**
+
+```bash
+pnpm sup:db:reset
+```
+
+Expected: completes with no error, all migrations applied in order.
+
+If it fails on the new migration, the SQL is order-dependent in a way Task 3 masked (Task 3 applied it to an already-migrated DB). STOP and report the error.
+
+- [ ] **Step 3: Re-run the Task 3 Step 3 verification query against local**
+
+Expected: the same nine values as Task 3 Step 3. Seed data may add festivals, so if `active_count` is not 1, report what else is active rather than assuming.
+
+- [ ] **Step 4: [HUMAN] Push to production**
+
+```bash
+pnpm sup:db:push
+```
+
+Review the list of migrations it intends to apply before confirming. It should be only the new `add_oktoberfest_2026` file. If it wants to apply anything else, STOP.
+
+- [ ] **Step 5: Verify production**
+
+Run the Task 3 Step 3 verification query with `mcp__supabase-remote__execute_sql`. Expected: identical nine values.
+
+- [ ] **Step 6: [HUMAN] Confirm the app renders correctly**
+
+Load the app, check the home screen shows a "starts in N days" info alert naming Oktoberfest 2026, and that the tent list is populated. If it shows Frühlingsfest or an error, STOP.
+
+---
+
+## Task 5: Create the news. sending domain with tracking
+
+**Pre-check:** Confirm with `mcp__resend__list-domains` that `account.prostcounter.fun` still shows `Open Tracking: false` and `Click Tracking: false`. If either is true, someone changed it; STOP.
+
+**Files:** none.
+
+**Interfaces:**
+- Produces: a verified `news.prostcounter.fun` domain ID, consumed by Task 7.
+
+- [ ] **Step 1: Create the domain**
+
+Call `mcp__resend__create-domain` with name `news.prostcounter.fun` and region `eu-west-1`.
+
+Record the returned domain ID and the full DNS record list. The records will follow the pattern already present for `account.`: a DKIM `TXT` at `resend._domainkey.news`, an SPF `TXT` at `send.news`, and an `MX` at `send.news` pointing to `feedback-smtp.eu-west-1.amazonses.com` with priority 10.
+
+- [ ] **Step 2: Add each returned DNS record via the Vercel CLI**
+
+Use the values Resend returned, not the illustrative ones below. The command shape is
+`vercel dns add <domain> <subdomain> <type> <value> [priority]`:
+
+```bash
+vercel dns add prostcounter.fun resend._domainkey.news TXT "<dkim-value-from-resend>"
+vercel dns add prostcounter.fun send.news TXT "v=spf1 include:amazonses.com ~all"
+vercel dns add prostcounter.fun send.news MX feedback-smtp.eu-west-1.amazonses.com 10
+```
+
+If Resend returns a record whose name, type or value differs from this shape, use Resend's version and note the difference. If it returns a fourth record, add it too.
+
+- [ ] **Step 3: Confirm the records resolve**
+
+```bash
+dig +short TXT resend._domainkey.news.prostcounter.fun
+dig +short TXT send.news.prostcounter.fun
+dig +short MX send.news.prostcounter.fun
+```
+
+Expected: each returns the value just added. Vercel DNS propagates in seconds; if still empty after two minutes, STOP.
+
+- [ ] **Step 4: Verify the domain in Resend**
+
+Call `mcp__resend__verify-domain` with the domain ID, then `mcp__resend__get-domain` to check status.
+
+Expected: status `verified`. If `pending` after a few minutes, re-check. If `failed`, STOP.
+
+- [ ] **Step 5: Enable open and click tracking on the new domain only**
+
+Call `mcp__resend__update-domain` with the `news.prostcounter.fun` domain ID, `openTracking: true`, `clickTracking: true`.
+
+Do NOT pass a `trackingSubdomain`. Do NOT call update-domain against `account.prostcounter.fun`.
+
+- [ ] **Step 6: Confirm both domains are in the right state**
+
+Call `mcp__resend__list-domains`.
+
+Expected: `news.prostcounter.fun` verified with both tracking flags true, AND `account.prostcounter.fun` still with both flags false. If `account.` changed, STOP immediately; that affects password resets.
+
+---
+
+## Task 6: [HUMAN] Obtain the Apple campaign link
+
+Human-gated: requires an authenticated App Store Connect session and interactive navigation.
+
+**Files:** none.
+
+**Interfaces:**
+- Produces: either a provider token (`pt`) value, or an explicit "no token" outcome. Consumed by Task 7.
+
+- [ ] **Step 1: [HUMAN] Navigate to the campaign generator**
+
+Using the `mcp__chrome-devtools-existing__*` tools against the already-authenticated browser, go to App Store Connect, then App Analytics for ProstCounter, then Acquisition, then Campaigns.
+
+- [ ] **Step 2: [HUMAN] Create a campaign named `aug2026-whatsnew` and copy the generated link**
+
+The generated link has the shape
+`https://apps.apple.com/app/prostcounter/id6758376527?pt=<provider-token>&ct=aug2026-whatsnew&mt=8`.
+
+Record the exact link.
+
+- [ ] **Step 3: Record the outcome for Task 7**
+
+If a link was obtained, Task 7 uses it verbatim. If the campaign generator is not available on this account, record "no Apple token" and Task 7 uses the bare URL `https://apps.apple.com/app/prostcounter/id6758376527` with no parameters, per Open Questions Resolved. Do not construct a `ct`-only URL.
+
+---
+
+## Task 7: Add campaign parameters to both broadcasts and snapshot the HTML
+
+**Pre-check:** Task 5 finished with `news.prostcounter.fun` verified and tracking enabled. Confirm both draft broadcasts still exist and are `status: draft` via `mcp__resend__list-broadcasts`. If either is `sent`, STOP.
+
+**Files:**
+- Create: `docs/email/2026-08-bulletin.html`
+
+**Interfaces:**
+- Consumes: the Apple link decision from Task 6, the verified domain from Task 5.
+- Produces: two updated draft broadcasts, ready to send in Tasks 8 and 9.
+
+The three URLs, used in both the HTML and plain-text bodies:
+
+- Web: `https://prostcounter.fun/?utm_source=email&utm_medium=bulletin&utm_campaign=aug2026-whatsnew&utm_content=web`
+- Play: `https://play.google.com/store/apps/details?id=com.prostcounter.app&referrer=utm_source%3Demail%26utm_medium%3Dbulletin%26utm_campaign%3Daug2026-whatsnew`
+- Apple: the Task 6 link, or the bare URL if no token.
+
+- [ ] **Step 1: Fetch the current HTML and text of Batch 1**
+
+Call `mcp__resend__get-broadcast` with `d193c030-d7a4-4ff9-b42c-93dc3bdf2940`. Save both bodies locally so the only diff you introduce is the URLs.
+
+- [ ] **Step 2: Replace the three URLs in both bodies**
+
+In the HTML there are FIVE occurrences to change, not three, because the App Store and Play buttons each appear twice: once in an `<!--[if mso]>` VML `<v:roundrect href="...">` block for Outlook and once in the normal `<a href="...">`. Update every one.
+
+Occurrences to replace:
+1. `<v:roundrect ... href="https://apps.apple.com/app/prostcounter/id6758376527"` → Apple link
+2. `<a href="https://apps.apple.com/app/prostcounter/id6758376527"` → Apple link
+3. `<v:roundrect ... href="https://play.google.com/store/apps/details?id=com.prostcounter.app"` → Play link
+4. `<a href="https://play.google.com/store/apps/details?id=com.prostcounter.app"` → Play link
+5. `<a href="https://prostcounter.fun"` → web link
+
+In the plain text, replace the three bare URLs on the "Get it on the App Store:", "Get it on Google Play:" and "Open ProstCounter on the web:" lines.
+
+Change nothing else. Do not touch `{{{FIRST_NAME|there}}}` or `{{{RESEND_UNSUBSCRIBE_URL}}}`.
+
+Note: the Play URL already contains a `?`, so `referrer` is appended with `&`. The web URL has no query string, so it uses `/?`.
+
+- [ ] **Step 3: Update Batch 1**
+
+Call `mcp__resend__update-broadcast` with:
+- `broadcastId`: `d193c030-d7a4-4ff9-b42c-93dc3bdf2940`
+- `from`: `Ignacio from ProstCounter <ignacio@news.prostcounter.fun>`
+- `segmentId`: `ab9269de-d777-42e3-a22e-3c67fe0d589b`
+- `html` and `text`: the updated bodies
+
+`from` and `segmentId` must be included even though they are already set; the API requires them on update.
+
+- [ ] **Step 4: Update Batch 2 with the identical bodies**
+
+Same call, with:
+- `broadcastId`: `455968b3-3358-46fa-95c6-bc01fe2dae87`
+- `segmentId`: `e998142d-d562-4a5a-8778-8a582253ec20`
+- same `from`, `html`, `text`
+
+- [ ] **Step 5: Verify both broadcasts**
+
+Call `mcp__resend__get-broadcast` for each ID. Confirm for both: `from` is the `news.` address, the subject is unchanged (`ProstCounter now has real apps (and a few other things worth checking out)`), all five HTML URLs carry parameters, and status is still `draft`.
+
+- [ ] **Step 6: Write the HTML snapshot to the repo**
+
+Create `docs/email/2026-08-bulletin.html` containing the final HTML, prefixed with:
+
+```html
+<!--
+  Snapshot of the August 2026 "what's new" bulletin, as sent.
+  Resend is the source of truth for what actually shipped; this file is a
+  point-in-time copy kept so a future bulletin starts from an edit rather than
+  a rebuild. It is not read by any code and is not kept in sync automatically.
+
+  Campaign: aug2026-whatsnew
+  Sent from: ignacio@news.prostcounter.fun
+  Broadcasts: d193c030-d7a4-4ff9-b42c-93dc3bdf2940 (batch 1),
+              455968b3-3358-46fa-95c6-bc01fe2dae87 (batch 2)
+-->
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add docs/email/2026-08-bulletin.html
+git commit -m "docs(email): snapshot Aug 2026 bulletin with campaign params"
+```
+
+---
+
+## Task 8: [HUMAN] Test send and verify tracking
+
+Human-gated: requires reading a real inbox and judging rendering.
+
+**Pre-check:** Task 7 Step 5 passed. If not, STOP.
+
+**Files:** none.
+
+- [ ] **Step 1: Send a test to the author's own address**
+
+Use `mcp__resend__send-email` with `from: Ignacio from ProstCounter <ignacio@news.prostcounter.fun>`, `to: ignacioguri@gmail.com`, the exact subject and HTML from the updated broadcast.
+
+Note: a direct send will not include the `{{{FIRST_NAME|there}}}` or `{{{RESEND_UNSUBSCRIBE_URL}}}` substitutions, which only resolve for broadcasts. Replace those two tokens with `there` and `https://example.com/unsub` for the test only. Do not save that version anywhere.
+
+- [ ] **Step 2: [HUMAN] Check the delivered email**
+
+Confirm: header renders with the yellow background and the app icon loads; body text is unchanged; all three buttons render; nothing shows a raw template token.
+
+- [ ] **Step 3: [HUMAN] Verify link rewriting preserves parameters**
+
+Hover or long-press each button. Each href should now be a Resend tracking URL rather than the raw destination, which proves click tracking is active. Click each one and confirm the final landed URL still carries its parameters: the web link keeps its four `utm_*` params, the Play link keeps `referrer`, the Apple link keeps `pt`/`ct`/`mt` if a token was obtained.
+
+If a link lands without its parameters, STOP. Store-side attribution would be silently broken.
+
+- [ ] **Step 4: Confirm the send is healthy in Resend**
+
+Call `mcp__resend__list-emails` with `limit: 5`. Expected: the test email present with status `delivered`. If `bounced` or `complained`, STOP.
+
+---
+
+## Task 9: [HUMAN] Send both batches and verify delivery
+
+Human-gated: irreversible outward-facing send to 139 real people. Requires explicit go-ahead immediately before each send, not carried over from earlier approval.
+
+**Pre-check:** Task 4 finished (Oktoberfest 2026 live in production) AND Task 8 passed. Both are required. The email drives people into the app, so the festival must be correct before anyone clicks. If Task 4 is incomplete, STOP.
+
+**Files:** none.
+
+- [ ] **Step 1: [HUMAN] Get explicit go-ahead for Batch 1**
+
+Confirm the human wants Batch 1 (96 recipients) sent now. Do not proceed on prior approval alone.
+
+- [ ] **Step 2: Send Batch 1**
+
+Call `mcp__resend__send-broadcast` with `broadcastId: d193c030-d7a4-4ff9-b42c-93dc3bdf2940` and no `scheduledAt`.
+
+- [ ] **Step 3: Verify Batch 1 went out**
+
+Call `mcp__resend__get-broadcast` on the same ID. Expected: status is no longer `draft`, and `sent_at` is populated.
+
+Then `mcp__resend__list-emails` with `limit: 100`. Check the delivered-to-bounced ratio. A handful of bounces on a lapsed list is normal; more than roughly 10 percent is not. If bounces are high, STOP before scheduling Batch 2.
+
+- [ ] **Step 4: Schedule Batch 2 for roughly 26 hours later**
+
+Call `mcp__resend__send-broadcast` with `broadcastId: 455968b3-3358-46fa-95c6-bc01fe2dae87` and `scheduledAt: "in 26 hours"`.
+
+26 hours rather than 24 because the free tier caps at 100 emails per day and PAUSES rather than queueing once hit. Batch 1 uses 96 of today's 100, so the buffer matters.
+
+- [ ] **Step 5: Confirm Batch 2 is scheduled**
+
+Call `mcp__resend__get-broadcast` on the Batch 2 ID. Expected: `scheduled_at` populated roughly 26 hours out, status `scheduled`.
+
+- [ ] **Step 6: [HUMAN] Verify Batch 2 after it fires**
+
+More than 26 hours later, call `mcp__resend__get-broadcast` and `mcp__resend__list-emails`. Confirm Batch 2 sent and delivery is healthy.
+
+- [ ] **Step 7: [HUMAN] Optional follow-up, place the two missing tents**
+
+`Münchner Weißbiergarten` and `Wiesn Guglhupf` have NULL coordinates. If wanted, read their positions off the official Wiesn map and write a small follow-up migration. Not required for this plan to be complete.
+
+---
+
+## Reading the results
+
+- Per-link clicks and opens: the Resend broadcast detail pages for the two broadcast IDs.
+- Web sessions and downstream behaviour: GA4, Acquisition, Traffic acquisition, filtered to `email / bulletin`.
+- Android installs: Play Console, Acquisition reports, filtered by `utm_campaign = aug2026-whatsnew`.
+- iOS installs: App Store Connect, App Analytics, Campaigns, campaign `aug2026-whatsnew`. Only populated if Task 6 produced a token.

--- a/docs/plans/2026-08-04-oktoberfest-2026-and-bulletin-tracking-plan.md
+++ b/docs/plans/2026-08-04-oktoberfest-2026-and-bulletin-tracking-plan.md
@@ -4,11 +4,37 @@
 
 **Goal:** Get Oktoberfest 2026 into production with correct tent data and coordinates, then send the already-drafted bulletin to 139 users with per-link and store-side attribution.
 
-**Architecture:** One SQL migration creates the festival, inserts two new tents, replaces every fabricated tent coordinate with an OpenStreetMap-sourced one, and links 40 tents with 2026 prices. Separately, a new Resend sending subdomain (`news.prostcounter.fun`) carries open/click tracking so the existing `account.prostcounter.fun` domain, which sends Supabase Auth mail, is never touched. Campaign parameters go on the three links in the two existing draft broadcasts.
+**Architecture:** One SQL migration creates the festival, inserts two new tents, replaces every fabricated tent coordinate with an OpenStreetMap-sourced one, and links 40 tents with 2026 prices. Separately, campaign parameters go on the three links in the two existing draft broadcasts, so attribution comes from the URLs themselves: GA4 for web sessions, Play Console and App Store Connect for installs. See the REVISION note below: the originally planned `news.prostcounter.fun` sending subdomain and Resend click tracking were dropped, and the existing `account.prostcounter.fun` sender stays as-is with tracking off.
 
 **Tech Stack:** Supabase (Postgres + PostGIS), Supabase CLI, Resend MCP, Vercel CLI (DNS), Chrome DevTools MCP (App Store Connect), GA4.
 
 **Stop-and-ask protocol:** If at any step you encounter state that contradicts the plan — file missing, function signature differs, test passes when expected to fail, unfamiliar code in target lines, dependency version unavailable, or any expectation in this plan does not match reality — STOP. Do not improvise, do not work around it, do not pick the closest interpretation. Report the discrepancy and wait for guidance.
+
+## REVISION 2026-08-04: no separate sending domain, no click tracking
+
+Task 5 could not be executed. Resend's free plan permits exactly one custom domain and
+`account.prostcounter.fun` holds the slot, so `create-domain` returns
+`403 "Your plan includes 1 domain. Upgrade to add more."`
+
+Options were Resend Pro at 20 USD/month, a second provider for marketing mail (Brevo, Kit,
+EmailOctopus and MailerLite were all checked; every free tier stamps its own branding on the
+email), or dropping click tracking. The decision was to drop click tracking and stay free.
+
+What this changes:
+
+- **Task 5 is cancelled.** No `news.prostcounter.fun`, no DNS records, no tracking flags. Resend
+  open and click tracking stay OFF everywhere, including on `account.prostcounter.fun`, which must
+  remain untouched.
+- **The From address stays `Ignacio from ProstCounter <ignacio@account.prostcounter.fun>`**, which is
+  what the two already-approved test sends used. Tasks 7 and 8 must NOT change it.
+- **No per-link click counts and no open rates.** Links are not rewritten, so Task 8 verifies the
+  raw hrefs carry their parameters rather than verifying a tracking redirect preserves them.
+- **The two-batch send stays.** The 100-per-day cap is a free-plan limit independent of domains.
+- **Task 6 becomes materially more important.** Without click tracking, the Apple `pt`/`ct` link is
+  the only way to learn anything about how the iOS button performed. Same for the Play `referrer`.
+
+Measurement surfaces that survive: GA4 web sessions from the `utm_*` params, Play Console installs
+from `referrer`, App Store Connect installs from `pt`/`ct`.
 
 ## Global Constraints
 
@@ -591,7 +617,18 @@ Load the app, check the home screen shows a "starts in N days" info alert naming
 
 ---
 
-## Task 5: Create the news. sending domain with tracking
+## Task 5: CANCELLED — create the news. sending domain with tracking
+
+**Do not execute this task.** See the REVISION note at the top of this plan. Resend's free plan caps
+the account at one custom domain and `account.prostcounter.fun` holds it. Nothing in this task ran:
+no domain was created, no DNS records were added, and no tracking flags were changed on any domain.
+
+`account.prostcounter.fun` must keep Open Tracking and Click Tracking both `false`. Do not call
+`mcp__resend__update-domain` against it under any circumstances.
+
+The original steps are retained below for the record only.
+
+### Original (not to be executed)
 
 **Pre-check:** Confirm with `mcp__resend__list-domains` that `account.prostcounter.fun` still shows `Open Tracking: false` and `Click Tracking: false`. If either is true, someone changed it; STOP.
 
@@ -677,12 +714,12 @@ If a link was obtained, Task 7 uses it verbatim. If the campaign generator is no
 
 ## Task 7: Add campaign parameters to both broadcasts
 
-**Pre-check:** Task 5 finished with `news.prostcounter.fun` verified and tracking enabled. Confirm both draft broadcasts still exist and are `status: draft` via `mcp__resend__list-broadcasts`. If either is `sent`, STOP.
+**Pre-check:** Confirm both draft broadcasts still exist and are `status: draft` via `mcp__resend__list-broadcasts`. If either is `sent`, STOP. Task 5 is cancelled and is NOT a prerequisite; see the REVISION note at the top of this plan.
 
 **Files:** none. The HTML snapshot file is created in Task 8.
 
 **Interfaces:**
-- Consumes: the Apple link decision from Task 6, the verified domain from Task 5.
+- Consumes: the Apple link decision from Task 6.
 - Produces: two updated draft broadcasts, ready to send in Tasks 8 and 9. The final HTML body, consumed by Task 8 Step 5.
 
 The three URLs, used in both the HTML and plain-text bodies:
@@ -716,11 +753,11 @@ Note: the Play URL already contains a `?`, so `referrer` is appended with `&`. T
 
 Call `mcp__resend__update-broadcast` with:
 - `broadcastId`: `d193c030-d7a4-4ff9-b42c-93dc3bdf2940`
-- `from`: `Ignacio from ProstCounter <ignacio@news.prostcounter.fun>`
+- `from`: `Ignacio from ProstCounter <ignacio@account.prostcounter.fun>`
 - `segmentId`: `ab9269de-d777-42e3-a22e-3c67fe0d589b`
 - `html` and `text`: the updated bodies
 
-`from` and `segmentId` must be included even though they are already set; the API requires them on update.
+`from` and `segmentId` must be included even though they are already set; the API requires them on update. The `from` value above is UNCHANGED from what the broadcast already carries, and it must stay that way: there is no `news.` domain. Do not invent a different sender.
 
 - [ ] **Step 4: Update Batch 2 with the identical bodies**
 
@@ -731,7 +768,7 @@ Same call, with:
 
 - [ ] **Step 5: Verify both broadcasts**
 
-Call `mcp__resend__get-broadcast` for each ID. Confirm for both: `from` is the `news.` address, the subject is unchanged (`ProstCounter now has real apps (and a few other things worth checking out)`), all five HTML URLs carry parameters, and status is still `draft`.
+Call `mcp__resend__get-broadcast` for each ID. Confirm for both: `from` is still `Ignacio from ProstCounter <ignacio@account.prostcounter.fun>`, the subject is unchanged (`ProstCounter now has real apps (and a few other things worth checking out)`), all five HTML URLs carry parameters, and status is still `draft`.
 
 The HTML snapshot is deliberately NOT written in this task. It lives in Task 8 Steps 5 and 6, after
 the test send has proven the HTML renders, so the committed snapshot can never be a version that was
@@ -750,7 +787,7 @@ Human-gated: requires reading a real inbox and judging rendering.
 
 - [ ] **Step 1: Send a test to the author's own address**
 
-Use `mcp__resend__send-email` with `from: Ignacio from ProstCounter <ignacio@news.prostcounter.fun>`, `to: ignacioguri@gmail.com`, the exact subject and HTML from the updated broadcast.
+Use `mcp__resend__send-email` with `from: Ignacio from ProstCounter <ignacio@account.prostcounter.fun>`, `to: ignacioguri@gmail.com`, the exact subject and HTML from the updated broadcast.
 
 Note: a direct send will not include the `{{{FIRST_NAME|there}}}` or `{{{RESEND_UNSUBSCRIBE_URL}}}` substitutions, which only resolve for broadcasts. Replace those two tokens with `there` and `https://example.com/unsub` for the test only. Do not save that version anywhere.
 
@@ -758,11 +795,20 @@ Note: a direct send will not include the `{{{FIRST_NAME|there}}}` or `{{{RESEND_
 
 Confirm: header renders with the yellow background and the app icon loads; body text is unchanged; all three buttons render; nothing shows a raw template token.
 
-- [ ] **Step 3: [HUMAN] Verify link rewriting preserves parameters**
+- [ ] **Step 3: [HUMAN] Verify each link carries its parameters**
 
-Hover or long-press each button. Each href should now be a Resend tracking URL rather than the raw destination, which proves click tracking is active. Click each one and confirm the final landed URL still carries its parameters: the web link keeps its four `utm_*` params, the Play link keeps `referrer`, the Apple link keeps `pt`/`ct`/`mt` if a token was obtained.
+Click tracking is OFF, so hrefs are NOT rewritten. Each button's href should be the raw destination
+with its parameters visible on hover or long-press. That is the expected state; a Resend tracking URL
+here would mean click tracking got enabled on `account.prostcounter.fun` by mistake, which is a STOP
+condition because it puts password-reset links at risk.
 
-If a link lands without its parameters, STOP. Store-side attribution would be silently broken.
+Confirm each href and then that each click lands correctly:
+- web link carries all four `utm_*` params
+- Play link carries `referrer` with its URL-encoded UTMs
+- Apple link carries `pt`/`ct`/`mt`, if Task 6 produced a token
+
+If a link lands without its parameters, STOP. Store-side attribution is the only iOS and Android
+signal we have left, so a dropped parameter loses the measurement entirely and silently.
 
 - [ ] **Step 4: Confirm the send is healthy in Resend**
 
@@ -784,7 +830,9 @@ Create `docs/email/2026-08-bulletin.html` prefixed with:
   a rebuild. It is not read by any code and is not kept in sync automatically.
 
   Campaign: aug2026-whatsnew
-  Sent from: ignacio@news.prostcounter.fun
+  Sent from: ignacio@account.prostcounter.fun
+  Tracking: none at the provider (Resend open/click tracking off). Attribution is
+            via URL parameters only: utm_* for GA4, referrer for Play, pt/ct for Apple.
   Broadcasts: d193c030-d7a4-4ff9-b42c-93dc3bdf2940 (batch 1),
               455968b3-3358-46fa-95c6-bc01fe2dae87 (batch 2)
 -->
@@ -891,7 +939,11 @@ git commit -m "docs: Oktoberfest 2026 tent data and sources for reference"
 
 ## Reading the results
 
-- Per-link clicks and opens: the Resend broadcast detail pages for the two broadcast IDs.
+- Delivery, bounces and complaints: the Resend broadcast detail pages for the two broadcast IDs. NOT clicks or opens; tracking is off, so Resend reports delivery only.
 - Web sessions and downstream behaviour: GA4, Acquisition, Traffic acquisition, filtered to `email / bulletin`.
 - Android installs: Play Console, Acquisition reports, filtered by `utm_campaign = aug2026-whatsnew`.
 - iOS installs: App Store Connect, App Analytics, Campaigns, campaign `aug2026-whatsnew`. Only populated if Task 6 produced a token.
+
+**Known blind spot:** there is no per-link click count and no open rate. If the web link shows GA4
+sessions but the stores show no installs, that is indistinguishable from nobody tapping the store
+buttons at all. Accepted as the cost of staying on the free plan.

--- a/docs/plans/2026-08-04-oktoberfest-2026-and-bulletin-tracking-plan.md
+++ b/docs/plans/2026-08-04-oktoberfest-2026-and-bulletin-tracking-plan.md
@@ -841,6 +841,54 @@ More than 26 hours later, call `mcp__resend__get-broadcast` and `mcp__resend__li
 
 ---
 
+## Task 10: Oktoberfest 2026 reference doc for future blog use
+
+Order-independent: can run any time after Task 1. Not a dependency of any other task.
+
+**Files:**
+- Create: `docs/festivals/oktoberfest-2026-reference.md`
+
+**Interfaces:**
+- Consumes: the approved tables in Task 1 of this plan file.
+- Produces: nothing other tasks depend on.
+
+Purpose: preserve the researched data and its provenance as raw material for a future blog post. This is a reference document, NOT a blog article. Do not write it to `apps/web/content/blog/`, do not add MDX frontmatter, and do not produce de/es translations. Those rules apply to real blog articles under `docs/BLOG.md`; this file is internal reference material only.
+
+- [ ] **Step 1: Write the reference document**
+
+Read ONLY the "Task 1" section of `docs/plans/2026-08-04-oktoberfest-2026-and-bulletin-tracking-plan.md` for the three tent tables. Do not read the rest of the plan.
+
+The document must contain, in this order:
+
+1. **Festival facts:** 191st Oktoberfest, 19 September to 4 October 2026, 16 days, Theresienwiese (48.1314, 11.5498). Maß range EUR 14.80 to 15.90. Festival base price EUR 15.80. The Oide Wiesn runs in 2026 (the Zentral-Landwirtschaftsfest that displaces it is not due again until 2028).
+2. **Full tent table:** all 40 tents with name, category, Maß price, latitude, longitude, copied from the Task 1 tables. Add a column marking whether the price was published for 2026 or inherited from the festival default. The 13 inherited ones are: Bodo's Cafézelt, Café Theres', Feisingers, Glöckle-Wirt, Goldener Hahn, Heimer, Heinz, Hühnerbraterei Poschner, Münchner Knödelei, Rischart's Café Kaiserschmarrn, Schiebl's Kaffeehaferl, Wiesn Guglhupf, Wildstuben.
+3. **What changed for 2026:** Bartls Flößerstadl (398 seats) is new and replaces Münchner Stubn on the same plot. Bodo's Cafézelt was rebuilt in wood, replacing its aluminium structure, capacity unchanged at 587. The Paulaner-Festzelt has new operators, Christine and Lorenz Stiftl, who previously ran the Schützenlisl. Michael Bietsch moved from the Historische Kegelbahn into the Volkssängerzelt Schützenlisl, which now serves Hacker-Pschorr from wooden casks. Sabine Erhard took over the Historische Kegelbahn. The Museumszelt gained a photography exhibition on Oktoberfest postcards. `Herzkasperlzelt` and `Zur Schönheitskönigin` are not in the 2026 lineup.
+4. **Notable price facts, useful for a post:** the EUR 15 barrier was broken in almost every large tent for 2026. Joint most expensive beer at EUR 15.90: Armbrustschützen, Bräurosl, Löwenbräu. Cheapest large tent: Augustiner-Festhalle at EUR 14.90. Cheapest on the grounds: Museumszelt at EUR 14.80. The Weinzelt's Weißbier Maß is EUR 17.80, the dearest pour anywhere on the Wiesn.
+5. **Data caveats,** stated plainly so a future post does not overclaim: Bartls Flößerstadl's EUR 15.70 comes from a single source, and that source also miscategorised it as a large tent. 13 small-tent prices were never published per-tent and are the festival default, not researched values. Münchner Weißbiergarten and Wiesn Guglhupf have no coordinate source and are recorded as NULL. Museumszelt is EUR 14.80 per the 2026 source; a separate table gave EUR 14.60 but was labelled 2025.
+6. **A short note on the coordinate correction,** which is itself a good blog anecdote: the coordinates shipped before this migration were placeholders, described as "approximate" in `supabase/migrations/20260126000000_postgis_tent_coordinates.sql`. Sorted by position they fell on an evenly spaced diagonal line across Theresienwiese. Measured against OSM, Marstall-Festzelt was off by roughly 900 m, the Museumszelt by roughly 650 m, and the Hofbräu-Festzelt by roughly 235 m. The giveaway that the new data is right: OSM places the Oide Wiesn tents south of the main tents, matching the real grounds, whereas the placeholders put them to the east.
+7. **Sources,** as a list of links:
+   - <https://www.oktoberfest.de/en>
+   - <https://www.munichtourism.org/oktoberfest-dates-schedule/>
+   - <https://wiesnkini.de/zelte/bierpreis/>
+   - <https://www.in-muenchen.de/stadtleben/oktoberfest-wiesn-preise.html>
+   - <https://www.oktoberfest.de/en/beer-tents/small-tents>
+   - <https://www.oktoberfest.de/en/tents/tents-oide-wiesn/festival-tents-oide-wiesn-event-glance>
+   - <https://www.muenchen.de/veranstaltungen/oktoberfest/aktuell/oktoberfest-2026-das-ist-neu-auf-der-wiesn>
+   - <https://www.falstaff.com/de/news/neuer-wiesn-wirt-floesserstadl-ersetzt-muenchner-stubn-auf-dem-oktoberfest>
+   - <https://www.muenchen.de/veranstaltungen/wiesn-kleine-zelte/bartls-floesserstadl>
+   - OpenStreetMap via the Overpass API, ODbL licensed, snapshot 2026-08-04
+
+Attribute the coordinates to OpenStreetMap contributors and name the ODbL licence explicitly. That attribution is a licence requirement if any of this reaches a published post.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/festivals/oktoberfest-2026-reference.md
+git commit -m "docs: Oktoberfest 2026 tent data and sources for reference"
+```
+
+---
+
 ## Reading the results
 
 - Per-link clicks and opens: the Resend broadcast detail pages for the two broadcast IDs.

--- a/supabase/migrations/20260804121948_add_oktoberfest_2026.sql
+++ b/supabase/migrations/20260804121948_add_oktoberfest_2026.sql
@@ -1,0 +1,193 @@
+-- Add Oktoberfest 2026 (191st Wiesn) and replace fabricated tent coordinates.
+-- Dates: 19 September to 4 October 2026 (16 days).
+--
+-- Coordinates come from OpenStreetMap via the Overpass API (ODbL, snapshot 2026-08-04).
+-- They replace the placeholder coordinates added in
+-- 20260126000000_postgis_tent_coordinates.sql, which that migration's own comment called
+-- "approximate": they were laid out along a synthetic diagonal and were wrong by up to ~900 m.
+-- The existing tent_location_trigger keeps the PostGIS `location` column in sync from
+-- latitude/longitude, so no geometry is written by hand here.
+
+BEGIN;
+
+-- Step 1: Only one festival may be active (idx_festivals_single_active is a unique partial
+-- index), so clear the current holder before inserting. Frühlingsfest 2026 is active today
+-- despite having ended in May.
+UPDATE festivals SET is_active = false WHERE is_active = true;
+
+-- Step 2: New tents for 2026.
+-- Bartls Flößerstadl (398 seats) takes over the Münchner Stubn plot, so it inherits that
+-- position. Münchner Stubn itself is not linked to 2026.
+INSERT INTO tents (id, name, category, latitude, longitude) VALUES
+  ('c0000000-0000-4000-b000-000000000001', 'Bartls Flößerstadl', 'small', 48.13138, 11.54925),
+  ('c0000000-0000-4000-b000-000000000002', 'Hühnerbraterei Poschner', 'small', 48.13266, 11.54864)
+-- ON CONFLICT guard matches the Frühlingsfest precedent. Note the whole migration is wrapped in
+-- a transaction, so a failure rolls back entirely and there is no partial state to retry over.
+-- The guard only matters if someone deletes the festival row by hand and re-runs this file.
+ON CONFLICT (id) DO NOTHING;
+
+-- Step 3: Fix the long-standing misspelling.
+UPDATE tents SET name = 'Museumszelt'
+WHERE id = '655190b1-ca0d-4d5a-8def-74f8a20f1e2b';
+
+-- Step 4: Replace fabricated coordinates with OSM-sourced ones, for the 2026 lineup only.
+-- Tents belonging to other festivals are deliberately untouched.
+UPDATE tents AS t SET latitude = v.lat, longitude = v.lon
+FROM (VALUES
+  -- Large tents
+  ('55ff3af6-f1d6-481a-a8f4-58fa23f00f68'::uuid, 48.13474, 11.54871), -- Armbrustschützen Festzelt
+  ('631abb99-4237-4bbc-94d7-2a6c18e11e25'::uuid, 48.13286, 11.55006), -- Augustiner-Festhalle
+  ('9eb72005-8026-4665-be77-4a61fbcc3fa1'::uuid, 48.13217, 11.54814), -- Festhalle Schottenhamel
+  ('da36b13f-1e75-4299-9f75-1de4eb38b416'::uuid, 48.13484, 11.55018), -- Fischer-Vroni
+  ('282d326c-0e14-43e2-b8c6-9bf098a0fde6'::uuid, 48.13305, 11.54816), -- Hacker-Festzelt
+  ('253eb29d-8efe-4095-9671-4eff02704c4a'::uuid, 48.13390, 11.54841), -- Hofbräu-Festzelt
+  ('37ad3fc4-9d52-4e19-91c7-a01ed11c6854'::uuid, 48.13030, 11.54729), -- Käfer Wiesn-Schänke
+  ('2661d289-5ecd-42a0-9a59-eaf5ef94f92d'::uuid, 48.13006, 11.54988), -- Kufflers Weinzelt
+  ('dd7b4b6d-7a57-411a-baf8-8c0d20682b64'::uuid, 48.13098, 11.54969), -- Löwenbräu-Festzelt
+  ('49449d2f-c9b7-4b8b-9ed7-889690493c3d'::uuid, 48.13537, 11.54906), -- Marstall-Festzelt
+  ('017977ea-a9c3-4865-b494-edc49efc6212'::uuid, 48.13412, 11.55041), -- Ochsenbraterei
+  ('0935a117-4fe2-46fb-b8fa-fc45d9496af9'::uuid, 48.13117, 11.54788), -- Paulaner Festzelt
+  ('4d140654-f235-44b8-8d6e-8f23e57274a2'::uuid, 48.13195, 11.54992), -- Pschorr-Festzelt Bräurosl
+  ('5deac267-6401-437f-adae-e81769e4e781'::uuid, 48.13124, 11.54692), -- Schützen-Festzelt
+  -- Oide Wiesn
+  ('907342a2-ab22-4b27-8ebd-f7225a4d13e7'::uuid, 48.12876, 11.54607), -- Boandlkramerei
+  ('f2df3186-ec0d-467f-a560-fffa48a72897'::uuid, 48.12863, 11.54748), -- Festzelt Tradition
+  ('655190b1-ca0d-4d5a-8def-74f8a20f1e2b'::uuid, 48.12781, 11.54727), -- Museumszelt
+  ('e61d04d2-6a16-4069-bf79-85dcf4827c94'::uuid, 48.12837, 11.54617), -- Volkssängerzelt Schützenlisl
+  -- Small tents
+  ('bbbf2c29-7b2e-487a-bcfc-c4b75547f83a'::uuid, 48.13340, 11.55039), -- Bodo's Cafézelt
+  ('1764c5e2-6f01-4119-a55a-7d0efe3ae861'::uuid, 48.13222, 11.55073), -- Café Theres'
+  ('28a517af-f440-4102-9ad3-beaed8347061'::uuid, 48.13135, 11.54857), -- Feisingers Kas- und Weinstubn
+  ('f8e94181-3a63-4e68-9285-588038be343f'::uuid, 48.13144, 11.55080), -- Fisch-Bäda
+  ('6fcea9eb-c5c5-4d8f-9363-cbd86119128e'::uuid, 48.13147, 11.54852), -- Glöckle-Wirt
+  ('f02ae7eb-3c8c-4e38-ae4a-7b0f9fc5e404'::uuid, 48.13325, 11.54892), -- Goldener Hahn
+  ('6d4e022d-c033-4a56-a19b-441dfe8430fd'::uuid, 48.13325, 11.55104), -- Heimer Enten- und Hühnerbraterei
+  ('e2eae4f6-8da8-46db-b76a-d1fb50eca8f6'::uuid, 48.13171, 11.54857), -- Heinz Wurst- und Hühnerbraterei
+  ('ecaae5eb-9745-4359-826a-9a14aa91591b'::uuid, 48.13343, 11.54889), -- Hochreiters Haxnbraterei
+  ('24b50db1-f7c1-4132-a07c-00ad2cb8c2e1'::uuid, 48.13345, 11.54979), -- Hühner- und Entenbraterei Ammer
+  ('2196e0ea-1262-4f2c-97ef-bcd67104ae72'::uuid, 48.13232, 11.54938), -- Kalbsbraterei
+  ('0898010d-693f-47be-b8f2-5916ad5a56d0'::uuid, 48.12919, 11.54917), -- Münchner Knödelei
+  ('cb0a2849-159f-48f6-902f-fba73ae9c9a2'::uuid, 48.13067, 11.55050), -- Rischart's Café Kaiserschmarrn
+  ('014c7c7e-f904-4fcc-931f-2b80c9ceff2b'::uuid, 48.13416, 11.54924), -- Schiebl's Kaffeehaferl
+  ('949ee890-ee80-406c-af23-ded34e838b44'::uuid, 48.13437, 11.54922), -- Vinzenzmurr Metzger Stubn
+  ('5162f382-2321-495c-b723-942a4708811e'::uuid, 48.13008, 11.55243), -- Wildstuben
+  ('b349fe59-e104-42f1-9157-1859d829c1fa'::uuid, 48.13387, 11.55242), -- Wirtshaus im Schichtl
+  ('387574a0-8c63-4bf0-a4d0-a0bc37158ddd'::uuid, 48.13029, 11.55261)  -- Zur Bratwurst
+) AS v(id, lat, lon)
+WHERE t.id = v.id;
+
+-- Step 5: Two 2026 tents have no trustworthy coordinate source. NULL them rather than keep
+-- fabricated values: get_nearby_tents filters on `location IS NOT NULL`, so they are simply
+-- omitted from proximity results instead of pointing users at the wrong place.
+UPDATE tents SET latitude = NULL, longitude = NULL
+WHERE id IN (
+  'a20effb6-612e-4085-8de0-6fbc0dff1dc1', -- Münchner Weißbiergarten
+  '7b91d421-5052-4109-b47f-8136f3bb9a89'  -- Wiesn Guglhupf
+);
+
+-- Step 6: The festival itself. status 'upcoming' matches the runtime value that
+-- packages/shared/src/utils/festival-status.ts derives from the dates.
+INSERT INTO festivals (
+  name, short_name, festival_type, location,
+  start_date, end_date, map_url,
+  is_active, status, description,
+  beer_cost, default_beer_price_cents,
+  latitude, longitude
+) VALUES (
+  'Oktoberfest 2026',
+  'oktoberfest-2026',
+  'oktoberfest',
+  'Munich, Germany',
+  '2026-09-19',
+  '2026-10-04',
+  'https://www.muenchen.de/en/events/oktoberfest',
+  true,
+  'upcoming',
+  'The 191st Oktoberfest on the Theresienwiese, 16 days from 19 September to 4 October 2026',
+  15.80,
+  1580,
+  48.1314,
+  11.5498
+);
+
+-- Step 7: Link the 40 tents of the 2026 lineup with their Maß prices. Tents with no published
+-- 2026 price carry the 1580 base.
+INSERT INTO festival_tents (festival_id, tent_id, beer_price, beer_price_cents)
+SELECT
+  (SELECT id FROM festivals WHERE short_name = 'oktoberfest-2026'),
+  v.tent_id,
+  v.cents / 100.0,
+  v.cents
+FROM (VALUES
+  -- Large tents
+  ('55ff3af6-f1d6-481a-a8f4-58fa23f00f68'::uuid, 1590), -- Armbrustschützen Festzelt
+  ('631abb99-4237-4bbc-94d7-2a6c18e11e25'::uuid, 1490), -- Augustiner-Festhalle
+  ('9eb72005-8026-4665-be77-4a61fbcc3fa1'::uuid, 1580), -- Festhalle Schottenhamel
+  ('da36b13f-1e75-4299-9f75-1de4eb38b416'::uuid, 1575), -- Fischer-Vroni
+  ('282d326c-0e14-43e2-b8c6-9bf098a0fde6'::uuid, 1580), -- Hacker-Festzelt
+  ('253eb29d-8efe-4095-9671-4eff02704c4a'::uuid, 1580), -- Hofbräu-Festzelt
+  ('37ad3fc4-9d52-4e19-91c7-a01ed11c6854'::uuid, 1580), -- Käfer Wiesn-Schänke
+  ('2661d289-5ecd-42a0-9a59-eaf5ef94f92d'::uuid, 1780), -- Kufflers Weinzelt
+  ('dd7b4b6d-7a57-411a-baf8-8c0d20682b64'::uuid, 1590), -- Löwenbräu-Festzelt
+  ('49449d2f-c9b7-4b8b-9ed7-889690493c3d'::uuid, 1580), -- Marstall-Festzelt
+  ('017977ea-a9c3-4865-b494-edc49efc6212'::uuid, 1580), -- Ochsenbraterei
+  ('0935a117-4fe2-46fb-b8fa-fc45d9496af9'::uuid, 1580), -- Paulaner Festzelt
+  ('4d140654-f235-44b8-8d6e-8f23e57274a2'::uuid, 1590), -- Pschorr-Festzelt Bräurosl
+  ('5deac267-6401-437f-adae-e81769e4e781'::uuid, 1580), -- Schützen-Festzelt
+  -- Oide Wiesn
+  ('907342a2-ab22-4b27-8ebd-f7225a4d13e7'::uuid, 1530), -- Boandlkramerei
+  ('f2df3186-ec0d-467f-a560-fffa48a72897'::uuid, 1580), -- Festzelt Tradition
+  ('655190b1-ca0d-4d5a-8def-74f8a20f1e2b'::uuid, 1480), -- Museumszelt
+  ('e61d04d2-6a16-4069-bf79-85dcf4827c94'::uuid, 1490), -- Volkssängerzelt Schützenlisl
+  -- Small tents
+  ('c0000000-0000-4000-b000-000000000001'::uuid, 1570), -- Bartls Flößerstadl
+  ('bbbf2c29-7b2e-487a-bcfc-c4b75547f83a'::uuid, 1580), -- Bodo's Cafézelt
+  ('1764c5e2-6f01-4119-a55a-7d0efe3ae861'::uuid, 1580), -- Café Theres'
+  ('28a517af-f440-4102-9ad3-beaed8347061'::uuid, 1580), -- Feisingers Kas- und Weinstubn
+  ('f8e94181-3a63-4e68-9285-588038be343f'::uuid, 1580), -- Fisch-Bäda
+  ('6fcea9eb-c5c5-4d8f-9363-cbd86119128e'::uuid, 1580), -- Glöckle-Wirt
+  ('f02ae7eb-3c8c-4e38-ae4a-7b0f9fc5e404'::uuid, 1580), -- Goldener Hahn
+  ('6d4e022d-c033-4a56-a19b-441dfe8430fd'::uuid, 1580), -- Heimer Enten- und Hühnerbraterei
+  ('e2eae4f6-8da8-46db-b76a-d1fb50eca8f6'::uuid, 1580), -- Heinz Wurst- und Hühnerbraterei
+  ('ecaae5eb-9745-4359-826a-9a14aa91591b'::uuid, 1570), -- Hochreiters Haxnbraterei
+  ('24b50db1-f7c1-4132-a07c-00ad2cb8c2e1'::uuid, 1495), -- Hühner- und Entenbraterei Ammer
+  ('c0000000-0000-4000-b000-000000000002'::uuid, 1580), -- Hühnerbraterei Poschner
+  ('2196e0ea-1262-4f2c-97ef-bcd67104ae72'::uuid, 1580), -- Kalbsbraterei
+  ('0898010d-693f-47be-b8f2-5916ad5a56d0'::uuid, 1580), -- Münchner Knödelei
+  ('a20effb6-612e-4085-8de0-6fbc0dff1dc1'::uuid, 1480), -- Münchner Weißbiergarten
+  ('cb0a2849-159f-48f6-902f-fba73ae9c9a2'::uuid, 1580), -- Rischart's Café Kaiserschmarrn
+  ('014c7c7e-f904-4fcc-931f-2b80c9ceff2b'::uuid, 1580), -- Schiebl's Kaffeehaferl
+  ('949ee890-ee80-406c-af23-ded34e838b44'::uuid, 1580), -- Vinzenzmurr Metzger Stubn
+  ('7b91d421-5052-4109-b47f-8136f3bb9a89'::uuid, 1580), -- Wiesn Guglhupf
+  ('5162f382-2321-495c-b723-942a4708811e'::uuid, 1580), -- Wildstuben
+  ('b349fe59-e104-42f1-9157-1859d829c1fa'::uuid, 1490), -- Wirtshaus im Schichtl
+  ('387574a0-8c63-4bf0-a4d0-a0bc37158ddd'::uuid, 1570)  -- Zur Bratwurst
+) AS v(tent_id, cents);
+
+-- Step 8: Festival-level drink prices from the 1580 base, using the same ratios as
+-- 20260409174404_add_fruehlingsfest_2026.sql.
+DO $$
+DECLARE
+  v_festival_id uuid;
+  v_base_price integer := 1580;
+BEGIN
+  SELECT id INTO v_festival_id FROM festivals WHERE short_name = 'oktoberfest-2026';
+
+  INSERT INTO drink_type_prices (festival_id, drink_type, price_cents) VALUES
+    (v_festival_id, 'beer', v_base_price),
+    (v_festival_id, 'radler', v_base_price),
+    (v_festival_id, 'alcohol_free', ROUND(v_base_price * 0.90)::integer),
+    (v_festival_id, 'wine', ROUND(v_base_price * 0.85)::integer),
+    (v_festival_id, 'soft_drink', ROUND(v_base_price * 0.40)::integer),
+    (v_festival_id, 'other', v_base_price);
+END $$;
+
+-- Step 9: Per-tent beer and radler overrides, only where the tent price differs from the base.
+INSERT INTO drink_type_prices (festival_tent_id, drink_type, price_cents)
+SELECT ft.id, d.drink_type, ft.beer_price_cents
+FROM festival_tents ft
+CROSS JOIN (VALUES ('beer'::drink_type), ('radler'::drink_type)) AS d(drink_type)
+WHERE ft.festival_id = (SELECT id FROM festivals WHERE short_name = 'oktoberfest-2026')
+  AND ft.beer_price_cents <> 1580;
+
+COMMIT;

--- a/supabase/migrations/20260804121948_add_oktoberfest_2026.sql
+++ b/supabase/migrations/20260804121948_add_oktoberfest_2026.sql
@@ -8,6 +8,12 @@
 -- The existing tent_location_trigger keeps the PostGIS `location` column in sync from
 -- latitude/longitude, so no geometry is written by hand here.
 
+-- This is the only migration in the repo with an explicit transaction. It is deliberate: the
+-- nine steps below are one logical change (deactivate the old festival, insert the new one,
+-- relink 40 tents) and a partial apply would leave no festival active at all. `supabase db push`
+-- does not wrap migrations in an outer transaction, so BEGIN here does not nest; this file
+-- applied to production on 2026-08-04 and is recorded with BEGIN and COMMIT as its first and
+-- last statements. If you copy this file as a template, drop the wrapper unless you need it.
 BEGIN;
 
 -- Step 1: Only one festival may be active (idx_festivals_single_active is a unique partial
@@ -30,8 +36,13 @@ ON CONFLICT (id) DO NOTHING;
 UPDATE tents SET name = 'Museumszelt'
 WHERE id = '655190b1-ca0d-4d5a-8def-74f8a20f1e2b';
 
--- Step 4: Replace fabricated coordinates with OSM-sourced ones, for the 2026 lineup only.
--- Tents belonging to other festivals are deliberately untouched.
+-- Step 4: Replace fabricated coordinates with OSM-sourced ones.
+-- The id list is the 2026 lineup, but `tents` is a shared table: 25 of these rows are also
+-- linked to Oktoberfest 2025 and 2024 via festival_tents, so those festivals see the new
+-- coordinates too. That is intended. The old values were fabricated for every festival that
+-- used them, and the tents stand in the same physical spots year to year, so the OSM
+-- coordinates are the correct ones for the earlier festivals as well. Tents never linked to
+-- Oktoberfest 2026 (for example the Frühlingsfest-only rows) keep whatever they had.
 UPDATE tents AS t SET latitude = v.lat, longitude = v.lon
 FROM (VALUES
   -- Large tents


### PR DESCRIPTION
## Summary

Gets everything ready for Oktoberfest 2026 and for the one-off "what's new" bulletin going out to lapsed users.

**Database (already applied to production)**
- Adds Oktoberfest 2026 (19 Sep - 4 Oct, 16 days) and sets it active, so users see the next Wiesn on login.
- Links all 40 tents with 2026 prices: EUR 15.80 base, EUR 14.80-17.80 range.
- Adds two new tents (Bartls Flößerstadl, Hühnerbraterei Poschner), renames Museumszelt.
- Replaces every fabricated tent coordinate with an OpenStreetMap-sourced one (ODbL, snapshot 2026-08-04). The previous values formed an evenly-spaced diagonal, so they were never real. Two tents with no trustworthy source are set to NULL rather than left wrong.

**Blog**
- New post: tent-by-tent 2026 beer prices, in en/de/es. Sources cited inline. The small tents that carry the festival default rather than a published per-tent figure are flagged as such instead of being passed off as researched.
- The three existing Oktoberfest 2026 posts still quoted a projected EUR 15.50-16.50; they now use the confirmed numbers and link the new post. `fruehlingsfest-guide` used the same stale range as a comparison.
- Fixes a factual error in `oktoberfest-2026-guide`: it claimed 2026 gains an extra day because October 3 falls in the window. The festival only extends when October 3 is a Monday or Tuesday. In 2026 it is a Saturday, so this is a standard 16-day Wiesn.

**Bulletin tracking**
- Campaign parameters on all four links in both draft broadcasts: UTMs for GA4, `referrer` for Play Console, `pt`/`ct` for App Store Connect.
- Snapshot of the email as sent in `docs/email/`, with the reasoning recorded in a header comment.
- Note: Resend open/click tracking stays OFF on `account.prostcounter.fun` and must stay off. That domain also sends Supabase Auth mail, and click tracking rewrites links, which can let a mail scanner consume a one-time password-reset token.

