### PR TITLE
fix: restore German umlauts, re-apply nearby-members festival scope

### DIFF
--- a/apps/web/content/blog/de/fruehlingsfest-guide.mdx
+++ b/apps/web/content/blog/de/fruehlingsfest-guide.mdx
@@ -1,6 +1,6 @@
 ---
-title: "Fruehlingsfest: Dein Guide zum Muenchner Fruehlingsfest"
-description: "Dein Guide zum Fruehlingsfest, Muenchens Fruehlings-Volksfest. Kleiner als das Oktoberfest, aber mit dem gleichen Wiesn-Zauber -- Fahrgeschaefte, Bierzelte und bayerisches Essen."
+title: "Frühlingsfest: Dein Guide zum Münchner Frühlingsfest"
+description: "Dein Guide zum Frühlingsfest, Münchens Frühlings-Volksfest. Kleiner als das Oktoberfest, aber mit dem gleichen Wiesn-Zauber -- Fahrgeschäfte, Bierzelte und bayerisches Essen."
 date: "2026-03-08"
 lastModified: "2026-03-08"
 author: "ProstCounter Team"
@@ -10,172 +10,172 @@ featuredImage: "/images/prost-counter-og-3.jpg"
 locale: "de"
 ---
 
-# Fruehlingsfest: Dein Guide zum Muenchner Fruehlingsfest
+# Frühlingsfest: Dein Guide zum Münchner Frühlingsfest
 
-Wenn die letzten Spuren des Winters verschwinden und die ersten warmen Tage in Muenchen ankommen, feiert die Stadt mit dem **Fruehlingsfest**. Auf dem gleichen Theresienwiese-Gelaende wie das [Oktoberfest](/blog/de/oktoberfest-2026-guide) bietet das Fruehlingsfest ein aehnlich tolles Erlebnis -- bei einem Bruchteil der Groesse, der Kosten und des Trubels. Es ist einer der bestgehueteten Geheimtipps Muenchens und verdient einen Platz in deinem Reisekalender.
+Wenn die letzten Spuren des Winters verschwinden und die ersten warmen Tage in München ankommen, feiert die Stadt mit dem **Frühlingsfest**. Auf dem gleichen Theresienwiese-Gelände wie das [Oktoberfest](/blog/de/oktoberfest-2026-guide) bietet das Frühlingsfest ein ähnlich tolles Erlebnis -- bei einem Bruchteil der Größe, der Kosten und des Trubels. Es ist einer der bestgehüteten Geheimtipps Münchens und verdient einen Platz in deinem Reisekalender.
 
-## Was ist das Fruehlingsfest?
+## Was ist das Frühlingsfest?
 
-Das Fruehlingsfest ist Muenchens zweitgroesstes Volksfest und zieht rund 1,5 Millionen Besucher waehrend seiner etwa dreiwoechigen Laufzeit an. Das klingt nach viel, aber vergleiche es mit den sechs Millionen des Oktoberfests, und du verstehst, warum Einheimische das Fruehlingsfest als die entspanntere Alternative betrachten.
+Das Frühlingsfest ist Münchens zweitgrößtes Volksfest und zieht rund 1,5 Millionen Besucher während seiner etwa dreiwöchigen Laufzeit an. Das klingt nach viel, aber vergleiche es mit den sechs Millionen des Oktoberfests, und du verstehst, warum Einheimische das Frühlingsfest als die entspanntere Alternative betrachten.
 
-Das Fest ist seit 1965 eine Muenchner Tradition, urspruenglich als weiteres festliches Event auf der Theresienwiese konzipiert. Ueber die Jahrzehnte ist es zu einem richtigen Volksfest mit Bierzelten, Fahrgeschaeften, Essensstaenden und Live-Musik herangewachsen -- im Grunde ein Mini-Oktoberfest im Fruehling.
+Das Fest ist seit 1965 eine Münchner Tradition, ursprünglich als weiteres festliches Event auf der Theresienwiese konzipiert. Über die Jahrzehnte ist es zu einem richtigen Volksfest mit Bierzelten, Fahrgeschäften, Essensständen und Live-Musik herangewachsen -- im Grunde ein Mini-Oktoberfest im Frühling.
 
-Die Muenchner nennen es liebevoll die **"kleine Schwester"** des Oktoberfests, und dieser Spitzname trifft es perfekt. Gleicher Ort, gleiche DNA, aber kleiner, guenstiger und mit einer entspannteren bayerischen Atmosphaere.
+Die Münchner nennen es liebevoll die **"kleine Schwester"** des Oktoberfests, und dieser Spitzname trifft es perfekt. Gleicher Ort, gleiche DNA, aber kleiner, günstiger und mit einer entspannteren bayerischen Atmosphäre.
 
-## Wann findet das Fruehlingsfest statt?
+## Wann findet das Frühlingsfest statt?
 
-Das Fruehlingsfest laeuft typischerweise von **Ende April bis Anfang Mai** ueber ungefaehr drei Wochen. Die genauen Termine verschieben sich leicht jedes Jahr, aber es beginnt generell am letzten Freitag im April und endet am zweiten oder dritten Sonntag im Mai.
+Das Frühlingsfest läuft typischerweise von **Ende April bis Anfang Mai** über ungefähr drei Wochen. Die genauen Termine verschieben sich leicht jedes Jahr, aber es beginnt generell am letzten Freitag im April und endet am zweiten oder dritten Sonntag im Mai.
 
-Fuer 2026 wird das Fest voraussichtlich von **Freitag, 24. April bis Sonntag, 17. Mai** laufen. Die offiziellen Termine werden normalerweise von der Stadt Muenchen im Fruehling bestaetigt.
+Für 2026 wird das Fest voraussichtlich von **Freitag, 24. April bis Sonntag, 17. Mai** laufen. Die offiziellen Termine werden normalerweise von der Stadt München im Frühling bestätigt.
 
-### Oeffnungszeiten
+### Öffnungszeiten
 
-- **Bierzelte**: Taeglich ab 10:00 Uhr geoeffnet (am ersten Tag ab 12:00 Uhr)
-- **Fahrgeschaefte und Staende**: Ab dem spaeten Vormittag bis 23:00 Uhr an den meisten Tagen
+- **Bierzelte**: Täglich ab 10:00 Uhr geöffnet (am ersten Tag ab 12:00 Uhr)
+- **Fahrgeschäfte und Stände**: Ab dem späten Vormittag bis 23:00 Uhr an den meisten Tagen
 - **Letzter Bierausschank**: 22:30 Uhr in den Hauptzelten
 
 ## Location: Die gleiche Theresienwiese
 
-Das Fruehlingsfest findet auf der suedlichen Haelfte der **Theresienwiese** statt, dem gleichen Gelaende wie das Oktoberfest. Allerdings nimmt es eine kleinere Flaeche ein -- ungefaehr ein Drittel des Oktoberfest-Layouts. Das bedeutet ein kompakteres, begehbares Fest, das du bequem an einem Nachmittag erkunden kannst.
+Das Frühlingsfest findet auf der südlichen Hälfte der **Theresienwiese** statt, dem gleichen Gelände wie das Oktoberfest. Allerdings nimmt es eine kleinere Fläche ein -- ungefähr ein Drittel des Oktoberfest-Layouts. Das bedeutet ein kompakteres, begehbares Fest, das du bequem an einem Nachmittag erkunden kannst.
 
 Die Anfahrt ist identisch zum Oktoberfest:
 
 - **U-Bahn**: U4/U5 bis Theresienwiese
-- **S-Bahn**: Hackerbruecke, dann 10 Minuten Fussweg
-- **Zu Fuss**: 15 Minuten vom Muenchner Hauptbahnhof
+- **S-Bahn**: Hackerbrücke, dann 10 Minuten Fußweg
+- **Zu Fuß**: 15 Minuten vom Münchner Hauptbahnhof
 
-## Die zwei grossen Bierzelte
+## Die zwei großen Bierzelte
 
-Im Gegensatz zu den 14 grossen Zelten des Oktoberfests hat das Fruehlingsfest **zwei Hauptbierzelte**, jedes mit eigenem Charakter und eigener Brauerei.
+Im Gegensatz zu den 14 großen Zelten des Oktoberfests hat das Frühlingsfest **zwei Hauptbierzelte**, jedes mit eigenem Charakter und eigener Brauerei.
 
 ### Festhalle Bayernland (Hippodrom)
 
-Die **Festhalle Bayernland** ist das groessere der beiden Zelte und das Herzstuck des Fests. Mit Platz fuer rund 6.000 Gaeste bietet sie ein Oktoberfest-aehnliches Erlebnis: lange Holzbaenke, Blasmusik, traditionelles bayerisches Essen und eine lebhafte Stimmung, die im Laufe des Tages zunimmt.
+Die **Festhalle Bayernland** ist das größere der beiden Zelte und das Herzstück des Fests. Mit Platz für rund 6.000 Gäste bietet sie ein Oktoberfest-ähnliches Erlebnis: lange Holzbänke, Blasmusik, traditionelles bayerisches Essen und eine lebhafte Stimmung, die im Laufe des Tages zunimmt.
 
-Das Zelt schenkt **Spaten**-Bier aus, eine der aeltesten Brauereien Muenchens. Die Atmosphaere ist festlich und familienfreundlich am Tag, mit einer energischeren Party-Stimmung am Abend -- besonders an Wochenenden.
+Das Zelt schenkt **Spaten**-Bier aus, eine der ältesten Brauereien Münchens. Die Atmosphäre ist festlich und familienfreundlich am Tag, mit einer energischeren Party-Stimmung am Abend -- besonders an Wochenenden.
 
 **Details:**
 
 - Brauerei: Spaten
-- Kapazitaet: ca. 6.000
-- Atmosphaere: Klassische Volksfest-Energie
-- Reservierungen: Empfohlen fuer Abende und Wochenenden, Walk-ins unter der Woche moeglich
+- Kapazität: ca. 6.000
+- Atmosphäre: Klassische Volksfest-Energie
+- Reservierungen: Empfohlen für Abende und Wochenenden, Walk-ins unter der Woche möglich
 - Musik: Traditionelle Blasmusik, mit modernen Hits am Abend
 
 ### Augustiner Festhalle
 
-Die **Augustiner Festhalle** ist das Zelt fuer Muenchner Puristen. Augustiner gilt weithin als die beste Brauerei der Stadt, und ihre Praesenz auf dem Fruehlingsfest zieht ein treues Publikum an. Das Zelt fasst rund 5.000 Gaeste und hat den Ruf einer etwas traditionelleren, gemuetlicheren Atmosphaere im Vergleich zur Festhalle Bayernland.
+Die **Augustiner Festhalle** ist das Zelt für Münchner Puristen. Augustiner gilt weithin als die beste Brauerei der Stadt, und ihre Präsenz auf dem Frühlingsfest zieht ein treues Publikum an. Das Zelt fasst rund 5.000 Gäste und hat den Ruf einer etwas traditionelleren, gemütlicheren Atmosphäre im Vergleich zur Festhalle Bayernland.
 
-Ein besonderes Highlight: Augustiner schenkt sein Bier aus **Holzfaessern** (Holzfaesser) aus, die vor Ort frisch angezapft werden. Das ist die traditionelle Art, wie Bier jahrhundertelang ausgeschenkt wurde, und viele Muenchner bestehen darauf, dass es dem Bier einen spuerbar besseren Geschmack gibt. Ob es am Holz, an der Frische oder an der Romantik der Tradition liegt -- ein Augustiner aus dem Fass hat etwas Besonderes.
+Ein besonderes Highlight: Augustiner schenkt sein Bier aus **Holzfässern** (Holzfässer) aus, die vor Ort frisch angezapft werden. Das ist die traditionelle Art, wie Bier jahrhundertelang ausgeschenkt wurde, und viele Münchner bestehen darauf, dass es dem Bier einen spürbar besseren Geschmack gibt. Ob es am Holz, an der Frische oder an der Romantik der Tradition liegt -- ein Augustiner aus dem Fass hat etwas Besonderes.
 
 **Details:**
 
 - Brauerei: Augustiner
-- Kapazitaet: ca. 5.000
-- Atmosphaere: Traditionell, etwas entspannter
-- Reservierungen: Empfohlen fuers Wochenende; unter der Woche generell ohne Reservierung zugaenglich
+- Kapazität: ca. 5.000
+- Atmosphäre: Traditionell, etwas entspannter
+- Reservierungen: Empfohlen fürs Wochenende; unter der Woche generell ohne Reservierung zugänglich
 - Musik: Traditionelle bayerische Blasmusik
-- Besonderheit: Bier aus Holzfaessern
+- Besonderheit: Bier aus Holzfässern
 
-## Fahrgeschaefte und Attraktionen
+## Fahrgeschäfte und Attraktionen
 
-Das Fruehlingsfest dreht sich nicht nur ums Bier -- es ist ein vollwertiger Jahrmarkt mit einer vielfaeltigen Auswahl an Fahrgeschaeften und Attraktionen. Das Angebot aendert sich leicht von Jahr zu Jahr, aber du kannst typischerweise mit Folgendem rechnen:
+Das Frühlingsfest dreht sich nicht nur ums Bier -- es ist ein vollwertiger Jahrmarkt mit einer vielfältigen Auswahl an Fahrgeschäften und Attraktionen. Das Angebot ändert sich leicht von Jahr zu Jahr, aber du kannst typischerweise mit Folgendem rechnen:
 
-### Nervenkitzel-Fahrgeschaefte
+### Nervenkitzel-Fahrgeschäfte
 
-- **Achterbahnen**: Normalerweise ein bis zwei mittelgrosse Achterbahnen
-- **Freifallturm**: Fuer alle, die zwischen den Bieren einen Adrenalinkick wollen
-- **Karussells und Schwingfahrten**: Verschiedene thematisierte Dreh- und Schwungfahrgeschaefte
-- **Autoscooter**: Ein Klassiker, der seit Jahrzehnten zum Volksfest gehoert
+- **Achterbahnen**: Normalerweise ein bis zwei mittelgroße Achterbahnen
+- **Freifallturm**: Für alle, die zwischen den Bieren einen Adrenalinkick wollen
+- **Karussells und Schwingfahrten**: Verschiedene thematisierte Dreh- und Schwungfahrgeschäfte
+- **Autoscooter**: Ein Klassiker, der seit Jahrzehnten zum Volksfest gehört
 
 ### Familienfreundliche Attraktionen
 
-- **Riesenrad**: Eine kleinere Version des Klassikers mit schoener Aussicht ueber die Theresienwiese und Muenchens Skyline
-- **Kinderfahrgeschaefte**: Karussells, Mini-Achterbahnen und Kinderautos
-- **Lachkabinett und Spiegelirrgarten**: Lustiger, Low-Tech-Spass, den Kinder lieben
-- **Spielbuden**: Schiessstaende, Ballondarts, Ringwerfen und die allgegenwaertige Moeglichkeit, ueberdimensionale Stofftiere zu gewinnen
+- **Riesenrad**: Eine kleinere Version des Klassikers mit schöner Aussicht über die Theresienwiese und Münchens Skyline
+- **Kinderfahrgeschäfte**: Karussells, Mini-Achterbahnen und Kinderautos
+- **Lachkabinett und Spiegelirrgarten**: Lustiger, Low-Tech-Spaß, den Kinder lieben
+- **Spielbuden**: Schießstände, Ballondarts, Ringwerfen und die allgegenwärtige Möglichkeit, überdimensionale Stofftiere zu gewinnen
 
 ### Familientag
 
-Das Fruehlingsfest bestimmt mindestens einen **Familientag** (normalerweise ein Dienstag) mit reduzierten Preisen bei Fahrgeschaeften und Sonderangeboten in den Bierzelten. Wenn du mit Kindern kommst, ist das der beste Tag -- die Fahrpreise sind typischerweise halbiert und die Atmosphaere ist auf Familien ausgerichtet.
+Das Frühlingsfest bestimmt mindestens einen **Familientag** (normalerweise ein Dienstag) mit reduzierten Preisen bei Fahrgeschäften und Sonderangeboten in den Bierzelten. Wenn du mit Kindern kommst, ist das der beste Tag -- die Fahrpreise sind typischerweise halbiert und die Atmosphäre ist auf Familien ausgerichtet.
 
-## Essen auf dem Fruehlingsfest
+## Essen auf dem Frühlingsfest
 
-Das Essen auf dem Fruehlingsfest spiegelt das wider, was du auch auf dem Oktoberfest findest -- alle bayerischen Klassiker sind in den Zelten und an den Essensstaenden vertreten:
+Das Essen auf dem Frühlingsfest spiegelt das wider, was du auch auf dem Oktoberfest findest -- alle bayerischen Klassiker sind in den Zelten und an den Essensständen vertreten:
 
 ### In den Bierzelten
 
-- **Hendl** (Brathaehnchen): Das typische Bierzelt-Essen -- knusprig, golden und perfekt zu einem kalten Bier
-- **Schweinshaxe**: Langsam gebraten bis die Haut knackt, serviert mit Knoedeln und Krautsalat
-- **Obatzda**: Cremige bayerische Kaesecreme mit frischen Brezen
-- **Schweinebraten**: Mit kraeftiger Sosse und Knoedeln
-- **Steckerlfisch**: Eine bayerische Volksfest-Spezialitaet -- ganze Makrele ueber Holzkohle gegrillt
+- **Hendl** (Brathähnchen): Das typische Bierzelt-Essen -- knusprig, golden und perfekt zu einem kalten Bier
+- **Schweinshaxe**: Langsam gebraten bis die Haut knackt, serviert mit Knödeln und Krautsalat
+- **Obatzda**: Cremige bayerische Käsecreme mit frischen Brezen
+- **Schweinebraten**: Mit kräftiger Soße und Knödeln
+- **Steckerlfisch**: Eine bayerische Volksfest-Spezialität -- ganze Makrele über Holzkohle gegrillt
 
-### An den Freiluft-Staenden
+### An den Freiluft-Ständen
 
-- **Brezen**: Warm, salzig und weich -- der perfekte Snack fuer unterwegs
-- **Leberkaese-Semmel**: Dick geschnittener bayerischer Leberkaese in einer Semmel
+- **Brezen**: Warm, salzig und weich -- der perfekte Snack für unterwegs
+- **Leberkäse-Semmel**: Dick geschnittener bayerischer Leberkäse in einer Semmel
 - **Gebrannte Mandeln**: Zuckerummantelt und mit Zimtduft
-- **Langos**: Frittiertes Fladenbrot mit Knoblauch, Sauerrahm oder Kaese
-- **Dampfnudeln**: Gedaempfte Hefeknodel mit Vanillesauce -- ein bayerischer Dessert-Klassiker
+- **Langos**: Frittiertes Fladenbrot mit Knoblauch, Sauerrahm oder Käse
+- **Dampfnudeln**: Gedämpfte Hefeknödel mit Vanillesauce -- ein bayerischer Dessert-Klassiker
 
 ## Preise: Freundlicher als beim Oktoberfest
 
-Einer der groessten Vorteile des Fruehlingsfests sind die Kosten. Zwar ist es nicht gerade billig (das ist schliesslich Muenchen), aber die Preise sind insgesamt spuerbar niedriger als beim Oktoberfest:
+Einer der größten Vorteile des Frühlingsfests sind die Kosten. Zwar ist es nicht gerade billig (das ist schließlich München), aber die Preise sind insgesamt spürbar niedriger als beim Oktoberfest:
 
-- **Bier (1 Mass)**: 13 - 14,50 EUR (vs. 15,80 EUR in den meisten Oktoberfest-Zelten)
+- **Bier (1 Maß)**: 13 - 14,50 EUR (vs. 15,80 EUR in den meisten Oktoberfest-Zelten)
 - **Halbes Hendl**: 14 - 16 EUR (vs. 16 - 18 EUR)
 - **Fahrten**: 3 - 6 EUR pro Fahrt (mit Rabatt am Familientag)
-- **Hotels**: Normale Muenchner Preise, nicht der 2-3-fache Aufschlag, den das Oktoberfest mit sich bringt
+- **Hotels**: Normale Münchner Preise, nicht der 2-3-fache Aufschlag, den das Oktoberfest mit sich bringt
 
-Die Ersparnis laeppert sich schnell, besonders fuer Gruppen. Ein Tag auf dem Fruehlingsfest kann leicht 20-30 % weniger kosten als das gleiche Erlebnis auf dem Oktoberfest.
+Die Ersparnis läppert sich schnell, besonders für Gruppen. Ein Tag auf dem Frühlingsfest kann leicht 20-30 % weniger kosten als das gleiche Erlebnis auf dem Oktoberfest.
 
-## Warum Einheimische das Fruehlingsfest bevorzugen
+## Warum Einheimische das Frühlingsfest bevorzugen
 
-Frage einen Muenchner, welches Fest er bevorzugt, und erstaunlich viele waehlen das Fruehlingsfest. Hier ist warum:
+Frage einen Münchner, welches Fest er bevorzugt, und erstaunlich viele wählen das Frühlingsfest. Hier ist warum:
 
 ### Weniger touristisch
 
-Das Fruehlingsfest fliegt international unter dem Radar. Das Publikum ist ueberwiegend bayerisch, mit Besuchern aus anderen Teilen Deutschlands und dem benachbarten Oesterreich. Du hoerst bayerischen Dialekt an den Tischen, die Musikauswahl ist eher traditionell, und das gesamte Erlebnis fuehlt sich authentisch lokal an.
+Das Frühlingsfest fliegt international unter dem Radar. Das Publikum ist überwiegend bayerisch, mit Besuchern aus anderen Teilen Deutschlands und dem benachbarten Österreich. Du hörst bayerischen Dialekt an den Tischen, die Musikauswahl ist eher traditionell, und das gesamte Erlebnis fühlt sich authentisch lokal an.
 
 ### Leichterer Zugang
 
-Du kannst realistisch um 14 Uhr an einem Samstag in ein Bierzelt laufen und einen Sitzplatz finden -- etwas, das beim Oktoberfest zur gleichen Zeit praktisch unmoeglich ist. Reservierungen sind nett, aber fuer die meisten Besuche nicht zwingend.
+Du kannst realistisch um 14 Uhr an einem Samstag in ein Bierzelt laufen und einen Sitzplatz finden -- etwas, das beim Oktoberfest zur gleichen Zeit praktisch unmöglich ist. Reservierungen sind nett, aber für die meisten Besuche nicht zwingend.
 
-### Schoenes Wetter
+### Schönes Wetter
 
-Ende April und Mai bringen in Muenchen oft die ersten wirklich warmen Tage des Jahres. Die Kombination aus blauem Himmel, frischer Fruehlingsluft und kaltem Bier auf der Theresienwiese ist nach einem langen bayerischen Winter wirklich zauberhaft. Die Temperaturen liegen typischerweise bei 15-22 Grad C -- waermer und angenehmer als das manchmal kuehle Spaetseptemberwetter des Oktoberfests.
+Ende April und Mai bringen in München oft die ersten wirklich warmen Tage des Jahres. Die Kombination aus blauem Himmel, frischer Frühlingsluft und kaltem Bier auf der Theresienwiese ist nach einem langen bayerischen Winter wirklich zauberhaft. Die Temperaturen liegen typischerweise bei 15-22 Grad C -- wärmer und angenehmer als das manchmal kühle Spätseptemberwetter des Oktoberfests.
 
-### Fruehlings-Energie
+### Frühlings-Energie
 
-Es liegt etwas am ersten warmen Volksfest des Jahres, das dem Fruehlingsfest eine besondere Energie verleiht. Muenchen schuettelt den Winter ab, die Biergaerten oeffnen wieder, und die ganze Stadt hat eine optimistische, feierliche Stimmung. Das ist ein anderes Feeling als die End-of-Summer-Energie des Oktoberfests, und viele Einheimische finden es angenehmer.
+Es liegt etwas am ersten warmen Volksfest des Jahres, das dem Frühlingsfest eine besondere Energie verleiht. München schüttelt den Winter ab, die Biergärten öffnen wieder, und die ganze Stadt hat eine optimistische, feierliche Stimmung. Das ist ein anderes Feeling als die End-of-Summer-Energie des Oktoberfests, und viele Einheimische finden es angenehmer.
 
-## Tipps fuer deinen Besuch
+## Tipps für deinen Besuch
 
-### Beste Tage fuer einen Besuch
+### Beste Tage für einen Besuch
 
-- **Wochentag-Nachmittage**: Das entspannteste Erlebnis. Geh einfach in eines der Zelte, find einen Tisch und geniess es.
-- **Freitag- und Samstagabende**: Lebhafteste Stimmung, aber komm frueh (bis 16 Uhr), um einen Platz zu sichern.
-- **Familientag (Dienstag)**: Ideal fuer Familien mit Kindern -- reduzierte Fahrpreise und eine einladende Atmosphaere.
-- **Eroeffnungswochenende**: Tolle Stimmung zum Feststart, aber voller als im Durchschnitt.
+- **Wochentag-Nachmittage**: Das entspannteste Erlebnis. Geh einfach in eines der Zelte, find einen Tisch und genieß es.
+- **Freitag- und Samstagabende**: Lebhafteste Stimmung, aber komm früh (bis 16 Uhr), um einen Platz zu sichern.
+- **Familientag (Dienstag)**: Ideal für Familien mit Kindern -- reduzierte Fahrpreise und eine einladende Atmosphäre.
+- **Eröffnungswochenende**: Tolle Stimmung zum Feststart, aber voller als im Durchschnitt.
 
 ### Was anziehen
 
-Traditionelle Kleidung ist willkommen, aber noch weniger erwartet als beim Oktoberfest. Etwa 40-50 % der Besucher tragen Lederhosen oder Dirndl, besonders am Wochenende. Legere, bequeme Kleidung ist voellig in Ordnung. Bring eine leichte Jacke fuer den Abend mit -- Fruehlingsnaechte koennen noch kuehl werden.
+Traditionelle Kleidung ist willkommen, aber noch weniger erwartet als beim Oktoberfest. Etwa 40-50 % der Besucher tragen Lederhosen oder Dirndl, besonders am Wochenende. Legere, bequeme Kleidung ist völlig in Ordnung. Bring eine leichte Jacke für den Abend mit -- Frühlingsnächte können noch kühl werden.
 
 ### Praktische Tipps
 
-- **Bargeld herrscht** immer noch an manchen Staenden, obwohl die Kartenakzeptanz in den Hauptzelten deutlich besser geworden ist
-- **Komm mit oeffentlichen Verkehrsmitteln** -- die Parksituation ist genauso hoffnungslos wie beim Oktoberfest
-- **Sonnencreme**: Die Fruehlingssonne kann truegerisch stark sein, besonders wenn du draussen zwischen den Zelten sitzt
+- **Bargeld herrscht** immer noch an manchen Ständen, obwohl die Kartenakzeptanz in den Hauptzelten deutlich besser geworden ist
+- **Komm mit öffentlichen Verkehrsmitteln** -- die Parksituation ist genauso hoffnungslos wie beim Oktoberfest
+- **Sonnencreme**: Die Frühlingssonne kann trügerisch stark sein, besonders wenn du draußen zwischen den Zelten sitzt
 - **Bequeme Schuhe**: Der Boden besteht aus Schotter und Gras, und du wirst stundenlang auf den Beinen sein
 
-## Verfolge dein Fruehlingsfest
+## Verfolge dein Frühlingsfest
 
-Das Fruehlingsfest ist der perfekte Anlass, ProstCounter zu nutzen. Protokolliere jeden Besuch, tracke deinen Bierkonsum ueber die Festdauer und vergleiche dein Fruehlingsfest-Erlebnis mit deinen Oktoberfest-Statistiken. Die App unterstuetzt mehrere Feste, sodass deine Fruehlingsfest-Daten separat und uebersichtlich bleiben.
+Das Frühlingsfest ist der perfekte Anlass, ProstCounter zu nutzen. Protokolliere jeden Besuch, tracke deinen Bierkonsum über die Festdauer und vergleiche dein Frühlingsfest-Erlebnis mit deinen Oktoberfest-Statistiken. Die App unterstützt mehrere Feste, sodass deine Frühlingsfest-Daten separat und übersichtlich bleiben.
 
-Ob du ein Muenchner bist, der das Fruehlingsfest zur jaehrlichen Tradition macht, oder ein Besucher, der seine Reise auf das Fruehlingsfest abstimmt -- dich erwartet ein Genuss. Es ist alles, was die Leute am Oktoberfest lieben -- das Bier, das Essen, die Musik, die Fahrgeschaefte -- in einem zugaenglicheren, guenstigeren und authentisch bayerischen Paket.
+Ob du ein Münchner bist, der das Frühlingsfest zur jährlichen Tradition macht, oder ein Besucher, der seine Reise auf das Frühlingsfest abstimmt -- dich erwartet ein Genuss. Es ist alles, was die Leute am Oktoberfest lieben -- das Bier, das Essen, die Musik, die Fahrgeschäfte -- in einem zugänglicheren, günstigeren und authentisch bayerischen Paket.
 
-Fuer einen vollstaendigen Ueberblick ueber alle Bierfeste, die Muenchen zu bieten hat, schau dir unseren [Kompletten Muenchner Bierfeste-Kalender](/blog/de/munich-beer-festivals-calendar) an.
+Für einen vollständigen Überblick über alle Bierfeste, die München zu bieten hat, schau dir unseren [Kompletten Münchner Bierfeste-Kalender](/blog/de/munich-beer-festivals-calendar) an.
 
 <CTA />

--- a/apps/web/content/blog/de/munich-beer-festivals-calendar.mdx
+++ b/apps/web/content/blog/de/munich-beer-festivals-calendar.mdx
@@ -1,6 +1,6 @@
 ---
-title: "Alle Muenchner Bierfeste: Der komplette Kalender"
-description: "Ein kompletter Kalender aller Muenchner Bierfeste ueber das ganze Jahr -- vom Starkbierfest bis zum Oktoberfest und alles dazwischen."
+title: "Alle Münchner Bierfeste: Der komplette Kalender"
+description: "Ein kompletter Kalender aller Münchner Bierfeste über das ganze Jahr -- vom Starkbierfest bis zum Oktoberfest und alles dazwischen."
 date: "2026-03-05"
 lastModified: "2026-03-05"
 author: "ProstCounter Team"
@@ -10,29 +10,29 @@ featuredImage: "/images/prost-counter-og-4.jpg"
 locale: "de"
 ---
 
-# Alle Muenchner Bierfeste: Der komplette Kalender
+# Alle Münchner Bierfeste: Der komplette Kalender
 
-Die meisten Leute verbinden Muenchen nur mit dem Oktoberfest. Das ist ein Fehler. Muenchen ist eine Stadt, die Bier und bayerische Kultur **das ganze Jahr ueber** feiert -- mit Festen, saisonalen Traditionen und Events in jedem Monat des Kalenders. Ob du als Einheimischer deinen Jahreskalender planst oder als Besucher den perfekten Reisezeitpunkt suchst -- dieser komplette Guide deckt jedes wichtige Bier-Event ab, das Muenchen zu bieten hat.
+Die meisten Leute verbinden München nur mit dem Oktoberfest. Das ist ein Fehler. München ist eine Stadt, die Bier und bayerische Kultur **das ganze Jahr über** feiert -- mit Festen, saisonalen Traditionen und Events in jedem Monat des Kalenders. Ob du als Einheimischer deinen Jahreskalender planst oder als Besucher den perfekten Reisezeitpunkt suchst -- dieser komplette Guide deckt jedes wichtige Bier-Event ab, das München zu bieten hat.
 
-## Januar - Februar: Winterbiergaerten und Starkbier-Vorgeschmack
+## Januar - Februar: Winterbiergärten und Starkbier-Vorgeschmack
 
-Muenchens Wintermonate sind auf der Festfront ruhig, aber die Bierkultur der Stadt haelt nie wirklich Winterschlaf.
+Münchens Wintermonate sind auf der Festfront ruhig, aber die Bierkultur der Stadt hält nie wirklich Winterschlaf.
 
-### Winterbiergaerten
+### Winterbiergärten
 
-Einige Biergaerten haben einen eingeschraenkten Winterbetrieb und servieren warmes Essen und frisches Bier unter beheizten Unterschlaendern:
+Einige Biergärten haben einen eingeschränkten Winterbetrieb und servieren warmes Essen und frisches Bier unter beheizten Unterschländern:
 
-- **Augustiner Keller**: Ganzjaehrig geoeffnet, mit gemuetlichem Innensaal und begrenzten Aussenplaetzen an waermeren Wintertagen
-- **Hofbraeu Keller am Wiener Platz**: Ihr beheizter Winterbiergarten in Haidhausen ist ein Liebling der Einheimischen
-- **Paulaner am Nockherberg**: Im Winter geoeffnet mit deftiger bayerischer Kueche
+- **Augustiner Keller**: Ganzjährig geöffnet, mit gemütlichem Innensaal und begrenzten Außenplätzen an wärmeren Wintertagen
+- **Hofbräu Keller am Wiener Platz**: Ihr beheizter Winterbiergarten in Haidhausen ist ein Liebling der Einheimischen
+- **Paulaner am Nockherberg**: Im Winter geöffnet mit deftiger bayerischer Küche
 
-### Starkbierfest-Vorlaeufer
+### Starkbierfest-Vorläufer
 
-Einige kleinere Brauereien und Bierbars starten die Starkbierzeit schon Ende Februar mit fruehen Verkostungen und speziellen Zapf-Events. Schau bei Craft-Bier-Bars wie dem **Tap House Munich** und der **Crew Republic Brewery** nach Starkbier-Events vor der Saison.
+Einige kleinere Brauereien und Bierbars starten die Starkbierzeit schon Ende Februar mit frühen Verkostungen und speziellen Zapf-Events. Schau bei Craft-Bier-Bars wie dem **Tap House Munich** und der **Crew Republic Brewery** nach Starkbier-Events vor der Saison.
 
-## Maerz - April: Starkbierfest
+## März - April: Starkbierfest
 
-Das ist Muenchens am meisten unterschaetzte Festsaison. Fuer einen tiefen Einblick lies unseren kompletten [Starkbierfest-Guide](/blog/de/starkbierfest-guide).
+Das ist Münchens am meisten unterschätzte Festsaison. Für einen tiefen Einblick lies unseren kompletten [Starkbierfest-Guide](/blog/de/starkbierfest-guide).
 
 <FestivalInfo
   name="Starkbierfest"
@@ -42,21 +42,21 @@ Das ist Muenchens am meisten unterschaetzte Festsaison. Fuer einen tiefen Einbli
 
 ### Was passiert
 
-Jede grosse Muenchner Brauerei bringt ihren eigenen Doppelbock raus -- ein starkes, malziges Lagerbier mit 7-8,5 % Vol. -- und veranstaltet Feiern quer durch die Stadt. Das Flaggschiff-Event ist der Anstich beim **Paulaner am Nockherberg**, komplett mit einer national im Fernsehen uebertragenen politischen Komoedienshow (dem Derblecken).
+Jede große Münchner Brauerei bringt ihren eigenen Doppelbock raus -- ein starkes, malziges Lagerbier mit 7-8,5 % Vol. -- und veranstaltet Feiern quer durch die Stadt. Das Flaggschiff-Event ist der Anstich beim **Paulaner am Nockherberg**, komplett mit einer national im Fernsehen übertragenen politischen Komödienshow (dem Derblecken).
 
 ### Wichtige Termine (2026)
 
-- **Nockherberg Starkbieranstich**: Normalerweise Mitte Maerz (genauer Termin wird im Januar bekanntgegeben)
-- **Saisondauer**: Ungefaehr 3-4 Wochen, bis Anfang April
-- **Andere Locations**: Augustiner Keller, Hofbraeuhaus, Loewenbraeukeller und viele weitere veranstalten eigene Feiern
+- **Nockherberg Starkbieranstich**: Normalerweise Mitte März (genauer Termin wird im Januar bekanntgegeben)
+- **Saisondauer**: Ungefähr 3-4 Wochen, bis Anfang April
+- **Andere Locations**: Augustiner Keller, Hofbräuhaus, Löwenbräukeller und viele weitere veranstalten eigene Feiern
 
 ### Warum hingehen
 
-Es ist das authentischste bayerische Bier-Event des Jahres. Kleinere Menschenmengen, staerkeres Bier und eine Atmosphaere, die sich anfuehlt, als wuerde Muenchen fuer Muenchen feiern -- nicht fuer Touristen.
+Es ist das authentischste bayerische Bier-Event des Jahres. Kleinere Menschenmengen, stärkeres Bier und eine Atmosphäre, die sich anfühlt, als würde München für München feiern -- nicht für Touristen.
 
-## Ende April - Mai: Fruehlingsfest
+## Ende April - Mai: Frühlingsfest
 
-Muenchens zweitgroesstes Volksfest erweckt die Theresienwiese nach dem Winter wieder zum Leben. Alle Details findest du in unserem [Fruehlingsfest-Guide](/blog/de/fruehlingsfest-guide).
+Münchens zweitgrößtes Volksfest erweckt die Theresienwiese nach dem Winter wieder zum Leben. Alle Details findest du in unserem [Frühlingsfest-Guide](/blog/de/fruehlingsfest-guide).
 
 <FestivalInfo
   name="Frühlingsfest"
@@ -66,17 +66,17 @@ Muenchens zweitgroesstes Volksfest erweckt die Theresienwiese nach dem Winter wi
 
 ### Was passiert
 
-Ein Mini-Oktoberfest auf dem gleichen Gelaende, mit zwei grossen Bierzelten (Augustiner Festhalle und Festhalle Bayernland), Fahrgeschaeften, Essensstaenden und Live-Musik. Rund 1,5 Millionen Besucher kommen ueber ungefaehr drei Wochen.
+Ein Mini-Oktoberfest auf dem gleichen Gelände, mit zwei großen Bierzelten (Augustiner Festhalle und Festhalle Bayernland), Fahrgeschäften, Essensständen und Live-Musik. Rund 1,5 Millionen Besucher kommen über ungefähr drei Wochen.
 
 ### Wichtige Termine (2026)
 
-- **Eroeffnung**: Voraussichtlich Freitag, 24. April
+- **Eröffnung**: Voraussichtlich Freitag, 24. April
 - **Ende**: Voraussichtlich Sonntag, 17. Mai
 - **Familientag**: Normalerweise dienstags, mit reduzierten Fahrpreisen
 
 ### Warum hingehen
 
-Gleicher Wiesn-Zauber wie beim Oktoberfest, aber mit 75 % weniger Leuten, 20 % niedrigeren Preisen und deutlich besserem Wetter. Das ist die Insider-Wahl fuer ein Muenchner Volksfest-Erlebnis.
+Gleicher Wiesn-Zauber wie beim Oktoberfest, aber mit 75 % weniger Leuten, 20 % niedrigeren Preisen und deutlich besserem Wetter. Das ist die Insider-Wahl für ein Münchner Volksfest-Erlebnis.
 
 ## Mai: Maibock-Saison und Maibaum-Feiern
 
@@ -84,26 +84,26 @@ Der Mai bringt zwei beliebte Traditionen: die Ankunft des Maibocks und das Aufst
 
 ### Maibock-Saison
 
-**Maibock** (auch Heller Bock oder Lentebock genannt) ist ein starkes, helles Lagerbier, das traditionell fuer den Fruehling gebraut wird. Wichtige Events:
+**Maibock** (auch Heller Bock oder Lentebock genannt) ist ein starkes, helles Lagerbier, das traditionell für den Frühling gebraut wird. Wichtige Events:
 
-- **Hofbraeuhaus Maibockanstich**: Das Hofbraeuhaus veranstaltet einen offiziellen Maibock-Anstich, normalerweise Ende April oder Anfang Mai. Es ist ein festlicher Abend mit Reden, Blasmusik und den ersten Ausschaenken des neuen Maibocks.
-- **Maibock-Verfuegbarkeit**: Die meisten Muenchner Bierhallen und -gaerten nehmen den Maibock im Mai auf ihre Karten, was einen prima Anlass fuer eine Biergarten-Tour bietet.
+- **Hofbräuhaus Maibockanstich**: Das Hofbräuhaus veranstaltet einen offiziellen Maibock-Anstich, normalerweise Ende April oder Anfang Mai. Es ist ein festlicher Abend mit Reden, Blasmusik und den ersten Ausschänken des neuen Maibocks.
+- **Maibock-Verfügbarkeit**: Die meisten Münchner Bierhallen und -gärten nehmen den Maibock im Mai auf ihre Karten, was einen prima Anlass für eine Biergarten-Tour bietet.
 
 ### Maibaum-Feiern
 
-Am **1. Mai** stellen Doerfer und Stadtviertel in ganz Bayern aufwaendig geschmueckte Maibaeueme auf -- eine Tradition, die Jahrhunderte zurueckreicht. Die Feiern umfassen:
+Am **1. Mai** stellen Dörfer und Stadtviertel in ganz Bayern aufwändig geschmückte Maibäume auf -- eine Tradition, die Jahrhunderte zurückreicht. Die Feiern umfassen:
 
 - Live-Musik und Tanzen um den Maibaum
-- Bier- und Essensstaende
-- Gemeinschaftstreffen auf Dorfplaetzen und in Biergaerten
+- Bier- und Essensstände
+- Gemeinschaftstreffen auf Dorfplätzen und in Biergärten
 
-In Muenchen steht der bekannteste Maibaum am **Viktualienmarkt**. Vororte wie Harlaching, Solln und Thalkirchen haben ebenfalls bemerkenswerte Maibaum-Traditionen mit echten lokalen Feierlichkeiten.
+In München steht der bekannteste Maibaum am **Viktualienmarkt**. Vororte wie Harlaching, Solln und Thalkirchen haben ebenfalls bemerkenswerte Maibaum-Traditionen mit echten lokalen Feierlichkeiten.
 
-In der Nacht davor (Walpurgisnacht, 30. April) versuchen rivalisierende Doerfer traditionell, sich gegenseitig die Maibaeueme zu stehlen -- ein Brauch, der heute noch praktiziert wird und zu gutmuetigen Loesegeld-Verhandlungen fuehrt (die normalerweise mit Bier beglichen werden).
+In der Nacht davor (Walpurgisnacht, 30. April) versuchen rivalisierende Dörfer traditionell, sich gegenseitig die Maibäume zu stehlen -- ein Brauch, der heute noch praktiziert wird und zu gutmütigen Lösegeld-Verhandlungen führt (die normalerweise mit Bier beglichen werden).
 
 ## Juni: Tollwood Sommerfestival
 
-**Tollwood** ist Muenchens wichtigstes Open-Air-Kulturfestival, das von Ende Juni bis Ende Juli im **Olympiapark** stattfindet.
+**Tollwood** ist Münchens wichtigstes Open-Air-Kulturfestival, das von Ende Juni bis Ende Juli im **Olympiapark** stattfindet.
 
 <FestivalInfo
   name="Tollwood Sommerfestival"
@@ -115,52 +115,52 @@ In der Nacht davor (Walpurgisnacht, 30. April) versuchen rivalisierende Doerfer 
 
 Tollwood ist in erster Linie ein Musik-, Kunst- und Kulturfestival, hat aber eine starke Essen-und-Trinken-Komponente. Das Fest bietet:
 
-- **Bio-Bier- und Essensmarkt**: Ueber 50 Essensstaende mit internationaler Kueche, alle mit oekologischem und nachhaltigem Anspruch. Mehrere Bierstaende schenken Craft- und Regionalbiere aus.
-- **Kostenlose Konzerte und Auffuehrungen**: Musikacts, Theater, Zirkusvorfuehrungen und Kunstinstallationen auf dem Olympiapark-Gelaende.
-- **Marktstaende**: Kunsthandwerk, Handwerkskunst und Geschenke aus aller Welt.
+- **Bio-Bier- und Essensmarkt**: Über 50 Essensstände mit internationaler Küche, alle mit ökologischem und nachhaltigem Anspruch. Mehrere Bierstände schenken Craft- und Regionalbiere aus.
+- **Kostenlose Konzerte und Aufführungen**: Musikacts, Theater, Zirkusvorführungen und Kunstinstallationen auf dem Olympiapark-Gelände.
+- **Marktstände**: Kunsthandwerk, Handwerkskunst und Geschenke aus aller Welt.
 
 ### Wichtige Termine (2026)
 
-- **Dauer**: Ungefaehr Ende Juni bis Ende Juli
-- **Eintritt**: Freier Eintritt aufs Gelaende (manche Konzerte und Auffuehrungen sind kostenpflichtig)
+- **Dauer**: Ungefähr Ende Juni bis Ende Juli
+- **Eintritt**: Freier Eintritt aufs Gelände (manche Konzerte und Aufführungen sind kostenpflichtig)
 
 ### Warum hingehen
 
-Es ist zwar kein Bierfest im eigentlichen Sinne, aber die Kombination aus Live-Musik, exzellentem Essen, Bio-Bier-Optionen und einer entspannten Sommeratmosphaere macht es zu einem der angenehmsten Events Muenchens. Das Publikum ist vielfaeltig und die Location im Olympiapark -- mit dem Olympiaturm und der BMW Welt im Hintergrund -- ist umwerfend.
+Es ist zwar kein Bierfest im eigentlichen Sinne, aber die Kombination aus Live-Musik, exzellentem Essen, Bio-Bier-Optionen und einer entspannten Sommeratmosphäre macht es zu einem der angenehmsten Events Münchens. Das Publikum ist vielfältig und die Location im Olympiapark -- mit dem Olympiaturm und der BMW Welt im Hintergrund -- ist umwerfend.
 
 ## Juli - August: Biergarten-Hochsaison
 
-Die Muenchner Biergarten-Saison laeuft technisch gesehen von Maerz bis Oktober, aber Juli und August sind die absolute Hochsaison. Mit langen Sommertagen, Temperaturen bis 25-30 Grad C und Sonnenuntergang erst um 21 Uhr -- dann entfaltet Muenchens Biergarten-Kultur ihre ganze Pracht.
+Die Münchner Biergarten-Saison läuft technisch gesehen von März bis Oktober, aber Juli und August sind die absolute Hochsaison. Mit langen Sommertagen, Temperaturen bis 25-30 Grad C und Sonnenuntergang erst um 21 Uhr -- dann entfaltet Münchens Biergarten-Kultur ihre ganze Pracht.
 
-### Die wichtigsten Biergaerten
+### Die wichtigsten Biergärten
 
-Muenchen hat ueber 100 Biergaerten. Das sind die Ikonen:
+München hat über 100 Biergärten. Das sind die Ikonen:
 
-- **Augustiner Keller** (Arnulfstrasse): 5.000 Plaetze unter Kastanienbaeuemen. Augustiner vom Fass. Fuer viele Einheimische die Nummer 1.
-- **Hirschgarten**: Der groesste Biergarten der Welt -- 8.000 Plaetze in einer wunderschoenen Parkanlage nahe Schloss Nymphenburg. Serviert Augustiner.
-- **Chinesischer Turm** (Englischer Garten): 7.000 Plaetze rund um die Pagode. Zentral, touristisch, aber wirklich schoen. Hofbraeu.
-- **Seehaus** (Englischer Garten): Biergarten am See mit gehobenerer Atmosphaere. Paulaner.
-- **Viktualienmarkt**: Muenchens beruehmter Lebensmittelmarkt hat einen kleinen, aber beliebten Biergarten, der durch alle sechs Muenchner Brauereien rotiert.
-- **Waldwirtschaft Grosshesselohe**: Ueber dem Isarufer gelegen, mit Live-Jazz an Sommerabenden. Spaten.
-- **Paulaner am Nockherberg**: Die gleiche Location, die das Starkbierfest ausrichtet, hat auch einen schoenen Biergarten fuer den Sommer.
-- **Taxisgarten**: Ein Geheimtipp im Stadtteil Gern mit 1.500 Plaetzen und Spielplatz. Spaten.
-- **Muffatwerk Biergarten**: Neben dem Mueller'schen Volksbad an der Isar. Junges, alternatives Publikum. Verschiedene Biere.
+- **Augustiner Keller** (Arnulfstraße): 5.000 Plätze unter Kastanienbäumen. Augustiner vom Fass. Für viele Einheimische die Nummer 1.
+- **Hirschgarten**: Der größte Biergarten der Welt -- 8.000 Plätze in einer wunderschönen Parkanlage nahe Schloss Nymphenburg. Serviert Augustiner.
+- **Chinesischer Turm** (Englischer Garten): 7.000 Plätze rund um die Pagode. Zentral, touristisch, aber wirklich schön. Hofbräu.
+- **Seehaus** (Englischer Garten): Biergarten am See mit gehobenerer Atmosphäre. Paulaner.
+- **Viktualienmarkt**: Münchens berühmter Lebensmittelmarkt hat einen kleinen, aber beliebten Biergarten, der durch alle sechs Münchner Brauereien rotiert.
+- **Waldwirtschaft Großhesselohe**: Über dem Isarufer gelegen, mit Live-Jazz an Sommerabenden. Spaten.
+- **Paulaner am Nockherberg**: Die gleiche Location, die das Starkbierfest ausrichtet, hat auch einen schönen Biergarten für den Sommer.
+- **Taxisgarten**: Ein Geheimtipp im Stadtteil Gern mit 1.500 Plätzen und Spielplatz. Spaten.
+- **Muffatwerk Biergarten**: Neben dem Müller'schen Volksbad an der Isar. Junges, alternatives Publikum. Verschiedene Biere.
 
 ### Biergarten-Regeln
 
-Muenchner Biergaerten funktionieren nach einer einzigartigen Tradition: Du darfst dein eigenes Essen mitbringen, solange du deine Getraenke dort kaufst. Das ist gesetzlich geschuetzt und wird zutiefst respektiert. Du wirst Familien sehen, die mit aufwendigen Picknick-Auslagen ankommen -- Brotzeit-Bretter, Salate, Kuchen -- waehrend sie Masskruege an der Theke bestellen. Die Biergarten-Tische sind in "Bedienung" (mit Kellnerservice) und "Selbstbedienung" unterteilt.
+Münchner Biergärten funktionieren nach einer einzigartigen Tradition: Du darfst dein eigenes Essen mitbringen, solange du deine Getränke dort kaufst. Das ist gesetzlich geschützt und wird zutiefst respektiert. Du wirst Familien sehen, die mit aufwendigen Picknick-Auslagen ankommen -- Brotzeit-Bretter, Salate, Kuchen -- während sie Maßkrüge an der Theke bestellen. Die Biergarten-Tische sind in "Bedienung" (mit Kellnerservice) und "Selbstbedienung" unterteilt.
 
 ### Sommerabend-Events
 
-Viele Biergaerten veranstalten waehrend der Hochsaison besondere Events:
+Viele Biergärten veranstalten während der Hochsaison besondere Events:
 
-- **Live-Musik-Abende**: Waldwirtschaft und Seehaus bieten regelmaessig Live-Bands
-- **Italienische Naechte**: Einige Biergaerten servieren an bestimmten Abenden italienisches Essen zum Bier
-- **Kocherlball**: Ein Fruehmorgens-Tanz-Event am Chinesischen Turm, am dritten Sonntag im Juli. Tausende Menschen kommen um 6 Uhr morgens in Tracht, um zu Blasmusik zu tanzen. Kostenlos und absolut magisch.
+- **Live-Musik-Abende**: Waldwirtschaft und Seehaus bieten regelmäßig Live-Bands
+- **Italienische Nächte**: Einige Biergärten servieren an bestimmten Abenden italienisches Essen zum Bier
+- **Kocherlball**: Ein Frühmorgens-Tanz-Event am Chinesischen Turm, am dritten Sonntag im Juli. Tausende Menschen kommen um 6 Uhr morgens in Tracht, um zu Blasmusik zu tanzen. Kostenlos und absolut magisch.
 
 ## September - Oktober: Oktoberfest
 
-Das grosse Event. Das groesste Volksfest der Welt. Alle Details findest du in unserem [Oktoberfest 2026 Guide](/blog/de/oktoberfest-2026-guide) und unserem Guide zu [allen 38 Oktoberfest-Zelten](/blog/de/oktoberfest-tents-guide).
+Das große Event. Das größte Volksfest der Welt. Alle Details findest du in unserem [Oktoberfest 2026 Guide](/blog/de/oktoberfest-2026-guide) und unserem Guide zu [allen 38 Oktoberfest-Zelten](/blog/de/oktoberfest-tents-guide).
 
 <FestivalInfo
   name="Oktoberfest 2026"
@@ -170,23 +170,23 @@ Das grosse Event. Das groesste Volksfest der Welt. Alle Details findest du in un
 
 ### Was passiert
 
-Ueber sechs Millionen Besucher stroemen 16 Tage lang auf die Theresienwiese zum Feiern mit Bier, Essen, Fahrgeschaeften und Tradition. Vierzehn grosse Bierzelte, 21 kleine Zelte und der historische Bereich Oide Wiesn bieten jede erdenkliche Atmosphaere -- vom ruhigen Familienmittag bis zur ausgelassenen Abendparty.
+Über sechs Millionen Besucher strömen 16 Tage lang auf die Theresienwiese zum Feiern mit Bier, Essen, Fahrgeschäften und Tradition. Vierzehn große Bierzelte, 21 kleine Zelte und der historische Bereich Oide Wiesn bieten jede erdenkliche Atmosphäre -- vom ruhigen Familienmittag bis zur ausgelassenen Abendparty.
 
 ### Wichtige Termine (2026)
 
-- **Eroeffnung**: Samstag, 19. September (O'zapft is!-Zeremonie um 12 Uhr)
+- **Eröffnung**: Samstag, 19. September (O'zapft is!-Zeremonie um 12 Uhr)
 - **Ende**: Sonntag, 4. Oktober
-- **Trachten- und Schuetzenzug**: Sonntag, 20. September
+- **Trachten- und Schützenzug**: Sonntag, 20. September
 
 ### Warum hingehen
 
-Es ist das Oktoberfest. Es gibt nichts Vergleichbares auf der Welt. Die Groesse, die Energie, die Tradition, die Musik -- es steht nicht umsonst auf jeder Bucket List.
+Es ist das Oktoberfest. Es gibt nichts Vergleichbares auf der Welt. Die Größe, die Energie, die Tradition, die Musik -- es steht nicht umsonst auf jeder Bucket List.
 
 ## Oktober: Biergarten-Finale nach dem Oktoberfest
 
-Nach dem Ende des Oktoberfests Anfang Oktober geniessen Muenchens Biergaerten noch ein paar letzte Wochen vor dem Winter. Der Oktober kann wunderschoenes Herbstwetter bringen -- klare, frische Tage mit Temperaturen um 10-15 Grad C -- und die Biergaerten dienen als friedlicher Kontrast zum gerade beendeten Oktoberfest-Trubel.
+Nach dem Ende des Oktoberfests Anfang Oktober genießen Münchens Biergärten noch ein paar letzte Wochen vor dem Winter. Der Oktober kann wunderschönes Herbstwetter bringen -- klare, frische Tage mit Temperaturen um 10-15 Grad C -- und die Biergärten dienen als friedlicher Kontrast zum gerade beendeten Oktoberfest-Trubel.
 
-Das ist eine wunderbare Zeit, Muenchen zu besuchen, wenn du die Atmosphaere ohne die Volksfest-Massen moechtest. Die Stadt ist erleichtert und entspannt, die Herbstfarben im Englischen Garten sind spektakulaer, und die Biergaerten sind ruhig genug, um tatsaechlich ein Gespraech zu fuehren.
+Das ist eine wunderbare Zeit, München zu besuchen, wenn du die Atmosphäre ohne die Volksfest-Massen möchtest. Die Stadt ist erleichtert und entspannt, die Herbstfarben im Englischen Garten sind spektakulär, und die Biergärten sind ruhig genug, um tatsächlich ein Gespräch zu führen.
 
 ## November: Winterfest (ehemals Tollwood Winter)
 
@@ -194,52 +194,52 @@ Wenn die Temperaturen sinken, verwandelt das **Tollwood Winterfestival** die The
 
 ### Was passiert
 
-- **Weihnachtsmarkt**: Kunsthandwerker-Staende mit Handwerk, Geschenken und Dekoration
-- **Bio-Essensmarkt**: Heisser Gluehwein, gerostete Maroni, bayerisches Gebaeck und internationales Streetfood
-- **Live-Auffuehrungen**: Theater, Konzerte und Zirkusacts in beheizten Zelten
-- **Eislaufen und Winteraktivitaeten**
+- **Weihnachtsmarkt**: Kunsthandwerker-Stände mit Handwerk, Geschenken und Dekoration
+- **Bio-Essensmarkt**: Heißer Glühwein, gerostete Maroni, bayerisches Gebäck und internationales Streetfood
+- **Live-Aufführungen**: Theater, Konzerte und Zirkusacts in beheizten Zelten
+- **Eislaufen und Winteraktivitäten**
 
 ### Wichtige Termine (2026)
 
 - **Dauer**: Ende November bis 31. Dezember
-- **Eintritt**: Freier Eintritt aufs Gelaende; manche Auffuehrungen sind kostenpflichtig
+- **Eintritt**: Freier Eintritt aufs Gelände; manche Aufführungen sind kostenpflichtig
 
-## Dezember: Christkindlmaerkte (Weihnachtsmaerkte)
+## Dezember: Christkindlmärkte (Weihnachtsmärkte)
 
-Muenchens Weihnachtsmaerkte gehoeren zu den schoensten Deutschlands. Zwar keine Bierfeste, aber ein wesentlicher Teil von Muenchens Trinkkultur -- im Zeichen von **Gluehwein** und saisonalen Bieren.
+Münchens Weihnachtsmärkte gehören zu den schönsten Deutschlands. Zwar keine Bierfeste, aber ein wesentlicher Teil von Münchens Trinkkultur -- im Zeichen von **Glühwein** und saisonalen Bieren.
 
-### Grosse Weihnachtsmaerkte
+### Große Weihnachtsmärkte
 
-- **Marienplatz Christkindlmarkt**: Das Hauptevent, vor der Kulisse des beleuchteten Neuen Rathauses. Mit dem riesigen Weihnachtsbaum der Stadt und dem beruehmten Balkonkonzert-Programm.
-- **Mittelaltermarkt**: Am Wittelsbacherplatz, mit historischem Handwerk, Met (Honigwein) und einzigartiger Atmosphaere.
-- **Haidhauser Weihnachtsmarkt**: Der Markt am Weissenburger Platz ist ein Geheimtipp der Einheimischen, weniger touristisch und staerker gemeinschaftlich gepraegt.
-- **Residenz Weihnachtsmarkt**: Im Innenhof der Muenchner Koenigsresidenz, mit einer erlesenen Auswahl an Kunsthandwerk.
-- **Schwabinger Weihnachtsmarkt**: Muenchens Kuenstlerviertel veranstaltet einen kunsthandwerk-orientierten Markt an der Muenchner Freiheit.
+- **Marienplatz Christkindlmarkt**: Das Hauptevent, vor der Kulisse des beleuchteten Neuen Rathauses. Mit dem riesigen Weihnachtsbaum der Stadt und dem berühmten Balkonkonzert-Programm.
+- **Mittelaltermarkt**: Am Wittelsbacherplatz, mit historischem Handwerk, Met (Honigwein) und einzigartiger Atmosphäre.
+- **Haidhauser Weihnachtsmarkt**: Der Markt am Weißenburger Platz ist ein Geheimtipp der Einheimischen, weniger touristisch und stärker gemeinschaftlich geprägt.
+- **Residenz Weihnachtsmarkt**: Im Innenhof der Münchner Königsresidenz, mit einer erlesenen Auswahl an Kunsthandwerk.
+- **Schwabinger Weihnachtsmarkt**: Münchens Künstlerviertel veranstaltet einen kunsthandwerk-orientierten Markt an der Münchner Freiheit.
 
 ### Saisonale Winterbiere
 
-Mehrere Muenchner Brauereien bringen im Dezember spezielle Winterbiere (Winterfestbier) heraus. Das Hofbraeuhaus und der Augustiner Keller schenken beide saisonale Spezialitaeten neben klassischem bayerischem Weihnachtsessen aus.
+Mehrere Münchner Brauereien bringen im Dezember spezielle Winterbiere (Winterfestbier) heraus. Das Hofbräuhaus und der Augustiner Keller schenken beide saisonale Spezialitäten neben klassischem bayerischem Weihnachtsessen aus.
 
-## Plane dein Bierjahr in Muenchen
+## Plane dein Bierjahr in München
 
-Hier eine Kurzuebersicht fuer die Reiseplanung:
+Hier eine Kurzübersicht für die Reiseplanung:
 
 | Monat     | Fest / Event                         | Menschenmenge  | Insider-Bewertung                  |
 | --------- | ------------------------------------ | -------------- | ---------------------------------- |
-| Jan-Feb   | Winterbiergaerten                    | Niedrig        | Gemuetlich                         |
-| Maerz     | Starkbierfest                        | Niedrig-Mittel | Hoch authentisch                   |
-| April     | Fruehlingsfest                       | Mittel         | Bestes Preis-Leistungs-Verhaeltnis |
+| Jan-Feb   | Winterbiergärten                    | Niedrig        | Gemütlich                         |
+| März     | Starkbierfest                        | Niedrig-Mittel | Hoch authentisch                   |
+| April     | Frühlingsfest                       | Mittel         | Bestes Preis-Leistungs-Verhältnis |
 | Mai       | Maibock + Maibaum                    | Niedrig        | Lokale Tradition                   |
 | Juni-Juli | Tollwood Sommer                      | Mittel         | Kultur + Bier                      |
-| Juli-Aug  | Biergarten-Hochsaison                | Mittel         | Quintessenz Muenchens              |
+| Juli-Aug  | Biergarten-Hochsaison                | Mittel         | Quintessenz Münchens              |
 | Sep-Okt   | Oktoberfest                          | Extrem         | Bucket List                        |
-| Nov-Dez   | Christkindlmaerkte + Tollwood Winter | Mittel-Hoch    | Festlich und magisch               |
+| Nov-Dez   | Christkindlmärkte + Tollwood Winter | Mittel-Hoch    | Festlich und magisch               |
 
 ## Verfolge jedes Fest mit ProstCounter
 
-Bei so vielen Festen und Events ueber das ganze Jahr ist ProstCounter die perfekte Moeglichkeit, deine Muenchner Bier-Abenteuer festzuhalten. Protokolliere deine Anwesenheit bei jedem Fest, tracke deinen Konsum ueber verschiedene Events, vergleiche deine Fruehlingsfest-Statistiken mit deiner Oktoberfest-Performance und baue eine komplette Chronik deiner Volksfest-Erlebnisse auf.
+Bei so vielen Festen und Events über das ganze Jahr ist ProstCounter die perfekte Möglichkeit, deine Münchner Bier-Abenteuer festzuhalten. Protokolliere deine Anwesenheit bei jedem Fest, tracke deinen Konsum über verschiedene Events, vergleiche deine Frühlingsfest-Statistiken mit deiner Oktoberfest-Performance und baue eine komplette Chronik deiner Volksfest-Erlebnisse auf.
 
-Ob du ein Fest besuchst oder die Pilgerreise zu allen machst -- Muenchen belohnt den neugierigen Biertrinker. Jede Jahreszeit bringt etwas anderes, jede Brauerei hat ihren eigenen Charakter, und jeder Biergarten hat eine Geschichte zu erzaehlen.
+Ob du ein Fest besuchst oder die Pilgerreise zu allen machst -- München belohnt den neugierigen Biertrinker. Jede Jahreszeit bringt etwas anderes, jede Brauerei hat ihren eigenen Charakter, und jeder Biergarten hat eine Geschichte zu erzählen.
 
 Prost auf den vollen Kalender!
 

--- a/apps/web/content/blog/de/oktoberfest-2026-guide.mdx
+++ b/apps/web/content/blog/de/oktoberfest-2026-guide.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Der komplette Oktoberfest-Guide 2026: Termine, Tipps & was dich erwartet"
-description: "Alles, was du zum Oktoberfest 2026 wissen musst -- Termine, Bierpreise, Zeltreservierungen und Insider-Tipps zum groessten Volksfest der Welt."
+description: "Alles, was du zum Oktoberfest 2026 wissen musst -- Termine, Bierpreise, Zeltreservierungen und Insider-Tipps zum größten Volksfest der Welt."
 date: "2026-03-15"
 lastModified: "2026-08-05"
 author: "ProstCounter Team"
@@ -12,7 +12,7 @@ locale: "de"
 
 # Der komplette Oktoberfest-Guide 2026: Termine, Tipps & was dich erwartet
 
-Das Oktoberfest ist das groesste Volksfest der Welt und lockt jedes Jahr ueber sechs Millionen Besucher nach Muenchen. Ob du zum ersten Mal dabei bist und deinen Traumtrip planst oder als alter Hase die neuesten Infos suchst -- dieser umfassende Guide deckt alles ab, was du zum **Oktoberfest 2026** wissen musst.
+Das Oktoberfest ist das größte Volksfest der Welt und lockt jedes Jahr über sechs Millionen Besucher nach München. Ob du zum ersten Mal dabei bist und deinen Traumtrip planst oder als alter Hase die neuesten Infos suchst -- dieser umfassende Guide deckt alles ab, was du zum **Oktoberfest 2026** wissen musst.
 
 ## Offizielle Termine: 19. September - 4. Oktober 2026
 
@@ -20,144 +20,144 @@ Das Oktoberfest 2026 dauert **16 Tage**: Eröffnung am Samstag, den 19. Septembe
 
 ### Wichtige Termine zum Vormerken
 
-- **Samstag, 19. September**: Grosse Eroeffnungszeremonie -- der Oberbuergermeister von Muenchen sticht um 12 Uhr mittags im Schottenhamel-Festzelt das erste Fass an mit dem beruehmten Ruf "O'zapft is!" (Es ist angezapft!). Das Fest beginnt offiziell.
-- **Sonntag, 20. September**: Trachten- und Schuetzenzug mit ueber 9.000 Teilnehmern in bayerischer Tracht.
+- **Samstag, 19. September**: Große Eröffnungszeremonie -- der Oberbürgermeister von München sticht um 12 Uhr mittags im Schottenhamel-Festzelt das erste Fass an mit dem berühmten Ruf "O'zapft is!" (Es ist angezapft!). Das Fest beginnt offiziell.
+- **Sonntag, 20. September**: Trachten- und Schützenzug mit über 9.000 Teilnehmern in bayerischer Tracht.
 - **Samstag, 19. September**: Einzug der Wiesnwirte und Brauereien.
-- **Samstag, 3. Oktober**: Tag der Deutschen Einheit -- erwarte groessere Menschenmengen.
+- **Samstag, 3. Oktober**: Tag der Deutschen Einheit -- erwarte größere Menschenmengen.
 - **Sonntag, 4. Oktober**: Letzter Tag. Letzter Ausschank in den Zelten um 22:30 Uhr.
 
 ## Wo es stattfindet: Theresienwiese
 
-Das Oktoberfest findet auf der **Theresienwiese** statt (die Muenchner sagen einfach "die Wiesn"), einer 42 Hektar grossen Freiflaeche suedwestlich der Muenchner Innenstadt. Der Name geht zurueck auf das Jahr 1810, als das erste Oktoberfest zur Feier der Hochzeit von Kronprinz Ludwig und Prinzessin Therese von Sachsen-Hildburghausen abgehalten wurde.
+Das Oktoberfest findet auf der **Theresienwiese** statt (die Münchner sagen einfach "die Wiesn"), einer 42 Hektar großen Freifläche südwestlich der Münchner Innenstadt. Der Name geht zurück auf das Jahr 1810, als das erste Oktoberfest zur Feier der Hochzeit von Kronprinz Ludwig und Prinzessin Therese von Sachsen-Hildburghausen abgehalten wurde.
 
 ### Anfahrt
 
-Die Theresienwiese ist hervorragend an den oeffentlichen Nahverkehr angebunden:
+Die Theresienwiese ist hervorragend an den öffentlichen Nahverkehr angebunden:
 
-- **U-Bahn**: Linien U4 und U5 zur Station **Theresienwiese** -- damit stehst du direkt am Eingang. Die U3/U6 zu **Goetheplatz** oder **Poccistrasse** sind Alternativen in der Naehe mit kuerzeren Wartezeiten.
-- **S-Bahn**: Ausstieg **Hackerbruecke** und 10 Minuten suedlich entlang der Brauereiwagen laufen. Ein schoener Weg.
-- **Hauptbahnhof**: 15 Minuten Fussweg Richtung Sueden -- einfach der Menschenmenge folgen.
-- **Mit dem Auto**: Lass es sein. Es gibt praktisch keine Parkplaetze in der Naehe des Festgelaendes, und der Verkehr ist stark eingeschraenkt. Nutze Park & Ride-Plaetze am Stadtrand und fahre mit den Oeffis rein.
+- **U-Bahn**: Linien U4 und U5 zur Station **Theresienwiese** -- damit stehst du direkt am Eingang. Die U3/U6 zu **Goetheplatz** oder **Poccistraße** sind Alternativen in der Nähe mit kürzeren Wartezeiten.
+- **S-Bahn**: Ausstieg **Hackerbrücke** und 10 Minuten südlich entlang der Brauereiwagen laufen. Ein schöner Weg.
+- **Hauptbahnhof**: 15 Minuten Fußweg Richtung Süden -- einfach der Menschenmenge folgen.
+- **Mit dem Auto**: Lass es sein. Es gibt praktisch keine Parkplätze in der Nähe des Festgeländes, und der Verkehr ist stark eingeschränkt. Nutze Park & Ride-Plätze am Stadtrand und fahre mit den Öffis rein.
 
-**Profi-Tipp**: Kauf dir eine Tageskarte fuer das Muenchner MVV-Netz (Tageskarte Innenraum, ca. 9 EUR). Damit faehrst du unbegrenzt mit allen S-Bahnen, U-Bahnen, Trams und Bussen innerhalb der Stadt.
+**Profi-Tipp**: Kauf dir eine Tageskarte für das Münchner MVV-Netz (Tageskarte Innenraum, ca. 9 EUR). Damit fährst du unbegrenzt mit allen S-Bahnen, U-Bahnen, Trams und Bussen innerhalb der Stadt.
 
 ## Bierpreise und was dich 2026 erwartet
 
-Die Preise auf dem Oktoberfest sind ueber die Jahre stetig gestiegen, und 2026 wird da keine Ausnahme sein. Basierend auf den letzten Trends kannst du ungefaehr mit folgenden Preisen rechnen:
+Die Preise auf dem Oktoberfest sind über die Jahre stetig gestiegen, und 2026 wird da keine Ausnahme sein. Basierend auf den letzten Trends kannst du ungefähr mit folgenden Preisen rechnen:
 
 - **Eine Maß Bier (1 Liter)**: 15,80 € in den meisten Zelten, insgesamt zwischen 14,80 € und 17,80 € ([komplette Preisliste nach Zelt](/blog/de/oktoberfest-2026-beer-prices))
 - **Halbes Hendl**: 16 - 18 EUR
 - **Schweinshaxe**: 20 - 25 EUR
-- **Grosse Breze**: 6 - 8 EUR
+- **Große Breze**: 6 - 8 EUR
 - **Gebrannte Mandeln**: 8 - 10 EUR
 
-Nur sechs Brauereien duerfen auf dem Oktoberfest Bier ausschenken: **Augustiner**, **Hacker-Pschorr**, **Hofbraeu**, **Loewenbraeu**, **Paulaner** und **Spaten**. Alle Biere muessen dem Reinheitsgebot (dem deutschen Bierreinheitsgesetz von 1516) entsprechen und werden speziell fuer das Fest mit leicht hoeherem Alkoholgehalt gebraut (typisch 5,8 % - 6,3 %).
+Nur sechs Brauereien dürfen auf dem Oktoberfest Bier ausschenken: **Augustiner**, **Hacker-Pschorr**, **Hofbräu**, **Löwenbräu**, **Paulaner** und **Spaten**. Alle Biere müssen dem Reinheitsgebot (dem deutschen Bierreinheitsgesetz von 1516) entsprechen und werden speziell für das Fest mit leicht höherem Alkoholgehalt gebraut (typisch 5,8 % - 6,3 %).
 
-Behalte deine Ausgaben und deinen Konsum im Blick mit [ProstCounter](/) -- die App wurde speziell fuer Volksfest-Besucher entwickelt, die ihre taegliche Anwesenheit protokollieren, sich mit Freunden vergleichen und nach dem Fest lustige Statistiken sehen wollen.
+Behalte deine Ausgaben und deinen Konsum im Blick mit [ProstCounter](/) -- die App wurde speziell für Volksfest-Besucher entwickelt, die ihre tägliche Anwesenheit protokollieren, sich mit Freunden vergleichen und nach dem Fest lustige Statistiken sehen wollen.
 
-## Zeltuebersicht: 14 grosse Zelte + 21 kleine Zelte + Oide Wiesn
+## Zeltübersicht: 14 große Zelte + 21 kleine Zelte + Oide Wiesn
 
-Das Oktoberfest-Gelaende bietet **14 grosse Bierzelte** (je 3.000 bis 10.000 Plaetze), **21 kleinere Zelte** und die **Oide Wiesn** -- einen historischen Bereich mit nostalgischer Atmosphaere. Fuer einen detaillierten Ueberblick ueber jedes Zelt schau dir unseren [Kompletten Guide zu allen Oktoberfest-Zelten](/blog/de/oktoberfest-tents-guide) an.
+Das Oktoberfest-Gelände bietet **14 große Bierzelte** (je 3.000 bis 10.000 Plätze), **21 kleinere Zelte** und die **Oide Wiesn** -- einen historischen Bereich mit nostalgischer Atmosphäre. Für einen detaillierten Überblick über jedes Zelt schau dir unseren [Kompletten Guide zu allen Oktoberfest-Zelten](/blog/de/oktoberfest-tents-guide) an.
 
 Einige Highlights:
 
-- **Schottenhamel**: Hier findet die Eroeffnungszeremonie statt. Beliebt beim juengeren Publikum.
-- **Hofbraeu-Festzelt**: Das internationalste Zelt. Der Stehbereich ist ohne Reservierung zugaenglich, was es zum einfachsten Zelt zum Reinkommen macht.
-- **Augustiner-Festhalle**: Der Liebling der Einheimischen. Bier wird aus Holzfaessern ausgeschenkt -- eine Seltenheit, selbst auf dem Oktoberfest.
-- **Kaefer Wiesn-Schaenke**: Das Promi-Zelt mit Gourmet-Kueche und langen Oeffnungszeiten (bis 1:00 Uhr nachts).
+- **Schottenhamel**: Hier findet die Eröffnungszeremonie statt. Beliebt beim jüngeren Publikum.
+- **Hofbräu-Festzelt**: Das internationalste Zelt. Der Stehbereich ist ohne Reservierung zugänglich, was es zum einfachsten Zelt zum Reinkommen macht.
+- **Augustiner-Festhalle**: Der Liebling der Einheimischen. Bier wird aus Holzfässern ausgeschenkt -- eine Seltenheit, selbst auf dem Oktoberfest.
+- **Käfer Wiesn-Schänke**: Das Promi-Zelt mit Gourmet-Küche und langen Öffnungszeiten (bis 1:00 Uhr nachts).
 
 ## So buchst du Zeltreservierungen
 
-Reservierungen auf dem Oktoberfest sind **kostenlos** -- du bezahlst nicht fuer den Tisch an sich. Allerdings musst du dich verpflichten, pro Person einen Mindestumsatz an Essen und Trinken zu bestellen (typischerweise 2 Mass und ein halbes Hendl, zusammen ca. 50-60 EUR pro Kopf).
+Reservierungen auf dem Oktoberfest sind **kostenlos** -- du bezahlst nicht für den Tisch an sich. Allerdings musst du dich verpflichten, pro Person einen Mindestumsatz an Essen und Trinken zu bestellen (typischerweise 2 Maß und ein halbes Hendl, zusammen ca. 50-60 EUR pro Kopf).
 
 ### Der Reservierungsprozess
 
-1. **Wann**: Reservierungen oeffnen fuer die meisten Zelte im Januar/Februar. Manche sind innerhalb von Stunden ausgebucht.
-2. **Wie**: Kontaktiere jedes Zelt direkt ueber deren offizielle Website. Es gibt kein zentrales Buchungssystem.
-3. **Gruppengroesse**: Die meisten Zelte verlangen eine Mindestanzahl von 6-10 Personen pro Reservierung.
-4. **Zeitfenster**: Typischerweise fuer Mittag (11:00 - 15:00 Uhr) und Abend (17:00 - 22:30 Uhr). Abendreservierungen am Wochenende sind am schwersten zu bekommen.
+1. **Wann**: Reservierungen öffnen für die meisten Zelte im Januar/Februar. Manche sind innerhalb von Stunden ausgebucht.
+2. **Wie**: Kontaktiere jedes Zelt direkt über deren offizielle Website. Es gibt kein zentrales Buchungssystem.
+3. **Gruppengröße**: Die meisten Zelte verlangen eine Mindestanzahl von 6-10 Personen pro Reservierung.
+4. **Zeitfenster**: Typischerweise für Mittag (11:00 - 15:00 Uhr) und Abend (17:00 - 22:30 Uhr). Abendreservierungen am Wochenende sind am schwersten zu bekommen.
 
 ### Keine Reservierung? Kein Problem.
 
 Wenn du keine Reservierung hast, kommst du trotzdem rein -- es braucht nur Geduld und Strategie:
 
-- **Frueh da sein**: Zelte oeffnen um 10:00 Uhr unter der Woche und um 9:00 Uhr am Wochenende. Zur Oeffnungszeit da zu sein ist deine beste Chance.
+- **Früh da sein**: Zelte öffnen um 10:00 Uhr unter der Woche und um 9:00 Uhr am Wochenende. Zur Öffnungszeit da zu sein ist deine beste Chance.
 - **Unter der Woche gehen**: Montag bis Donnerstag ist es deutlich weniger voll als am Wochenende.
-- **Die richtigen Zelte ansteuern**: Das Hofbraeu-Festzelt hat grosse Stehbereiche, die keine Reservierung erfordern. Augustiner ist tendenziell auch zugaenglicher als andere.
+- **Die richtigen Zelte ansteuern**: Das Hofbräu-Festzelt hat große Stehbereiche, die keine Reservierung erfordern. Augustiner ist tendenziell auch zugänglicher als andere.
 - **Unter der Woche nach 17:00 Uhr kommen**: Manche reservierten Tische, die nicht beansprucht wurden, werden freigegeben.
 
 ## Was anziehen: Lederhosen und Dirndl
 
-Traditionelle bayerische Kleidung ist keine Pflicht, aber etwa 70 % der Besucher tragen sie -- und du wirst dich staerker ins Erlebnis eintauchen, wenn du mitmachst.
+Traditionelle bayerische Kleidung ist keine Pflicht, aber etwa 70 % der Besucher tragen sie -- und du wirst dich stärker ins Erlebnis eintauchen, wenn du mitmachst.
 
-### Fuer Maenner: Lederhosen
+### Für Männer: Lederhosen
 
 - **Kniebundhosen** (knielang) sind die klassische Oktoberfest-Wahl
-- Kombiniert mit einem karierten Hemd, Wollstruempfen (Loferl) und festen Schuhen oder Haferlschuhen
-- Rechne mit 80-200 EUR fuer ordentliche Lederhosen (vermeide die billigsten Touristenoptionen, die fallen auseinander)
+- Kombiniert mit einem karierten Hemd, Wollstrümpfen (Loferl) und festen Schuhen oder Haferlschuhen
+- Rechne mit 80-200 EUR für ordentliche Lederhosen (vermeide die billigsten Touristenoptionen, die fallen auseinander)
 
-### Fuer Frauen: Dirndl
+### Für Frauen: Dirndl
 
-- Ein traditionelles Dirndl besteht aus Mieder, Bluse, Rock und Schuerze
-- **Die Position der Schuerzenschleife ist wichtig**: links gebunden bedeutet ledig, rechts bedeutet vergeben, mittig/hinten bedeutet verwitwet oder Bedienung
-- Die Rocklaenge variiert -- knielang ist Standard fuers Oktoberfest
+- Ein traditionelles Dirndl besteht aus Mieder, Bluse, Rock und Schürze
+- **Die Position der Schürzenschleife ist wichtig**: links gebunden bedeutet ledig, rechts bedeutet vergeben, mittig/hinten bedeutet verwitwet oder Bedienung
+- Die Rocklänge variiert -- knielang ist Standard fürs Oktoberfest
 
-Kaufen oder mieten kannst du traditionelle Kleidung in Geschaeften an der Sendlinger Strasse, am Viktualienmarkt oder bei Ludwig Beck am Marienplatz. Reserviere den Verleih frueh, wenn du zur Hochsaison kommst.
+Kaufen oder mieten kannst du traditionelle Kleidung in Geschäften an der Sendlinger Straße, am Viktualienmarkt oder bei Ludwig Beck am Marienplatz. Reserviere den Verleih früh, wenn du zur Hochsaison kommst.
 
-## Die besten Tage und Uhrzeiten fuer einen Besuch
+## Die besten Tage und Uhrzeiten für einen Besuch
 
 Nicht alle Oktoberfest-Tage sind gleich. So planst du strategisch:
 
-| Zeitpunkt           | Menschenmenge | Ideal fuer                     |
+| Zeitpunkt           | Menschenmenge | Ideal für                     |
 | ------------------- | ------------- | ------------------------------ |
 | Werktag-Vormittage  | Niedrig       | Familien, entspanntes Erlebnis |
 | Werktag-Nachmittage | Mittel        | Gute Stimmung ohne Chaos       |
-| Werktag-Abende      | Mittel-Hoch   | Lebendig, aber ueberschaubar   |
+| Werktag-Abende      | Mittel-Hoch   | Lebendig, aber überschaubar   |
 | Freitag/Samstag     | Sehr hoch     | Volle Oktoberfest-Energie      |
-| Eroeffnungssamstag  | Extrem        | Das Zeremonie-Erlebnis         |
+| Eröffnungssamstag  | Extrem        | Das Zeremonie-Erlebnis         |
 | Letzter Sonntag     | Hoch          | Letzte-Runde-Stimmung          |
 
-**Der Sweet Spot**: Dienstag- oder Mittwochnachmittag. Du findest leicht Sitzplaetze, die Stimmung ist warm und einladend, und du hast Platz, die Fahrgeschaefte und Essensstaende zu geniessen, ohne dich durch Menschenmassen kaempfen zu muessen.
+**Der Sweet Spot**: Dienstag- oder Mittwochnachmittag. Du findest leicht Sitzplätze, die Stimmung ist warm und einladend, und du hast Platz, die Fahrgeschäfte und Essensstände zu genießen, ohne dich durch Menschenmassen kämpfen zu müssen.
 
-## Wettertipps fuer Ende September / Anfang Oktober
+## Wettertipps für Ende September / Anfang Oktober
 
-Das Muenchner Wetter Ende September kann unberechenbar sein. Historische Durchschnittswerte zeigen:
+Das Münchner Wetter Ende September kann unberechenbar sein. Historische Durchschnittswerte zeigen:
 
 - **Tagestemperaturen**: 12-18 Grad C
 - **Abendtemperaturen**: 6-10 Grad C
-- **Regenwahrscheinlichkeit**: Maessig -- pack eine Regenjacke oder einen kleinen Schirm ein
+- **Regenwahrscheinlichkeit**: Mäßig -- pack eine Regenjacke oder einen kleinen Schirm ein
 
 **Was du mitbringen solltest**:
 
 - Schichten -- in den Bierzelten wird es warm, aber zwischen den Zelten kann es frisch sein
 - Bequeme Schuhe -- du wirst stundenlang auf unebenem Boden stehen und laufen
-- Eine kleine Umhaengetasche (grosse Rucksaecke sind in den Zelten eingeschraenkt)
-- Bargeld -- obwohl Kartenzahlung immer verbreiteter ist, bevorzugen viele Essensstaende und kleinere Haendler immer noch Bargeld
+- Eine kleine Umhängetasche (große Rucksäcke sind in den Zelten eingeschränkt)
+- Bargeld -- obwohl Kartenzahlung immer verbreiteter ist, bevorzugen viele Essensstände und kleinere Händler immer noch Bargeld
 
-## Sehenswuerdigkeiten in der Naehe
+## Sehenswürdigkeiten in der Nähe
 
-Muenchen hat weit mehr zu bieten als nur das Oktoberfest. Wenn du extra Tage hast, erkunde:
+München hat weit mehr zu bieten als nur das Oktoberfest. Wenn du extra Tage hast, erkunde:
 
-- **Marienplatz und das Glockenspiel**: Muenchens zentraler Platz mit dem beruehmten Uhrturmspiel um 11 und 12 Uhr
-- **Englischer Garten**: Einer der groessten Stadtparks der Welt mit Biergaerten, Flusssurfen an der Eisbachwelle und ruhigen Spazierwegen
-- **Hofbraeuhaus**: Muenchens beruehmtestes Bierhaus, seit 1589 in Betrieb -- ideal zum Aufwaermen vor dem Oktoberfest
+- **Marienplatz und das Glockenspiel**: Münchens zentraler Platz mit dem berühmten Uhrturmspiel um 11 und 12 Uhr
+- **Englischer Garten**: Einer der größten Stadtparks der Welt mit Biergärten, Flusssurfen an der Eisbachwelle und ruhigen Spazierwegen
+- **Hofbräuhaus**: Münchens berühmtestes Bierhaus, seit 1589 in Betrieb -- ideal zum Aufwärmen vor dem Oktoberfest
 - **BMW Welt und Museum**: Freier Eintritt zur BMW Welt; das Museum zeigt Automobilgeschichte
-- **Schloss Nymphenburg**: Ein beeindruckendes Barockschloss mit wunderschoenen Gaerten im Westen Muenchens
-- **Viktualienmarkt**: Muenchens beruehmter Freiluft-Lebensmittelmarkt mit einem Biergarten, der rotierende Brauereien ausschenkt
-- **Tagesausflug zu Schloss Neuschwanstein**: Das Maerchenschloss liegt etwa 2 Stunden suedlich per Zug
+- **Schloss Nymphenburg**: Ein beeindruckendes Barockschloss mit wunderschönen Gärten im Westen Münchens
+- **Viktualienmarkt**: Münchens berühmter Freiluft-Lebensmittelmarkt mit einem Biergarten, der rotierende Brauereien ausschenkt
+- **Tagesausflug zu Schloss Neuschwanstein**: Das Märchenschloss liegt etwa 2 Stunden südlich per Zug
 
 ## Verfolge dein Oktoberfest-Erlebnis
 
-Bei so viel, was ueber 16 Tage passiert, verliert man leicht den Ueberblick. ProstCounter hilft dir, jeden Besuchstag zu protokollieren, deine Biere zu zaehlen, Statistiken mit deiner Gruppe zu vergleichen und auf dein Fest-Erlebnis mit detaillierten Auswertungen zurueckzublicken. Die perfekte Begleit-App fuer jedes Volksfest -- nicht nur fuer das Oktoberfest, sondern auch fuer das [Starkbierfest](/blog/de/starkbierfest-guide), das [Fruehlingsfest](/blog/de/fruehlingsfest-guide) und [alle anderen Muenchner Bierfeste](/blog/de/munich-beer-festivals-calendar) uebers ganze Jahr.
+Bei so viel, was über 16 Tage passiert, verliert man leicht den Überblick. ProstCounter hilft dir, jeden Besuchstag zu protokollieren, deine Biere zu zählen, Statistiken mit deiner Gruppe zu vergleichen und auf dein Fest-Erlebnis mit detaillierten Auswertungen zurückzublicken. Die perfekte Begleit-App für jedes Volksfest -- nicht nur für das Oktoberfest, sondern auch für das [Starkbierfest](/blog/de/starkbierfest-guide), das [Frühlingsfest](/blog/de/fruehlingsfest-guide) und [alle anderen Münchner Bierfeste](/blog/de/munich-beer-festivals-calendar) übers ganze Jahr.
 
 <DownloadButtons />
 
 ## Letzte Tipps
 
-1. **Lass es ruhig angehen** -- Oktoberfest-Bier ist staerker als normales Lagerbier, und eine volle Mass ist ein ganzer Liter davon.
-2. **Iss vor und waehrend des Trinkens** -- das traditionelle Essen ist nicht umsonst so deftig.
-3. **Legt einen Treffpunkt fest** -- der Handyempfang wird unzuverlaessig, wenn Millionen Menschen an einem Ort sind.
-4. **Respektiere das Personal** -- Bedienungen tragen 10+ volle Masskruege gleichzeitig. Gib gutes Trinkgeld (auf den naechsten Euro aufrunden oder 10 % drauflegen).
+1. **Lass es ruhig angehen** -- Oktoberfest-Bier ist stärker als normales Lagerbier, und eine volle Maß ist ein ganzer Liter davon.
+2. **Iss vor und während des Trinkens** -- das traditionelle Essen ist nicht umsonst so deftig.
+3. **Legt einen Treffpunkt fest** -- der Handyempfang wird unzuverlässig, wenn Millionen Menschen an einem Ort sind.
+4. **Respektiere das Personal** -- Bedienungen tragen 10+ volle Maßkrüge gleichzeitig. Gib gutes Trinkgeld (auf den nächsten Euro aufrunden oder 10 % drauflegen).
 5. **Wisse, wann Schluss ist** -- das Fest ist ein Marathon, kein Sprint. Du hast 16 Tage.
 
 Prost!

--- a/apps/web/content/blog/de/starkbierfest-guide.mdx
+++ b/apps/web/content/blog/de/starkbierfest-guide.mdx
@@ -22,7 +22,7 @@ Die Geschichte des Starkbierfests beginnt im 17. Jahrhundert mit den Paulaner-M�
 
 Als findige Bayern fanden die Mönche eine kreative Lösung -- sie brauten ein besonders starkes, nahrhaftes Bier, das sie durch die Fastenzeit bringen sollte. Sie nannten es **"flüssiges Brot"**, mit dem Argument, dass Trinken das Fasten technisch gesehen nicht breche. Das Bier war dickflüssig, malzig und kalorienreich -- genau das, was man braucht, um Wochen ohne Essen zu überstehen.
 
-Der populären Legende nach schickten die Mönche ein Fass ihres Starkbiers zur Genehmigung an den Papst nach Rom. Bis es nach der langen Reise über die Alpen ankam, war das Bier verdorben und schmeckte fürchterlich. Der Papst erklärte nach einer Kostprobe, dass das Trinken einer derart unangenehmen Substanz tatsächlich eine Form der Busse sei -- und gab seinen Segen.
+Der populären Legende nach schickten die Mönche ein Fass ihres Starkbiers zur Genehmigung an den Papst nach Rom. Bis es nach der langen Reise über die Alpen ankam, war das Bier verdorben und schmeckte fürchterlich. Der Papst erklärte nach einer Kostprobe, dass das Trinken einer derart unangenehmen Substanz tatsächlich eine Form der Buße sei -- und gab seinen Segen.
 
 Ob die Legende nun ganz der Wahrheit entspricht oder über Jahrhunderte ausgeschmückt wurde, die Tradition blieb bestehen. Das Bier der Mönche wurde schließlich als **Salvator** (Erlöserbier) bekannt und begründete eine ganze Bierkategorie: den **Doppelbock**.
 

--- a/apps/web/content/blog/de/starkbierfest-guide.mdx
+++ b/apps/web/content/blog/de/starkbierfest-guide.mdx
@@ -1,6 +1,6 @@
 ---
-title: "Starkbierfest: Muenchens verstecktes Starkbier-Festival"
-description: "Entdecke das Starkbierfest, Muenchens beliebte Starkbierzeit. Erfahre alles ueber Doppelbock-Traditionen, die besten Locations und warum Einheimische es dem Oktoberfest vorziehen."
+title: "Starkbierfest: Münchens verstecktes Starkbier-Festival"
+description: "Entdecke das Starkbierfest, Münchens beliebte Starkbierzeit. Erfahre alles über Doppelbock-Traditionen, die besten Locations und warum Einheimische es dem Oktoberfest vorziehen."
 date: "2026-03-10"
 lastModified: "2026-03-10"
 author: "ProstCounter Team"
@@ -10,164 +10,164 @@ featuredImage: "/images/prost-counter-og-2.jpg"
 locale: "de"
 ---
 
-# Starkbierfest: Muenchens verstecktes Starkbier-Festival
+# Starkbierfest: Münchens verstecktes Starkbier-Festival
 
-Waehrend das [Oktoberfest](/blog/de/oktoberfest-2026-guide) jeden September Millionen internationaler Besucher anzieht, wissen Muenchens wahre Bierkenner, dass das geschmackvollste Fest der Stadt viel frueher im Jahr stattfindet. Das **Starkbierfest** -- Muenchens Starkbierzeit -- laeuft im Maerz und April und bietet ein zutiefst bayerisches Erlebnis, das die meisten Touristen nie entdecken.
+Während das [Oktoberfest](/blog/de/oktoberfest-2026-guide) jeden September Millionen internationaler Besucher anzieht, wissen Münchens wahre Bierkenner, dass das geschmackvollste Fest der Stadt viel früher im Jahr stattfindet. Das **Starkbierfest** -- Münchens Starkbierzeit -- läuft im März und April und bietet ein zutiefst bayerisches Erlebnis, das die meisten Touristen nie entdecken.
 
-Wenn du eine authentische Muenchner Biertradition mit weniger Trubel und staerkerem Bier suchst, ist das Starkbierfest genau das Richtige.
+Wenn du eine authentische Münchner Biertradition mit weniger Trubel und stärkerem Bier suchst, ist das Starkbierfest genau das Richtige.
 
-## Die Geschichte: Moenche, Fasten und fluessiges Brot
+## Die Geschichte: Mönche, Fasten und flüssiges Brot
 
-Die Geschichte des Starkbierfests beginnt im 17. Jahrhundert mit den Paulaner-Moenchen des Ordens des heiligen Franz von Paula. Stationiert im Kloster auf dem Nockherberg im Muenchner Stadtteil Au, standen die Moenche jede Fastenzeit vor einer Herausforderung: Sie mussten 40 Tage lang auf feste Nahrung verzichten.
+Die Geschichte des Starkbierfests beginnt im 17. Jahrhundert mit den Paulaner-Mönchen des Ordens des heiligen Franz von Paula. Stationiert im Kloster auf dem Nockherberg im Münchner Stadtteil Au, standen die Mönche jede Fastenzeit vor einer Herausforderung: Sie mussten 40 Tage lang auf feste Nahrung verzichten.
 
-Als findige Bayern fanden die Moenche eine kreative Loesung -- sie brauten ein besonders starkes, nahrhaftes Bier, das sie durch die Fastenzeit bringen sollte. Sie nannten es **"fluessiges Brot"**, mit dem Argument, dass Trinken das Fasten technisch gesehen nicht breche. Das Bier war dickfluessig, malzig und kalorienreich -- genau das, was man braucht, um Wochen ohne Essen zu ueberstehen.
+Als findige Bayern fanden die Mönche eine kreative Lösung -- sie brauten ein besonders starkes, nahrhaftes Bier, das sie durch die Fastenzeit bringen sollte. Sie nannten es **"flüssiges Brot"**, mit dem Argument, dass Trinken das Fasten technisch gesehen nicht breche. Das Bier war dickflüssig, malzig und kalorienreich -- genau das, was man braucht, um Wochen ohne Essen zu überstehen.
 
-Der populaeren Legende nach schickten die Moenche ein Fass ihres Starkbiers zur Genehmigung an den Papst nach Rom. Bis es nach der langen Reise ueber die Alpen ankam, war das Bier verdorben und schmeckte fuerchterlich. Der Papst erklaerte nach einer Kostprobe, dass das Trinken einer derart unangenehmen Substanz tatsaechlich eine Form der Busse sei -- und gab seinen Segen.
+Der populären Legende nach schickten die Mönche ein Fass ihres Starkbiers zur Genehmigung an den Papst nach Rom. Bis es nach der langen Reise über die Alpen ankam, war das Bier verdorben und schmeckte fürchterlich. Der Papst erklärte nach einer Kostprobe, dass das Trinken einer derart unangenehmen Substanz tatsächlich eine Form der Busse sei -- und gab seinen Segen.
 
-Ob die Legende nun ganz der Wahrheit entspricht oder ueber Jahrhunderte ausgeschmueckt wurde, die Tradition blieb bestehen. Das Bier der Moenche wurde schliesslich als **Salvator** (Erloeserbier) bekannt und begruendete eine ganze Bierkategorie: den **Doppelbock**.
+Ob die Legende nun ganz der Wahrheit entspricht oder über Jahrhunderte ausgeschmückt wurde, die Tradition blieb bestehen. Das Bier der Mönche wurde schließlich als **Salvator** (Erlöserbier) bekannt und begründete eine ganze Bierkategorie: den **Doppelbock**.
 
 ## Was ist Doppelbock?
 
-Doppelbock ist ein starker Lagerbier-Stil, der in Muenchen seinen Ursprung hat. Der Name bedeutet woertlich "doppelter Bock" -- ein Hinweis darauf, dass es eine staerkere Version des traditionellen Bockbiers ist. Wichtige Merkmale:
+Doppelbock ist ein starker Lagerbier-Stil, der in München seinen Ursprung hat. Der Name bedeutet wörtlich "doppelter Bock" -- ein Hinweis darauf, dass es eine stärkere Version des traditionellen Bockbiers ist. Wichtige Merkmale:
 
 - **Alkoholgehalt**: Typischerweise 7,0 % - 8,5 % Vol. (im Vergleich zu 4,5 % - 5,5 % bei normalem Lagerbier)
-- **Geschmacksprofil**: Reich, malzig, mit Noten von Brotkruste, Karamell, Toffee und Trockenfruechten. Minimale Hopfenbitterkeit.
+- **Geschmacksprofil**: Reich, malzig, mit Noten von Brotkruste, Karamell, Toffee und Trockenfrüchten. Minimale Hopfenbitterkeit.
 - **Farbe**: Tiefes Bernstein bis Dunkelbraun
-- **Koerper**: Vollmundig und waermend -- du spuerst seine Staerke
-- **Kalorien**: Deutlich hoeher als bei normalem Bier, was ihm den Spitznamen "fluessiges Brot" einbrachte
+- **Körper**: Vollmundig und wärmend -- du spürst seine Stärke
+- **Kalorien**: Deutlich höher als bei normalem Bier, was ihm den Spitznamen "flüssiges Brot" einbrachte
 
 ### Die "-ator"-Namenstradition
 
-Einer der charmantesten Aspekte der Doppelbock-Kultur ist die Namenskonvention. Als Paulaner begann, ihren Salvator kommerziell zu verkaufen, zogen andere Muenchner Brauereien mit eigenen Starkbieren nach -- und uebernahmen traditionell das **Suffix "-ator"**:
+Einer der charmantesten Aspekte der Doppelbock-Kultur ist die Namenskonvention. Als Paulaner begann, ihren Salvator kommerziell zu verkaufen, zogen andere Münchner Brauereien mit eigenen Starkbieren nach -- und übernahmen traditionell das **Suffix "-ator"**:
 
 | Brauerei       | Doppelbock-Name | Vol.  |
 | -------------- | --------------- | ----- |
 | Paulaner       | **Salvator**    | 7,9 % |
 | Augustiner     | **Maximator**   | 7,5 % |
 | Hacker-Pschorr | **Animator**    | 8,1 % |
-| Loewenbraeu    | **Triumphator** | 7,6 % |
+| Löwenbräu    | **Triumphator** | 7,6 % |
 | Spaten         | **Optimator**   | 7,6 % |
-| Hofbraeu       | **Delicator**   | 7,2 % |
+| Hofbräu       | **Delicator**   | 7,2 % |
 | Ayinger        | **Celebrator**  | 6,7 % |
 
-Paulaner liess den Namen "Salvator" 1896 sogar als Marke schuetzen und versuchte auch, das Suffix "-ator" zu schuetzen -- aber bis dahin hatten es schon zu viele Brauereien uebernommen. Die Tradition lebt bis heute weiter, und auch neue Craft-Doppelboecke folgen oft der Konvention.
+Paulaner ließ den Namen "Salvator" 1896 sogar als Marke schützen und versuchte auch, das Suffix "-ator" zu schützen -- aber bis dahin hatten es schon zu viele Brauereien übernommen. Die Tradition lebt bis heute weiter, und auch neue Craft-Doppelböcke folgen oft der Konvention.
 
 ## Nockherberg: Das Hauptevent
 
-Das Herzstuck des Starkbierfests ist der **Paulaner am Nockherberg** -- eine riesige Bierhalle auf dem Huegel, wo die urspruenglichen Moenche vor Jahrhunderten ihren Salvator brauten. Hier findet der offizielle "Starkbieranstich" statt, und es ist eines der wichtigsten jaehrlichen Ereignisse Muenchens.
+Das Herzstück des Starkbierfests ist der **Paulaner am Nockherberg** -- eine riesige Bierhalle auf dem Hügel, wo die ursprünglichen Mönche vor Jahrhunderten ihren Salvator brauten. Hier findet der offizielle "Starkbieranstich" statt, und es ist eines der wichtigsten jährlichen Ereignisse Münchens.
 
 ### Das Derblecken
 
-Was den Nockherberg wirklich besonders macht, ist nicht nur das Bier -- es ist das **Derblecken** (auch Starkbierprobe genannt), eine politische Komoedienshow, die das Fest eroeffnet. Professionelle Schauspieler fuehren satirische Sketche auf, in denen Bayerns Politiker durch den Kakao gezogen werden -- und die echten Politiker sitzen in den vorderen Reihen und sollen mitlachen.
+Was den Nockherberg wirklich besonders macht, ist nicht nur das Bier -- es ist das **Derblecken** (auch Starkbierprobe genannt), eine politische Komödienshow, die das Fest eröffnet. Professionelle Schauspieler führen satirische Sketche auf, in denen Bayerns Politiker durch den Kakao gezogen werden -- und die echten Politiker sitzen in den vorderen Reihen und sollen mitlachen.
 
-Das Derblecken wird live im Bayerischen Rundfunk uebertragen und von Millionen in ganz Deutschland gesehen. Es ist im Grunde Bayerns Version des White House Correspondents' Dinner -- scharf, lustig und eine unantastbare Tradition. Die Politiker, die am haertesten drangkommen, betrachten es oft als Ehrenabzeichen.
+Das Derblecken wird live im Bayerischen Rundfunk übertragen und von Millionen in ganz Deutschland gesehen. Es ist im Grunde Bayerns Version des White House Correspondents' Dinner -- scharf, lustig und eine unantastbare Tradition. Die Politiker, die am härtesten drangkommen, betrachten es oft als Ehrenabzeichen.
 
 ### Besuch am Nockherberg
 
-- **Wann**: Das Fest laeuft typischerweise 2-3 Wochen im Maerz
-- **Wo**: Paulaner am Nockherberg, Hochstrasse 77, Muenchen (U-Bahn: Kolumbusplatz)
-- **Reservierungen**: Sehr empfohlen, besonders fuer Abende und Wochenenden. Buchung ueber die Website des Paulaner am Nockherberg ab Januar.
-- **Preise**: Eine Mass Salvator kostet ca. 13-14 EUR -- etwas guenstiger als Oktoberfest-Bier, obwohl es deutlich staerker ist
-- **Atmosphaere**: Live-Blasmusik, traditionelle bayerische Kueche und ein Publikum, das stark lokal gepraegt ist. Du hoerst hier weit mehr bayerischen Dialekt als auf dem Oktoberfest.
+- **Wann**: Das Fest läuft typischerweise 2-3 Wochen im März
+- **Wo**: Paulaner am Nockherberg, Hochstraße 77, München (U-Bahn: Kolumbusplatz)
+- **Reservierungen**: Sehr empfohlen, besonders für Abende und Wochenenden. Buchung über die Website des Paulaner am Nockherberg ab Januar.
+- **Preise**: Eine Maß Salvator kostet ca. 13-14 EUR -- etwas günstiger als Oktoberfest-Bier, obwohl es deutlich stärker ist
+- **Atmosphäre**: Live-Blasmusik, traditionelle bayerische Küche und ein Publikum, das stark lokal geprägt ist. Du hörst hier weit mehr bayerischen Dialekt als auf dem Oktoberfest.
 
 ## Weitere Starkbierfest-Locations
 
-Waehrend der Nockherberg das Flaggschiff-Event ist, feiert fast jede Brauerei und Bierhalle in Muenchen das Starkbierfest auf ihre eigene Art:
+Während der Nockherberg das Flaggschiff-Event ist, feiert fast jede Brauerei und Bierhalle in München das Starkbierfest auf ihre eigene Art:
 
 ### Augustiner Keller
 
-Muenchens beliebte Augustiner-Brauerei veranstaltet ihr eigenes Starkbierfest mit dem **Maximator** vom Fass. Der Augustiner Keller an der Arnulfstrasse hat eine wunderbar traditionelle Atmosphaere, und Augustiner-Fans sind aeusserst treu. Das ist eine gemuetlichere, nachbarschaftlichere Feier im Vergleich zum Nockherberg.
+Münchens beliebte Augustiner-Brauerei veranstaltet ihr eigenes Starkbierfest mit dem **Maximator** vom Fass. Der Augustiner Keller an der Arnulfstraße hat eine wunderbar traditionelle Atmosphäre, und Augustiner-Fans sind äußerst treu. Das ist eine gemütlichere, nachbarschaftlichere Feier im Vergleich zum Nockherberg.
 
-### Hofbraeuhaus
+### Hofbräuhaus
 
-Das weltberuehmte Hofbraeuhaus schenkt waehrend der Starkbierzeit den **Delicator** aus. Obwohl das Hofbraeuhaus das ganze Jahr ueber eher touristisch gepraegt ist, findest du waehrend des Starkbierfests eine gute Mischung aus Einheimischen und Gaesten, die das staerkere Gebraeu zu schaetzen wissen. Das historische Ambiente -- mit seinen bemalten Decken und langen Holztischen -- traegt zum Erlebnis bei.
+Das weltberühmte Hofbräuhaus schenkt während der Starkbierzeit den **Delicator** aus. Obwohl das Hofbräuhaus das ganze Jahr über eher touristisch geprägt ist, findest du während des Starkbierfests eine gute Mischung aus Einheimischen und Gästen, die das stärkere Gebräu zu schätzen wissen. Das historische Ambiente -- mit seinen bemalten Decken und langen Holztischen -- trägt zum Erlebnis bei.
 
-### Loewenbraeukeller
+### Löwenbräukeller
 
-Der Loewenbraeukeller am Stiglmaierplatz zapft den **Triumphator** an und veranstaltet eine der groesseren Starkbierfest-Feiern ausserhalb des Nockherbergs. Die Stimmung ist festlich, mit Blasmusik und traditioneller Dekoration, die den Raum fuer die Saison verwandeln.
+Der Löwenbräukeller am Stiglmaierplatz zapft den **Triumphator** an und veranstaltet eine der größeren Starkbierfest-Feiern außerhalb des Nockherbergs. Die Stimmung ist festlich, mit Blasmusik und traditioneller Dekoration, die den Raum für die Saison verwandeln.
 
 ### Brauerei Aying
 
-Fuer alle, die sich etwas ausserhalb Muenchens wagen moechten: Die Ayinger Brauerei im Dorf Aying (ca. 25 km suedoestlich, erreichbar mit der S-Bahn S7) produziert den **Celebrator**, einen der meistgefeierten Doppelboecke weltweit. Ihr Braeustueberl ist ein idyllischer Ort, um ihn frisch von der Quelle zu geniessen.
+Für alle, die sich etwas außerhalb Münchens wagen möchten: Die Ayinger Brauerei im Dorf Aying (ca. 25 km südöstlich, erreichbar mit der S-Bahn S7) produziert den **Celebrator**, einen der meistgefeierten Doppelböcke weltweit. Ihr Bräustüberl ist ein idyllischer Ort, um ihn frisch von der Quelle zu genießen.
 
-### Biergaerten und kleinere Locations
+### Biergärten und kleinere Locations
 
-Viele Muenchner Biergaerten und kleinere Bierhallen bieten waehrend der Saison ebenfalls spezielle Starkbier-Events an. Schau in die lokalen Veranstaltungskalender fuer:
+Viele Münchner Biergärten und kleinere Bierhallen bieten während der Saison ebenfalls spezielle Starkbier-Events an. Schau in die lokalen Veranstaltungskalender für:
 
-- **Biergarten am Viktualienmarkt**: Rotiert durch Muenchens Brauereien und bietet oft Starkbier-Specials
-- **Weisses Braeuhaus**: Bekannt fuer Weissbier, feiert aber auch die Starkbierzeit
-- **Tap House Munich**: Eine Craft-Bier-Bar, die waehrend der Saison oft spezielle Starkbier-Verkostungen anbietet
+- **Biergarten am Viktualienmarkt**: Rotiert durch Münchens Brauereien und bietet oft Starkbier-Specials
+- **Weißes Bräuhaus**: Bekannt für Weißbier, feiert aber auch die Starkbierzeit
+- **Tap House Munich**: Eine Craft-Bier-Bar, die während der Saison oft spezielle Starkbier-Verkostungen anbietet
 
 ## Wie sich das Starkbierfest vom Oktoberfest unterscheidet
 
-Fuer alle, die sich zwischen den beiden Festen entscheiden, hier ein ehrlicher Vergleich:
+Für alle, die sich zwischen den beiden Festen entscheiden, hier ein ehrlicher Vergleich:
 
-### Groesse und Menschenmengen
+### Größe und Menschenmengen
 
-Das Oktoberfest zaehlt ueber 6 Millionen Besucher waehrend seiner 16-taegigen Laufzeit. Das Starkbierfest, verteilt auf mehrere Locations ueber mehrere Wochen, zieht nur einen Bruchteil davon an. Du wirst selten auf die langen Schlangen und ueberfuellten Zelte stossen, die typisch fuer Oktoberfest-Wochenenden sind.
+Das Oktoberfest zählt über 6 Millionen Besucher während seiner 16-tägigen Laufzeit. Das Starkbierfest, verteilt auf mehrere Locations über mehrere Wochen, zieht nur einen Bruchteil davon an. Du wirst selten auf die langen Schlangen und überfüllten Zelte stoßen, die typisch für Oktoberfest-Wochenenden sind.
 
-### Atmosphaere
+### Atmosphäre
 
-Das Oktoberfest ist ein Spektakel -- riesige Zelte, Fahrgeschaefte, internationale Touristen und eine Party-Stimmung, die im Laufe des Tages zunimmt. Das Starkbierfest fuehlt sich eher wie ein Nachbarschaftsfest an. Die Musik ist traditionell, die Gespraeche laufen auf Bayerisch, und die Stimmung ist gesellig statt chaotisch.
+Das Oktoberfest ist ein Spektakel -- riesige Zelte, Fahrgeschäfte, internationale Touristen und eine Party-Stimmung, die im Laufe des Tages zunimmt. Das Starkbierfest fühlt sich eher wie ein Nachbarschaftsfest an. Die Musik ist traditionell, die Gespräche laufen auf Bayerisch, und die Stimmung ist gesellig statt chaotisch.
 
 ### Das Bier
 
-Oktoberfest-Bier wird speziell fuer das Fest gebraut mit etwa 5,8 % - 6,3 % Vol. Doppelbock beim Starkbierfest hat 7 % - 8,5 %. Die Geschmacksprofile sind voellig verschieden -- Oktoberfest-Bier ist ein sauberes, sueffiges Maerzen oder Festbier, waehrend Doppelbock reich, komplex und waermend ist. Du trinkst beim Starkbierfest natuerlich weniger Mass, und das ist voellig in Ordnung.
+Oktoberfest-Bier wird speziell für das Fest gebraut mit etwa 5,8 % - 6,3 % Vol. Doppelbock beim Starkbierfest hat 7 % - 8,5 %. Die Geschmacksprofile sind völlig verschieden -- Oktoberfest-Bier ist ein sauberes, süffiges Märzen oder Festbier, während Doppelbock reich, komplex und wärmend ist. Du trinkst beim Starkbierfest natürlich weniger Maß, und das ist völlig in Ordnung.
 
 ### Wer hingeht
 
-Das Oktoberfest zieht ein wirklich internationales Publikum an. Das Starkbierfest wird ueberwiegend von Bayern und Muenchner Einwohnern besucht. Wenn du erleben moechtest, wie die Einheimischen wirklich Bierkultur feiern -- statt wie die Welt eine Marke feiert -- ist das Starkbierfest die authentische Wahl.
+Das Oktoberfest zieht ein wirklich internationales Publikum an. Das Starkbierfest wird überwiegend von Bayern und Münchner Einwohnern besucht. Wenn du erleben möchtest, wie die Einheimischen wirklich Bierkultur feiern -- statt wie die Welt eine Marke feiert -- ist das Starkbierfest die authentische Wahl.
 
 ### Kosten
 
-Das Starkbierfest ist in jeder Hinsicht guenstiger. Bierpreise sind niedriger, Essen ist etwas preiswerter, es gibt keinen Eintrittspreis, und die Muenchner Hotels haben ihre Preise nicht verdreifacht, wie sie es waehrend des Oktoberfests tun.
+Das Starkbierfest ist in jeder Hinsicht günstiger. Bierpreise sind niedriger, Essen ist etwas preiswerter, es gibt keinen Eintrittspreis, und die Münchner Hotels haben ihre Preise nicht verdreifacht, wie sie es während des Oktoberfests tun.
 
 ## Essen beim Starkbierfest
 
-Das Essen beim Starkbierfest ist klassische bayerische Haussmannskost, und du solltest ordentlich essen -- Doppelbock auf leeren Magen ist ein Rezept fuer einen kurzen Abend.
+Das Essen beim Starkbierfest ist klassische bayerische Hausmannskost, und du solltest ordentlich essen -- Doppelbock auf leeren Magen ist ein Rezept für einen kurzen Abend.
 
-- **Schweinshaxe**: Krossknusprige Haut, zartes Fleisch, serviert mit Knoedeln
-- **Obatzda**: Cremige bayerische Kaesecreme aus Camembert, Butter, Zwiebeln und Paprika, serviert mit frischen Brezen
-- **Weisswurst**: Weisswuerstchen, traditionell vor dem Mittagslaeuten mit suessem Senf und einer Breze gegessen
-- **Leberkäse**: Ein bayerischer Bratenlaib in dicken Scheiben, oft als Leberkaessemmel
-- **Kaiserschmarrn**: Zerrissener Pfannkuchen mit Puderzucker und Fruchtkompott -- das perfekte Dessert, um die malzige Fuelle des Doppelbocks auszubalancieren
+- **Schweinshaxe**: Krossknusprige Haut, zartes Fleisch, serviert mit Knödeln
+- **Obatzda**: Cremige bayerische Käsecreme aus Camembert, Butter, Zwiebeln und Paprika, serviert mit frischen Brezen
+- **Weißwurst**: Weißwürstchen, traditionell vor dem Mittagsläuten mit süßem Senf und einer Breze gegessen
+- **Leberkäse**: Ein bayerischer Bratenlaib in dicken Scheiben, oft als Leberkässemmel
+- **Kaiserschmarrn**: Zerrissener Pfannkuchen mit Puderzucker und Fruchtkompott -- das perfekte Dessert, um die malzige Fülle des Doppelbocks auszubalancieren
 
 ## Planung deines Besuchs
 
 ### Wann hingehen
 
-Die Starkbierfest-Saison laeuft typischerweise von **Mitte Maerz bis Anfang April**. Die genauen Termine variieren je nach Location:
+Die Starkbierfest-Saison läuft typischerweise von **Mitte März bis Anfang April**. Die genauen Termine variieren je nach Location:
 
-- **Nockherberg**: Meist 2-3 Wochen ab Mitte Maerz
+- **Nockherberg**: Meist 2-3 Wochen ab Mitte März
 - **Andere Locations**: Manche beginnen schon Ende Februar und laufen bis Ostern
 
-Pruefe die Websites der einzelnen Locations fuer die genauen Termine 2026, da diese normalerweise im Januar bekanntgegeben werden.
+Prüfe die Websites der einzelnen Locations für die genauen Termine 2026, da diese normalerweise im Januar bekanntgegeben werden.
 
 ### Was anziehen
 
-Traditionelle bayerische Tracht ist willkommen, aber weniger verbreitet als beim Oktoberfest. Smart Casual ist die Norm. Wenn du Lederhosen oder ein Dirndl traegst, passt du trotzdem perfekt rein -- es wird nur nicht erwartet.
+Traditionelle bayerische Tracht ist willkommen, aber weniger verbreitet als beim Oktoberfest. Smart Casual ist die Norm. Wenn du Lederhosen oder ein Dirndl trägst, passt du trotzdem perfekt rein -- es wird nur nicht erwartet.
 
-### Unterwegs in Muenchen
+### Unterwegs in München
 
-Alle groesseren Locations sind mit oeffentlichen Verkehrsmitteln erreichbar:
+Alle größeren Locations sind mit öffentlichen Verkehrsmitteln erreichbar:
 
-- **Nockherberg**: U-Bahn U1/U2 bis Kolumbusplatz, dann ein kurzer Fussweg bergauf
-- **Augustiner Keller**: S-Bahn bis Hackerbruecke oder U-Bahn bis Hauptbahnhof
-- **Hofbraeuhaus**: U-Bahn U3/U6 bis Marienplatz
-- **Loewenbraeukeller**: U-Bahn U1/U7 bis Stiglmaierplatz
+- **Nockherberg**: U-Bahn U1/U2 bis Kolumbusplatz, dann ein kurzer Fußweg bergauf
+- **Augustiner Keller**: S-Bahn bis Hackerbrücke oder U-Bahn bis Hauptbahnhof
+- **Hofbräuhaus**: U-Bahn U3/U6 bis Marienplatz
+- **Löwenbräukeller**: U-Bahn U1/U7 bis Stiglmaierplatz
 
 ### Lass es langsam angehen
 
-Das kann nicht oft genug betont werden: Doppelbock ist rund 50 % staerker als normales Bier, und er schmeckt truegerisch sueffig. Die malzige Suesse ueberdeckt den Alkohol. Zwei oder drei Mass Salvator entsprechen vier oder fuenf normalen Bieren. Iss gut, trink Wasser zwischen den Runden und geniesse das Erlebnis in einem nachhaltigen Tempo.
+Das kann nicht oft genug betont werden: Doppelbock ist rund 50 % stärker als normales Bier, und er schmeckt trügerisch süffig. Die malzige Süße überdeckt den Alkohol. Zwei oder drei Maß Salvator entsprechen vier oder fünf normalen Bieren. Iss gut, trink Wasser zwischen den Runden und genieße das Erlebnis in einem nachhaltigen Tempo.
 
-Eine App wie ProstCounter zu nutzen, um deinen Konsum waehrend des Fests zu tracken, hilft dir, den Ueberblick zu behalten und gleichzeitig ein spassiges Protokoll deines Starkbierfest-Abenteuers aufzubauen. Vergleiche mit Freunden, sieh, welche Locations und Doppelboecke du probiert hast, und fuehre ein Logbuch deiner Starkbierzeit.
+Eine App wie ProstCounter zu nutzen, um deinen Konsum während des Fests zu tracken, hilft dir, den Überblick zu behalten und gleichzeitig ein spaßiges Protokoll deines Starkbierfest-Abenteuers aufzubauen. Vergleiche mit Freunden, sieh, welche Locations und Doppelböcke du probiert hast, und führe ein Logbuch deiner Starkbierzeit.
 
 ## Warum du das Starkbierfest erleben solltest
 
-Das Starkbierfest ist in vielerlei Hinsicht das Muenchner Bierfest fuer Leute, die Bier wirklich lieben. Es ist ruhiger, guenstiger, lokaler und dreht sich um einen Bierstil mit einer faszinierenden 400-jaehrigen Geschichte. Die Doppelbock-Tradition verbindet das moderne Muenchen direkt mit den Paulaner-Moenchen, die das Fasten zur Kunstform erhoben.
+Das Starkbierfest ist in vielerlei Hinsicht das Münchner Bierfest für Leute, die Bier wirklich lieben. Es ist ruhiger, günstiger, lokaler und dreht sich um einen Bierstil mit einer faszinierenden 400-jährigen Geschichte. Die Doppelbock-Tradition verbindet das moderne München direkt mit den Paulaner-Mönchen, die das Fasten zur Kunstform erhoben.
 
-Wenn du das Oktoberfest schon erlebt hast und etwas Tiefgruendigeres suchst, oder wenn du Muenchen zu einer Zeit besuchen moechtest, in der die Stadt sich mehr wie sie selbst anfuehlt, plane deine Reise rund um die Starkbierzeit. Du wirst die Fahrgeschaefte, das Spektakel und die internationale Party-Atmosphaere des Oktoberfests nicht finden -- aber du wirst etwas Besseres finden: eine authentische bayerische Tradition, auf die sich die Muenchner jedes Jahr ehrlich freuen.
+Wenn du das Oktoberfest schon erlebt hast und etwas Tiefgründigeres suchst, oder wenn du München zu einer Zeit besuchen möchtest, in der die Stadt sich mehr wie sie selbst anfühlt, plane deine Reise rund um die Starkbierzeit. Du wirst die Fahrgeschäfte, das Spektakel und die internationale Party-Atmosphäre des Oktoberfests nicht finden -- aber du wirst etwas Besseres finden: eine authentische bayerische Tradition, auf die sich die Münchner jedes Jahr ehrlich freuen.
 
-Fuer einen kompletten Ueberblick ueber alle Muenchner Bierfeste im Jahresverlauf schau dir unseren [Muenchner Bierfeste-Kalender](/blog/de/munich-beer-festivals-calendar) an.
+Für einen kompletten Überblick über alle Münchner Bierfeste im Jahresverlauf schau dir unseren [Münchner Bierfeste-Kalender](/blog/de/munich-beer-festivals-calendar) an.
 
 <CTA />

--- a/supabase/migrations/20260805003427_reapply_nearby_members_festival_scope.sql
+++ b/supabase/migrations/20260805003427_reapply_nearby_members_festival_scope.sql
@@ -1,0 +1,133 @@
+-- Re-apply the festival-scoped shared-group visibility check in
+-- get_nearby_group_members.
+--
+-- 20260424113700 introduced this fix, but production never ran it: that
+-- migration was registered with `supabase migration repair --status applied`
+-- while resolving schema drift, so `db push` skipped its SQL. Production has
+-- been running the pre-fix body, in which the visibility EXISTS joins two
+-- group_members rows without consulting groups.festival_id:
+--
+--   EXISTS (SELECT 1 FROM public.group_members gm1
+--           JOIN public.group_members gm2 ON gm2.group_id = gm1.group_id
+--           WHERE gm1.user_id = ls.user_id AND gm2.user_id = input_user_id)
+--
+-- Effect: two users who share any group at all can see each other's live
+-- location on every festival, not just the one the group belongs to. At the
+-- time of writing that is 4,274 (user-pair, festival) combinations across 6
+-- festivals. Groups are festival-scoped (groups.festival_id is NOT NULL), so
+-- the visibility check must be too.
+--
+-- The g.festival_id predicate already present in the group_names subquery is a
+-- different clause and never gated visibility; do not mistake one for the other.
+--
+-- Body below is byte-identical to 20260424113700 apart from this comment.
+
+CREATE OR REPLACE FUNCTION public.get_nearby_group_members(
+  input_user_id uuid,
+  input_festival_id uuid,
+  radius_meters integer DEFAULT 1000
+)
+RETURNS TABLE (
+  user_id uuid,
+  username text,
+  full_name text,
+  avatar_url text,
+  session_id uuid,
+  latitude double precision,
+  longitude double precision,
+  distance_meters double precision,
+  last_updated timestamptz,
+  group_names text[]
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  user_lat double precision;
+  user_lng double precision;
+BEGIN
+  IF auth.uid() IS NULL OR input_user_id <> auth.uid() THEN
+    RAISE EXCEPTION 'Access denied: input_user_id must match authenticated user';
+  END IF;
+
+  SELECT lp.latitude, lp.longitude INTO user_lat, user_lng
+  FROM public.location_sessions ls
+  JOIN public.location_points lp ON lp.session_id = ls.id
+  WHERE ls.user_id = input_user_id
+    AND ls.festival_id = input_festival_id
+    AND ls.is_active = true
+    AND ls.expires_at > NOW()
+  ORDER BY lp.recorded_at DESC
+  LIMIT 1;
+
+  IF user_lat IS NULL THEN
+    RETURN;
+  END IF;
+
+  RETURN QUERY
+  SELECT
+    ls.user_id::uuid,
+    p.username::text,
+    p.full_name::text,
+    p.avatar_url::text,
+    ls.id::uuid AS session_id,
+    lp.latitude::double precision,
+    lp.longitude::double precision,
+    (6371000 * acos(
+      LEAST(1.0, GREATEST(-1.0,
+        cos(radians(user_lat)) * cos(radians(lp.latitude)) *
+        cos(radians(lp.longitude) - radians(user_lng)) +
+        sin(radians(user_lat)) * sin(radians(lp.latitude))
+      ))
+    ))::double precision AS distance_meters,
+    lp.recorded_at::timestamptz AS last_updated,
+    COALESCE(
+      (SELECT array_agg(DISTINCT g.name)::text[]
+       FROM public.group_members gm
+       JOIN public.groups g ON g.id = gm.group_id
+       WHERE gm.user_id = ls.user_id
+         AND g.festival_id = input_festival_id
+         AND EXISTS (SELECT 1 FROM public.group_members gm2
+                     WHERE gm2.group_id = gm.group_id AND gm2.user_id = input_user_id)),
+      ARRAY[]::text[]
+    ) AS group_names
+  FROM public.location_sessions ls
+  JOIN public.location_points lp ON lp.session_id = ls.id
+  JOIN public.profiles p ON p.id = ls.user_id
+  LEFT JOIN public.friendships f
+    ON f.status = 'accepted'
+    AND ls.share_with_friends = true
+    AND (
+      (f.requester_id = input_user_id AND f.addressee_id = ls.user_id)
+      OR (f.requester_id = ls.user_id AND f.addressee_id = input_user_id)
+    )
+  WHERE ls.festival_id = input_festival_id
+    AND ls.is_active = true
+    AND ls.expires_at > NOW()
+    AND ls.user_id != input_user_id
+    AND lp.recorded_at = (SELECT MAX(lp2.recorded_at) FROM public.location_points lp2 WHERE lp2.session_id = ls.id)
+    AND (6371000 * acos(LEAST(1.0, GREATEST(-1.0,
+        cos(radians(user_lat)) * cos(radians(lp.latitude)) *
+        cos(radians(lp.longitude) - radians(user_lng)) +
+        sin(radians(user_lat)) * sin(radians(lp.latitude))
+      )))) <= radius_meters
+    -- Visibility: shared group on the SAME festival, OR friends-with-opt-in.
+    AND (
+      EXISTS (
+        SELECT 1
+        FROM public.group_members gm1
+        JOIN public.groups g ON g.id = gm1.group_id
+        JOIN public.group_members gm2 ON gm2.group_id = gm1.group_id
+        WHERE gm1.user_id = ls.user_id
+          AND gm2.user_id = input_user_id
+          AND g.festival_id = input_festival_id
+      )
+      OR f.id IS NOT NULL
+    )
+  ORDER BY distance_meters;
+END;
+$$;
+
+COMMENT ON FUNCTION public.get_nearby_group_members(uuid, uuid, integer) IS
+'Returns nearby users sharing location. Visibility is the UNION of (shared group on input_festival_id) and (ls.share_with_friends = true AND caller is an accepted friend of owner). Validates input_user_id matches auth.uid() to prevent unauthorized access.';


### PR DESCRIPTION
## Summary

Two cleanups that were parked during the Oktoberfest 2026 work.

### German umlauts (4 blog posts)

`fruehlingsfest-guide`, `munich-beer-festivals-calendar`, `starkbierfest-guide` and `oktoberfest-2026-guide` were written entirely with ASCII substitutes, which CLAUDE.md forbids. 327 distinct word forms restored.

Done per-word rather than by blind regex, because the digraphs are ambiguous in both directions:

- `ue` is not always `ü`: **Brauerei**, **bequem**, **Sauerrahm**, **Abenteuer**, **quer**, **Frauen**, **aufzubauen** all keep it. A first pass produced `Braürei` and `genaür` before this was handled positionally (`ue` is only an umlaut when not preceded by a/e/q).
- `ss` is only `ß` after a long vowel: **Straße**, **groß**, **genießen** yes; **Fass**, **dass**, **Schloss**, **Genuss** no.
- **Goetheplatz** keeps its spelling (Goethe, not Göthe).
- The `fruehlingsfest` frontmatter tag is untouched so it still matches the `en` and `es` locales.

Also fixes two pre-existing typos found on the way, both missing the `e` of the transliteration: `Herzstuck` → `Herzstück`, `Hefeknodel` → `Hefeknödel`.

### `get_nearby_group_members` festival scope

**This one was a live privacy bug, not just file drift.**

`20260424113700` introduced the fix, but production never ran its SQL: that migration was registered with `supabase migration repair --status applied` while resolving drift, so `db push` skipped it. Production kept the pre-fix body, whose visibility check joins two `group_members` rows without consulting `groups.festival_id`:

```sql
EXISTS (SELECT 1 FROM public.group_members gm1
        JOIN public.group_members gm2 ON gm2.group_id = gm1.group_id
        WHERE gm1.user_id = ls.user_id AND gm2.user_id = input_user_id)
```

So two users sharing any group could see each other's live location on **every** festival, not just the group's own. Measured against production data: **4,274 (user-pair, festival) combinations across 6 festivals**.

Worth recording why this went unnoticed: the `group_names` subquery contains its own `g.festival_id = input_festival_id`, so a grep for that predicate reports the gate as present. It is a different clause and never gated visibility.
