### PR TITLE
fix(achievements): add locale copy, fix category rendering bug

### DIFF
--- a/apps/mobile/components/achievements/achievement-card.tsx
+++ b/apps/mobile/components/achievements/achievement-card.tsx
@@ -85,16 +85,6 @@ const RARITY_STYLES: Record<AchievementRarity, { bg: string; text: string; borde
   },
 };
 
-// Category translation keys
-const CATEGORY_KEYS: Record<string, string> = {
-  consumption: "achievements.categories.consumption",
-  attendance: "achievements.categories.attendance",
-  explorer: "achievements.categories.explorer",
-  social: "achievements.categories.social",
-  competitive: "achievements.categories.competitive",
-  special: "achievements.categories.special",
-};
-
 interface AchievementCardProps {
   achievement: AchievementWithProgress;
   showProgress?: boolean;
@@ -119,15 +109,14 @@ export function AchievementCard({ achievement, showProgress = true }: Achievemen
 
   const displayIcon = ICON_MAP[icon] || "🏆";
   const rarityStyle = RARITY_STYLES[rarity];
-  const categoryKey = CATEGORY_KEYS[category] || category;
 
-  // Translate name and description (they are now i18n keys from database)
-  const displayName = t(name, { defaultValue: name });
-  const displayDescription = t(description, { defaultValue: description });
+  // Translate name and description (real i18n keys from the achievements table)
+  const displayName = t(name);
+  const displayDescription = t(description);
   const displayRarity = t(`achievements.rarity.${rarity}`, {
     defaultValue: rarity,
   });
-  const displayCategory = t(categoryKey, { defaultValue: category });
+  const displayCategory = t(`achievements.categories.${category}`);
 
   // Format unlock date
   const formattedUnlockDate = useMemo(() => {

--- a/apps/mobile/components/achievements/achievement-card.tsx
+++ b/apps/mobile/components/achievements/achievement-card.tsx
@@ -113,9 +113,7 @@ export function AchievementCard({ achievement, showProgress = true }: Achievemen
   // Translate name and description (real i18n keys from the achievements table)
   const displayName = t(name);
   const displayDescription = t(description);
-  const displayRarity = t(`achievements.rarity.${rarity}`, {
-    defaultValue: rarity,
-  });
+  const displayRarity = t(`achievements.rarity.${rarity}`);
   const displayCategory = t(`achievements.categories.${category}`);
 
   // Format unlock date

--- a/apps/mobile/components/shared/activity-item.tsx
+++ b/apps/mobile/components/shared/activity-item.tsx
@@ -181,9 +181,7 @@ export function ActivityItem({ activity, festivalId }: ActivityItemProps) {
           undefined,
         );
         // Achievement name is stored as an i18n key, so translate it
-        const translatedName = achievementName
-          ? t(achievementName, { defaultValue: achievementName })
-          : undefined;
+        const translatedName = achievementName ? t(achievementName) : undefined;
         return translatedName
           ? t("activityFeed.unlockedAchievementName", {
               name: translatedName,

--- a/apps/mobile/components/wrapped/slides/achievements-slide.tsx
+++ b/apps/mobile/components/wrapped/slides/achievements-slide.tsx
@@ -66,7 +66,7 @@ export function AchievementsSlide({ data, isActive }: AchievementsSlideProps) {
               </View>
               <VStack space="xs" className="ml-2 flex-1">
                 <Text className="text-sm font-semibold text-gray-800">
-                  {t(achievement.name, { defaultValue: achievement.name })}
+                  {t(achievement.name)}
                 </Text>
                 <HStack space="sm" className="items-center">
                   <View

--- a/apps/web/app/(private)/achievements/page.tsx
+++ b/apps/web/app/(private)/achievements/page.tsx
@@ -165,8 +165,8 @@ export default function AchievementsPage() {
                 options: [
                   { value: "all", label: t("achievements.filter.all") },
                   {
-                    value: "consumption",
-                    label: t("achievements.filter.consumption"),
+                    value: "drinking",
+                    label: t("achievements.filter.drinking"),
                   },
                   {
                     value: "attendance",
@@ -181,7 +181,10 @@ export default function AchievementsPage() {
                     value: "competitive",
                     label: t("achievements.filter.competitive"),
                   },
-                  { value: "special", label: t("achievements.filter.special") },
+                  {
+                    value: "dedication",
+                    label: t("achievements.filter.dedication"),
+                  },
                 ],
               },
             ]}

--- a/apps/web/components/achievements/AchievementBadge.tsx
+++ b/apps/web/components/achievements/AchievementBadge.tsx
@@ -109,7 +109,7 @@ export function AchievementBadge({
   const displayIcon = iconMap[icon as keyof typeof iconMap] || "🏆";
 
   // Achievement name is stored as an i18n key, so translate it
-  const translatedName = t(name, { defaultValue: name });
+  const translatedName = t(name);
 
   const sizeStyles = {
     sm: "text-xs px-1.5 py-0.5",

--- a/apps/web/components/achievements/AchievementCard.tsx
+++ b/apps/web/components/achievements/AchievementCard.tsx
@@ -37,9 +37,7 @@ export function AchievementCard({
   // Translate name and description (real i18n keys from the achievements table)
   const displayName = t(name);
   const displayDescription = t(description);
-  const displayRarity = t(`achievements.rarity.${rarity}`, {
-    defaultValue: rarity,
-  });
+  const displayRarity = t(`achievements.rarity.${rarity}`);
   const displayCategory = t(`achievements.categories.${category}`);
 
   return (

--- a/apps/web/components/achievements/AchievementCard.tsx
+++ b/apps/web/components/achievements/AchievementCard.tsx
@@ -16,16 +16,6 @@ interface AchievementCardProps {
   showProgress?: boolean;
 }
 
-// Map category values to translation keys
-const CATEGORY_KEYS: Record<string, string> = {
-  consumption: "achievements.categories.consumption",
-  attendance: "achievements.categories.attendance",
-  explorer: "achievements.categories.explorer",
-  social: "achievements.categories.social",
-  competitive: "achievements.categories.competitive",
-  special: "achievements.categories.special",
-};
-
 export function AchievementCard({
   achievement,
   className,
@@ -44,14 +34,13 @@ export function AchievementCard({
     user_progress,
   } = achievement;
 
-  // Translate name and description (they are now i18n keys from database)
-  const displayName = t(name, { defaultValue: name });
-  const displayDescription = t(description, { defaultValue: description });
+  // Translate name and description (real i18n keys from the achievements table)
+  const displayName = t(name);
+  const displayDescription = t(description);
   const displayRarity = t(`achievements.rarity.${rarity}`, {
     defaultValue: rarity,
   });
-  const categoryKey = CATEGORY_KEYS[category] || category;
-  const displayCategory = t(categoryKey, { defaultValue: category });
+  const displayCategory = t(`achievements.categories.${category}`);
 
   return (
     <Card

--- a/apps/web/components/achievements/AchievementHighlight.tsx
+++ b/apps/web/components/achievements/AchievementHighlight.tsx
@@ -78,9 +78,7 @@ export function AchievementHighlight({ className }: AchievementHighlightProps) {
                 {recentAchievements.map((achievement: AchievementWithProgress) => (
                   <div key={achievement.id} className="flex flex-col items-center gap-2">
                     <AchievementBadge
-                      name={t(achievement.name, {
-                        defaultValue: achievement.name,
-                      })}
+                      name={achievement.name}
                       icon={achievement.icon}
                       rarity={achievement.rarity}
                       points={achievement.points}

--- a/packages/shared/src/achievements/locale-coverage.test.ts
+++ b/packages/shared/src/achievements/locale-coverage.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+
+import de from "../i18n/locales/de.json";
+import en from "../i18n/locales/en.json";
+import es from "../i18n/locales/es.json";
+import { ALL_DEFINITIONS } from "./definitions";
+import { isSeries, slugFor } from "./types";
+import type { AchievementCategory } from "./types";
+
+type LocaleNode = string | { [key: string]: LocaleNode };
+
+const LOCALES: Record<string, LocaleNode> = {
+  en: en.achievements as unknown as LocaleNode,
+  de: de.achievements as unknown as LocaleNode,
+  es: es.achievements as unknown as LocaleNode,
+};
+
+const TIERS = ["bronze", "silver", "gold", "platinum"] as const;
+
+const CATEGORIES: AchievementCategory[] = [
+  "drinking",
+  "attendance",
+  "explorer",
+  "social",
+  "competitive",
+  "dedication",
+];
+
+function resolve(node: LocaleNode | undefined, path: string[]): LocaleNode | undefined {
+  let current: LocaleNode | undefined = node;
+  for (const key of path) {
+    if (current === undefined || typeof current === "string") return undefined;
+    current = current[key];
+  }
+  return current;
+}
+
+function hasCopy(node: LocaleNode, slug: string): boolean {
+  const entry = resolve(node, slug.split("."));
+  if (entry === undefined || typeof entry === "string") return false;
+  const name = entry.name;
+  const description = entry.description;
+  return (
+    typeof name === "string" &&
+    name.trim() !== "" &&
+    typeof description === "string" &&
+    description.trim() !== ""
+  );
+}
+
+describe("achievement locale coverage", () => {
+  describe("shared labels", () => {
+    for (const [localeName, node] of Object.entries(LOCALES)) {
+      it(`${localeName}: has all 4 tier labels`, () => {
+        for (const tier of TIERS) {
+          const label = resolve(node, ["tiers", tier]);
+          expect(typeof label).toBe("string");
+          expect((label as string) ?? "").not.toBe("");
+        }
+      });
+
+      it(`${localeName}: has all 6 category labels in categories and filter`, () => {
+        for (const category of CATEGORIES) {
+          const categoryLabel = resolve(node, ["categories", category]);
+          const filterLabel = resolve(node, ["filter", category]);
+          expect(typeof categoryLabel).toBe("string");
+          expect(typeof filterLabel).toBe("string");
+        }
+      });
+    }
+  });
+
+  for (const category of CATEGORIES) {
+    describe(`category: ${category}`, () => {
+      const slugs = ALL_DEFINITIONS.filter((def) => def.category === category).flatMap((def) =>
+        isSeries(def) ? def.tiers.map((tierDef) => slugFor(def, tierDef.tier)) : [slugFor(def)],
+      );
+
+      for (const [localeName, node] of Object.entries(LOCALES)) {
+        it(`${localeName}: every ${category} slug has name and description`, () => {
+          const missing = slugs.filter((slug) => !hasCopy(node, slug));
+          expect(missing).toEqual([]);
+        });
+      }
+    });
+  }
+});

--- a/packages/shared/src/achievements/locale-coverage.test.ts
+++ b/packages/shared/src/achievements/locale-coverage.test.ts
@@ -64,7 +64,9 @@ describe("achievement locale coverage", () => {
           const categoryLabel = resolve(node, ["categories", category]);
           const filterLabel = resolve(node, ["filter", category]);
           expect(typeof categoryLabel).toBe("string");
+          expect((categoryLabel as string) ?? "").not.toBe("");
           expect(typeof filterLabel).toBe("string");
+          expect((filterLabel as string) ?? "").not.toBe("");
         }
       });
     }

--- a/packages/shared/src/i18n/locales/de.json
+++ b/packages/shared/src/i18n/locales/de.json
@@ -831,6 +831,32 @@
       "t3": { "name": "Beständiger Herausforderer", "description": "Erreich 12-mal die Top 3 in einer Gruppe" },
       "t4": { "name": "Podium-Legende", "description": "Erreich 25-mal die Top 3 in einer Gruppe" }
     },
+    "active_days": {
+      "t1": { "name": "Guter Start", "description": "Sei an 5 verschiedenen Tagen aktiv" },
+      "t2": { "name": "Bekanntes Gesicht", "description": "Sei an 25 verschiedenen Tagen aktiv" },
+      "t3": { "name": "Alter Hase", "description": "Sei an 75 verschiedenen Tagen aktiv" },
+      "t4": { "name": "Urgestein", "description": "Sei an 200 verschiedenen Tagen aktiv" }
+    },
+    "active_day_streak": {
+      "t1": { "name": "Warmlaufen", "description": "Sei 3 Tage in Folge aktiv" },
+      "t2": { "name": "In Fahrt", "description": "Sei 7 Tage in Folge aktiv" },
+      "t3": { "name": "Gewohnheit gebildet", "description": "Sei 21 Tage in Folge aktiv" },
+      "t4": { "name": "Unaufhaltsame Serie", "description": "Sei 60 Tage in Folge aktiv" }
+    },
+    "crowd_reports": {
+      "t1": { "name": "Erste Meldung", "description": "Reich bei diesem Fest 1 Andrang-Meldung ein" },
+      "t2": { "name": "Regelmäßiger Melder", "description": "Reich bei diesem Fest 5 Andrang-Meldungen ein" },
+      "t3": { "name": "Andrang-Beobachter", "description": "Reich bei diesem Fest 15 Andrang-Meldungen ein" },
+      "t4": { "name": "Stütze der Gemeinschaft", "description": "Reich bei diesem Fest 30 Andrang-Meldungen ein" }
+    },
+    "profile_complete": {
+      "name": "Profil vollständig",
+      "description": "Leg Avatar, Benutzername und vollständigen Namen fest"
+    },
+    "wrapped_viewed": {
+      "name": "Jahresrückblick",
+      "description": "Sieh dir deinen Jahresrückblick an"
+    },
     "complete": "Abschließen",
     "items": {
       "firstDrop": {

--- a/packages/shared/src/i18n/locales/de.json
+++ b/packages/shared/src/i18n/locales/de.json
@@ -819,6 +819,18 @@
       "name": "Gruppengründer",
       "description": "Erstell eine Gruppe"
     },
+    "group_wins": {
+      "t1": { "name": "Erster Sieg", "description": "Gewinn einmal den ersten Platz in einer Gruppe" },
+      "t2": { "name": "Serien-Sieger", "description": "Gewinn 3-mal den ersten Platz in einer Gruppe" },
+      "t3": { "name": "Gruppen-Champion", "description": "Gewinn 6-mal den ersten Platz in einer Gruppe" },
+      "t4": { "name": "Dynastie", "description": "Gewinn 10-mal den ersten Platz in einer Gruppe" }
+    },
+    "podium_finishes": {
+      "t1": { "name": "Auf dem Podium", "description": "Erreich einmal die Top 3 in einer Gruppe" },
+      "t2": { "name": "Podium-Stammgast", "description": "Erreich 5-mal die Top 3 in einer Gruppe" },
+      "t3": { "name": "Beständiger Herausforderer", "description": "Erreich 12-mal die Top 3 in einer Gruppe" },
+      "t4": { "name": "Podium-Legende", "description": "Erreich 25-mal die Top 3 in einer Gruppe" }
+    },
     "complete": "Abschließen",
     "items": {
       "firstDrop": {

--- a/packages/shared/src/i18n/locales/de.json
+++ b/packages/shared/src/i18n/locales/de.json
@@ -787,6 +787,38 @@
       "name": "Große Tour",
       "description": "Besuch jedes große Zelt beim Fest"
     },
+    "groups_joined": {
+      "t1": { "name": "Beigetreten", "description": "Tritt bei diesem Fest 1 Gruppe bei" },
+      "t2": { "name": "Teamplayer", "description": "Tritt bei diesem Fest 2 Gruppen bei" },
+      "t3": { "name": "Gut vernetzt", "description": "Tritt bei diesem Fest 4 Gruppen bei" },
+      "t4": { "name": "Sozialer Mittelpunkt", "description": "Tritt bei diesem Fest 6 Gruppen bei" }
+    },
+    "friends_added": {
+      "t1": { "name": "Erster Freund", "description": "Füg deinen ersten Freund hinzu" },
+      "t2": { "name": "Wachsender Kreis", "description": "Füg 5 Freunde hinzu" },
+      "t3": { "name": "Beliebt", "description": "Füg 15 Freunde hinzu" },
+      "t4": { "name": "Geselliger Schmetterling", "description": "Füg 30 Freunde hinzu" }
+    },
+    "photos_uploaded": {
+      "t1": { "name": "Sag Cheese", "description": "Lad 1 Foto bei diesem Fest hoch" },
+      "t2": { "name": "Foto-Fan", "description": "Lad 10 Fotos bei diesem Fest hoch" },
+      "t3": { "name": "Fotoalbum", "description": "Lad 25 Fotos bei diesem Fest hoch" },
+      "t4": { "name": "Erinnerungshüter", "description": "Lad 50 Fotos bei diesem Fest hoch" }
+    },
+    "reactions_given": {
+      "t1": { "name": "Zuneigung zeigen", "description": "Reagier bei diesem Fest auf 5 Fotos" },
+      "t2": { "name": "Unterstützend", "description": "Reagier bei diesem Fest auf 25 Fotos" },
+      "t3": { "name": "Cheerleader", "description": "Reagier bei diesem Fest auf 75 Fotos" },
+      "t4": { "name": "Reaktions-Maschine", "description": "Reagier bei diesem Fest auf 150 Fotos" }
+    },
+    "first_photo": {
+      "name": "Erster Schnappschuss",
+      "description": "Lad dein allererstes Foto hoch"
+    },
+    "created_group": {
+      "name": "Gruppengründer",
+      "description": "Erstell eine Gruppe"
+    },
     "complete": "Abschließen",
     "items": {
       "firstDrop": {

--- a/packages/shared/src/i18n/locales/de.json
+++ b/packages/shared/src/i18n/locales/de.json
@@ -765,6 +765,28 @@
       "name": "Ganzes Fest",
       "description": "Besuch jeden einzelnen Tag des Fests"
     },
+    "tents_visited": {
+      "t1": { "name": "Zeltneugierig", "description": "Besuch 3 verschiedene Zelte" },
+      "t2": { "name": "Zelt-Hopper", "description": "Besuch 6 verschiedene Zelte" },
+      "t3": { "name": "Zelt-Entdecker", "description": "Besuch 10 verschiedene Zelte" },
+      "t4": { "name": "Zelt-Meister", "description": "Besuch 15 verschiedene Zelte" }
+    },
+    "festivals_attended": {
+      "t1": { "name": "Erstes Fest", "description": "Besuch dein erstes Fest" },
+      "t2": { "name": "Fest-Stammgast", "description": "Besuch 3 verschiedene Feste" },
+      "t3": { "name": "Fest-Veteran", "description": "Besuch 5 verschiedene Feste" },
+      "t4": { "name": "Fest-Legende", "description": "Besuch 8 verschiedene Feste" }
+    },
+    "festival_types": {
+      "t1": { "name": "Erster Stil", "description": "Besuch deine erste Festart" },
+      "t2": { "name": "Horizont erweitert", "description": "Besuch 2 verschiedene Festarten" },
+      "t3": { "name": "Weitgereist", "description": "Besuch 3 verschiedene Festarten" },
+      "t4": { "name": "Fest-Kenner", "description": "Besuch 4 verschiedene Festarten" }
+    },
+    "all_large_tents": {
+      "name": "Große Tour",
+      "description": "Besuch jedes große Zelt beim Fest"
+    },
     "complete": "Abschließen",
     "items": {
       "firstDrop": {

--- a/packages/shared/src/i18n/locales/de.json
+++ b/packages/shared/src/i18n/locales/de.json
@@ -654,12 +654,12 @@
       "categoriesTitle": "Erfolgs-Kategorien",
       "selectCategory": "Kategorie wählen",
       "all": "Alle Erfolge",
-      "consumption": "Bier-Erfolge",
+      "drinking": "Trink-Erfolge",
       "attendance": "Tage-Erfolge",
       "explorer": "Zelt-Erfolge",
       "social": "Soziale Erfolge",
       "competitive": "Wettbewerbs-Erfolge",
-      "special": "Spezielle Erfolge"
+      "dedication": "Hingabe-Erfolge"
     },
     "empty": {
       "title": "Keine Erfolge in dieser Kategorie",
@@ -667,11 +667,10 @@
     },
     "categories": {
       "attendance": "Anwesenheit",
-      "consumption": "Konsum",
+      "drinking": "Trinken",
       "social": "Sozial",
       "explorer": "Entdecker",
-      "veteran": "Veteran",
-      "special": "Spezial",
+      "dedication": "Hingabe",
       "competitive": "Wettbewerb"
     },
     "rarity": {
@@ -692,6 +691,12 @@
     "viewMyAchievements": "Meine Erfolge ansehen",
     "viewProgress": "deinen Fortschritt und freigeschaltete Abzeichen ansehen",
     "points": "Pkt",
+    "tiers": {
+      "bronze": "Bronze",
+      "silver": "Silber",
+      "gold": "Gold",
+      "platinum": "Platin"
+    },
     "complete": "Abschließen",
     "items": {
       "firstDrop": {

--- a/packages/shared/src/i18n/locales/de.json
+++ b/packages/shared/src/i18n/locales/de.json
@@ -737,6 +737,34 @@
       "name": "Erster Schluck",
       "description": "Erfasse dein allererstes Getränk"
     },
+    "days_attended": {
+      "t1": { "name": "Dabei gewesen", "description": "Besuch das Fest an 1 Tag" },
+      "t2": { "name": "Stammgast", "description": "Besuch das Fest an 3 Tagen" },
+      "t3": { "name": "Treuer Besucher", "description": "Besuch das Fest an 6 Tagen" },
+      "t4": { "name": "Fest-Urgestein", "description": "Besuch das Fest an 10 Tagen" }
+    },
+    "attendance_streak": {
+      "t1": { "name": "Zwei in Folge", "description": "Besuch das Fest 2 Tage in Folge" },
+      "t2": { "name": "Im Lauf", "description": "Besuch das Fest 3 Tage in Folge" },
+      "t3": { "name": "Serien-Meister", "description": "Besuch das Fest 5 Tage in Folge" },
+      "t4": { "name": "Ungebrochene Kette", "description": "Besuch das Fest 7 Tage in Folge" }
+    },
+    "opening_day": {
+      "name": "Eröffnungstag",
+      "description": "Sei am Eröffnungstag des Fests dabei"
+    },
+    "closing_day": {
+      "name": "Letzte Runde",
+      "description": "Sei am letzten Tag des Fests dabei"
+    },
+    "every_weekend_day": {
+      "name": "Wochenend-Krieger",
+      "description": "Besuch jeden Wochenendtag des Fests"
+    },
+    "full_festival": {
+      "name": "Ganzes Fest",
+      "description": "Besuch jeden einzelnen Tag des Fests"
+    },
     "complete": "Abschließen",
     "items": {
       "firstDrop": {

--- a/packages/shared/src/i18n/locales/de.json
+++ b/packages/shared/src/i18n/locales/de.json
@@ -697,6 +697,46 @@
       "gold": "Gold",
       "platinum": "Platin"
     },
+    "drinks_total": {
+      "t1": { "name": "Erste Runde", "description": "Trink 3 Getränke bei diesem Fest" },
+      "t2": { "name": "Standfester Trinker", "description": "Trink 10 Getränke bei diesem Fest" },
+      "t3": { "name": "Maß-Meister", "description": "Trink 25 Getränke bei diesem Fest" },
+      "t4": { "name": "Legendärer Durst", "description": "Trink 50 Getränke bei diesem Fest" }
+    },
+    "drinks_day_max": {
+      "t1": { "name": "Solide Session", "description": "Trink an einem Tag 3 Bier" },
+      "t2": { "name": "Großer Tag", "description": "Trink an einem Tag 5 Bier" },
+      "t3": { "name": "Schwergewicht", "description": "Trink an einem Tag 8 Bier" },
+      "t4": { "name": "Unaufhaltsam", "description": "Trink an einem Tag 12 Bier" }
+    },
+    "drink_variety": {
+      "t1": { "name": "Kostprobe", "description": "Probier 2 verschiedene Getränkearten" },
+      "t2": { "name": "Geschmacks-Entdecker", "description": "Probier 3 verschiedene Getränkearten" },
+      "t3": { "name": "Kenner", "description": "Probier 4 verschiedene Getränkearten" },
+      "t4": { "name": "Volle Karte", "description": "Probier 5 verschiedene Getränkearten" }
+    },
+    "volume_total": {
+      "t1": { "name": "Erste Liter", "description": "Trink 5 Liter bei diesem Fest" },
+      "t2": { "name": "Zwanzig geschafft", "description": "Trink 20 Liter bei diesem Fest" },
+      "t3": { "name": "Halbes Hektoliter", "description": "Trink 50 Liter bei diesem Fest" },
+      "t4": { "name": "Hundert Liter", "description": "Trink 100 Liter bei diesem Fest" }
+    },
+    "tips_total": {
+      "t1": { "name": "Großzügiger Start", "description": "Gib insgesamt 5 € Trinkgeld bei diesem Fest" },
+      "t2": { "name": "Guter Trinkgeldgeber", "description": "Gib insgesamt 20 € Trinkgeld bei diesem Fest" },
+      "t3": { "name": "Publikumsliebling", "description": "Gib insgesamt 50 € Trinkgeld bei diesem Fest" },
+      "t4": { "name": "Legendärer Trinkgeldgeber", "description": "Gib insgesamt 100 € Trinkgeld bei diesem Fest" }
+    },
+    "spend_total": {
+      "t1": { "name": "Geldbeutel geöffnet", "description": "Gib 100 € bei diesem Fest aus" },
+      "t2": { "name": "Großzügiger Ausgeber", "description": "Gib 300 € bei diesem Fest aus" },
+      "t3": { "name": "Hochroller", "description": "Gib 600 € bei diesem Fest aus" },
+      "t4": { "name": "Keine Grenzen", "description": "Gib 1.000 € bei diesem Fest aus" }
+    },
+    "first_drink": {
+      "name": "Erster Schluck",
+      "description": "Erfasse dein allererstes Getränk"
+    },
     "complete": "Abschließen",
     "items": {
       "firstDrop": {

--- a/packages/shared/src/i18n/locales/en.json
+++ b/packages/shared/src/i18n/locales/en.json
@@ -854,6 +854,18 @@
       "name": "Group Founder",
       "description": "Create a group"
     },
+    "group_wins": {
+      "t1": { "name": "First Win", "description": "Win first place in a group once" },
+      "t2": { "name": "Serial Winner", "description": "Win first place in a group 3 times" },
+      "t3": { "name": "Group Champion", "description": "Win first place in a group 6 times" },
+      "t4": { "name": "Dynasty", "description": "Win first place in a group 10 times" }
+    },
+    "podium_finishes": {
+      "t1": { "name": "On the Podium", "description": "Finish top 3 in a group once" },
+      "t2": { "name": "Podium Regular", "description": "Finish top 3 in a group 5 times" },
+      "t3": { "name": "Consistent Contender", "description": "Finish top 3 in a group 12 times" },
+      "t4": { "name": "Podium Legend", "description": "Finish top 3 in a group 25 times" }
+    },
     "complete": "Complete",
     "items": {
       "firstDrop": {

--- a/packages/shared/src/i18n/locales/en.json
+++ b/packages/shared/src/i18n/locales/en.json
@@ -689,12 +689,12 @@
       "categoriesTitle": "Achievement Categories",
       "selectCategory": "Select category",
       "all": "All Achievements",
-      "consumption": "Beer Achievements",
+      "drinking": "Drinking Achievements",
       "attendance": "Days Achievements",
       "explorer": "Tents Achievements",
       "social": "Social Achievements",
       "competitive": "Compete Achievements",
-      "special": "Special Achievements"
+      "dedication": "Dedication Achievements"
     },
     "empty": {
       "title": "No achievements in this category",
@@ -702,11 +702,10 @@
     },
     "categories": {
       "attendance": "Attendance",
-      "consumption": "Consumption",
+      "drinking": "Drinking",
       "social": "Social",
       "explorer": "Explorer",
-      "veteran": "Veteran",
-      "special": "Special",
+      "dedication": "Dedication",
       "competitive": "Competitive"
     },
     "rarity": {
@@ -727,6 +726,12 @@
     "viewMyAchievements": "See my achievements",
     "viewProgress": "View your progress and unlocked badges",
     "points": "pts",
+    "tiers": {
+      "bronze": "Bronze",
+      "silver": "Silver",
+      "gold": "Gold",
+      "platinum": "Platinum"
+    },
     "complete": "Complete",
     "items": {
       "firstDrop": {

--- a/packages/shared/src/i18n/locales/en.json
+++ b/packages/shared/src/i18n/locales/en.json
@@ -822,6 +822,38 @@
       "name": "Grand Tour",
       "description": "Visit every large tent at the festival"
     },
+    "groups_joined": {
+      "t1": { "name": "Joined Up", "description": "Join 1 group this festival" },
+      "t2": { "name": "Team Player", "description": "Join 2 groups this festival" },
+      "t3": { "name": "Networked", "description": "Join 4 groups this festival" },
+      "t4": { "name": "Social Hub", "description": "Join 6 groups this festival" }
+    },
+    "friends_added": {
+      "t1": { "name": "First Friend", "description": "Add your first friend" },
+      "t2": { "name": "Growing Circle", "description": "Add 5 friends" },
+      "t3": { "name": "Popular", "description": "Add 15 friends" },
+      "t4": { "name": "Social Butterfly", "description": "Add 30 friends" }
+    },
+    "photos_uploaded": {
+      "t1": { "name": "Say Cheese", "description": "Upload 1 photo this festival" },
+      "t2": { "name": "Photo Enthusiast", "description": "Upload 10 photos this festival" },
+      "t3": { "name": "Photo Album", "description": "Upload 25 photos this festival" },
+      "t4": { "name": "Memory Keeper", "description": "Upload 50 photos this festival" }
+    },
+    "reactions_given": {
+      "t1": { "name": "Showing Love", "description": "React to 5 photos this festival" },
+      "t2": { "name": "Supportive", "description": "React to 25 photos this festival" },
+      "t3": { "name": "Cheerleader", "description": "React to 75 photos this festival" },
+      "t4": { "name": "Reaction Machine", "description": "React to 150 photos this festival" }
+    },
+    "first_photo": {
+      "name": "First Snap",
+      "description": "Upload your first photo ever"
+    },
+    "created_group": {
+      "name": "Group Founder",
+      "description": "Create a group"
+    },
     "complete": "Complete",
     "items": {
       "firstDrop": {

--- a/packages/shared/src/i18n/locales/en.json
+++ b/packages/shared/src/i18n/locales/en.json
@@ -800,6 +800,28 @@
       "name": "Full Festival",
       "description": "Attend every single day of the festival"
     },
+    "tents_visited": {
+      "t1": { "name": "Tent Curious", "description": "Visit 3 different tents" },
+      "t2": { "name": "Tent Hopper", "description": "Visit 6 different tents" },
+      "t3": { "name": "Tent Explorer", "description": "Visit 10 different tents" },
+      "t4": { "name": "Tent Master", "description": "Visit 15 different tents" }
+    },
+    "festivals_attended": {
+      "t1": { "name": "First Festival", "description": "Attend your first festival" },
+      "t2": { "name": "Festival Regular", "description": "Attend 3 different festivals" },
+      "t3": { "name": "Festival Veteran", "description": "Attend 5 different festivals" },
+      "t4": { "name": "Festival Legend", "description": "Attend 8 different festivals" }
+    },
+    "festival_types": {
+      "t1": { "name": "First Style", "description": "Attend your first type of festival" },
+      "t2": { "name": "Branching Out", "description": "Attend 2 different types of festival" },
+      "t3": { "name": "Well Travelled", "description": "Attend 3 different types of festival" },
+      "t4": { "name": "Festival Connoisseur", "description": "Attend 4 different types of festival" }
+    },
+    "all_large_tents": {
+      "name": "Grand Tour",
+      "description": "Visit every large tent at the festival"
+    },
     "complete": "Complete",
     "items": {
       "firstDrop": {

--- a/packages/shared/src/i18n/locales/en.json
+++ b/packages/shared/src/i18n/locales/en.json
@@ -732,6 +732,46 @@
       "gold": "Gold",
       "platinum": "Platinum"
     },
+    "drinks_total": {
+      "t1": { "name": "First Round", "description": "Have 3 drinks this festival" },
+      "t2": { "name": "Steady Drinker", "description": "Have 10 drinks this festival" },
+      "t3": { "name": "Mass Master", "description": "Have 25 drinks this festival" },
+      "t4": { "name": "Legendary Thirst", "description": "Have 50 drinks this festival" }
+    },
+    "drinks_day_max": {
+      "t1": { "name": "Solid Session", "description": "Drink 3 beers in a single day" },
+      "t2": { "name": "Big Day", "description": "Drink 5 beers in a single day" },
+      "t3": { "name": "Heavy Hitter", "description": "Drink 8 beers in a single day" },
+      "t4": { "name": "Unstoppable", "description": "Drink 12 beers in a single day" }
+    },
+    "drink_variety": {
+      "t1": { "name": "Sampler", "description": "Try 2 different drink types" },
+      "t2": { "name": "Taste Explorer", "description": "Try 3 different drink types" },
+      "t3": { "name": "Connoisseur", "description": "Try 4 different drink types" },
+      "t4": { "name": "Full Menu", "description": "Try 5 different drink types" }
+    },
+    "volume_total": {
+      "t1": { "name": "First Litres", "description": "Drink 5 litres this festival" },
+      "t2": { "name": "Twenty Down", "description": "Drink 20 litres this festival" },
+      "t3": { "name": "Half Hectolitre", "description": "Drink 50 litres this festival" },
+      "t4": { "name": "Century Litres", "description": "Drink 100 litres this festival" }
+    },
+    "tips_total": {
+      "t1": { "name": "Generous Start", "description": "Tip €5 total this festival" },
+      "t2": { "name": "Big Tipper", "description": "Tip €20 total this festival" },
+      "t3": { "name": "Crowd Favourite", "description": "Tip €50 total this festival" },
+      "t4": { "name": "Legendary Tipper", "description": "Tip €100 total this festival" }
+    },
+    "spend_total": {
+      "t1": { "name": "Opening the Wallet", "description": "Spend €100 this festival" },
+      "t2": { "name": "Big Spender", "description": "Spend €300 this festival" },
+      "t3": { "name": "High Roller", "description": "Spend €600 this festival" },
+      "t4": { "name": "No Limits", "description": "Spend €1,000 this festival" }
+    },
+    "first_drink": {
+      "name": "First Drop",
+      "description": "Log your first drink ever"
+    },
     "complete": "Complete",
     "items": {
       "firstDrop": {

--- a/packages/shared/src/i18n/locales/en.json
+++ b/packages/shared/src/i18n/locales/en.json
@@ -866,6 +866,32 @@
       "t3": { "name": "Consistent Contender", "description": "Finish top 3 in a group 12 times" },
       "t4": { "name": "Podium Legend", "description": "Finish top 3 in a group 25 times" }
     },
+    "active_days": {
+      "t1": { "name": "Getting Started", "description": "Be active on 5 different days" },
+      "t2": { "name": "Regular Face", "description": "Be active on 25 different days" },
+      "t3": { "name": "Old Faithful", "description": "Be active on 75 different days" },
+      "t4": { "name": "Lifer", "description": "Be active on 200 different days" }
+    },
+    "active_day_streak": {
+      "t1": { "name": "Warming Up", "description": "Be active 3 days in a row" },
+      "t2": { "name": "On Fire", "description": "Be active 7 days in a row" },
+      "t3": { "name": "Habit Formed", "description": "Be active 21 days in a row" },
+      "t4": { "name": "Unstoppable Streak", "description": "Be active 60 days in a row" }
+    },
+    "crowd_reports": {
+      "t1": { "name": "First Report", "description": "Submit 1 crowd report this festival" },
+      "t2": { "name": "Regular Reporter", "description": "Submit 5 crowd reports this festival" },
+      "t3": { "name": "Crowd Watcher", "description": "Submit 15 crowd reports this festival" },
+      "t4": { "name": "Community Pillar", "description": "Submit 30 crowd reports this festival" }
+    },
+    "profile_complete": {
+      "name": "Profile Complete",
+      "description": "Set your avatar, username, and full name"
+    },
+    "wrapped_viewed": {
+      "name": "Year in Review",
+      "description": "View your Wrapped"
+    },
     "complete": "Complete",
     "items": {
       "firstDrop": {

--- a/packages/shared/src/i18n/locales/en.json
+++ b/packages/shared/src/i18n/locales/en.json
@@ -772,6 +772,34 @@
       "name": "First Drop",
       "description": "Log your first drink ever"
     },
+    "days_attended": {
+      "t1": { "name": "Showed Up", "description": "Attend 1 day of the festival" },
+      "t2": { "name": "Regular", "description": "Attend 3 days of the festival" },
+      "t3": { "name": "Dedicated", "description": "Attend 6 days of the festival" },
+      "t4": { "name": "Festival Fixture", "description": "Attend 10 days of the festival" }
+    },
+    "attendance_streak": {
+      "t1": { "name": "Two in a Row", "description": "Attend 2 days in a row" },
+      "t2": { "name": "On a Roll", "description": "Attend 3 days in a row" },
+      "t3": { "name": "Streak Master", "description": "Attend 5 days in a row" },
+      "t4": { "name": "Unbroken Chain", "description": "Attend 7 days in a row" }
+    },
+    "opening_day": {
+      "name": "Opening Day",
+      "description": "Attend on the festival's opening day"
+    },
+    "closing_day": {
+      "name": "Last Call",
+      "description": "Attend on the festival's closing day"
+    },
+    "every_weekend_day": {
+      "name": "Weekend Warrior",
+      "description": "Attend every weekend day of the festival"
+    },
+    "full_festival": {
+      "name": "Full Festival",
+      "description": "Attend every single day of the festival"
+    },
     "complete": "Complete",
     "items": {
       "firstDrop": {

--- a/packages/shared/src/i18n/locales/es.json
+++ b/packages/shared/src/i18n/locales/es.json
@@ -689,12 +689,12 @@
       "categoriesTitle": "Categorías de logros",
       "selectCategory": "Seleccioná una categoría",
       "all": "Todos los logros",
-      "consumption": "Logros de cerveza",
+      "drinking": "Logros de bebida",
       "attendance": "Logros de días",
       "explorer": "Logros de carpas",
       "social": "Logros sociales",
       "competitive": "Logros competitivos",
-      "special": "Logros especiales"
+      "dedication": "Logros de dedicación"
     },
     "empty": {
       "title": "No hay logros en esta categoría",
@@ -702,11 +702,10 @@
     },
     "categories": {
       "attendance": "Asistencia",
-      "consumption": "Consumo",
+      "drinking": "Bebida",
       "social": "Social",
       "explorer": "Explorador",
-      "veteran": "Veterano",
-      "special": "Especial",
+      "dedication": "Dedicación",
       "competitive": "Competitivo"
     },
     "rarity": {
@@ -727,6 +726,12 @@
     "viewMyAchievements": "Ver mis logros",
     "viewProgress": "Mirá tu progreso y medallas desbloqueadas",
     "points": "pts",
+    "tiers": {
+      "bronze": "Bronce",
+      "silver": "Plata",
+      "gold": "Oro",
+      "platinum": "Platino"
+    },
     "complete": "Completar",
     "items": {
       "firstDrop": {

--- a/packages/shared/src/i18n/locales/es.json
+++ b/packages/shared/src/i18n/locales/es.json
@@ -866,6 +866,32 @@
       "t3": { "name": "Contendiente Constante", "description": "Terminá entre los 3 primeros de un grupo 12 veces" },
       "t4": { "name": "Leyenda del Podio", "description": "Terminá entre los 3 primeros de un grupo 25 veces" }
     },
+    "active_days": {
+      "t1": { "name": "Buen Comienzo", "description": "Estuviste activo 5 días diferentes" },
+      "t2": { "name": "Cara Conocida", "description": "Estuviste activo 25 días diferentes" },
+      "t3": { "name": "Veterano de Ley", "description": "Estuviste activo 75 días diferentes" },
+      "t4": { "name": "Pilar de la Casa", "description": "Estuviste activo 200 días diferentes" }
+    },
+    "active_day_streak": {
+      "t1": { "name": "Entrando en Calor", "description": "Estuviste activo 3 días seguidos" },
+      "t2": { "name": "En Llamas", "description": "Estuviste activo 7 días seguidos" },
+      "t3": { "name": "Hábito Formado", "description": "Estuviste activo 21 días seguidos" },
+      "t4": { "name": "Racha Imparable", "description": "Estuviste activo 60 días seguidos" }
+    },
+    "crowd_reports": {
+      "t1": { "name": "Primer Reporte", "description": "Enviá 1 reporte de aglomeración en este festival" },
+      "t2": { "name": "Reportero Regular", "description": "Enviá 5 reportes de aglomeración en este festival" },
+      "t3": { "name": "Observador de Multitudes", "description": "Enviá 15 reportes de aglomeración en este festival" },
+      "t4": { "name": "Pilar de la Comunidad", "description": "Enviá 30 reportes de aglomeración en este festival" }
+    },
+    "profile_complete": {
+      "name": "Perfil Completo",
+      "description": "Configurá tu avatar, nombre de usuario y nombre completo"
+    },
+    "wrapped_viewed": {
+      "name": "Resumen del Año",
+      "description": "Mirá tu Resumen del Año"
+    },
     "complete": "Completar",
     "items": {
       "firstDrop": {

--- a/packages/shared/src/i18n/locales/es.json
+++ b/packages/shared/src/i18n/locales/es.json
@@ -800,6 +800,28 @@
       "name": "Festival Completo",
       "description": "Asistí todos los días del festival"
     },
+    "tents_visited": {
+      "t1": { "name": "Carpa Curiosa", "description": "Visitá 3 carpas diferentes" },
+      "t2": { "name": "Saltacarpas", "description": "Visitá 6 carpas diferentes" },
+      "t3": { "name": "Explorador de Carpas", "description": "Visitá 10 carpas diferentes" },
+      "t4": { "name": "Maestro de Carpas", "description": "Visitá 15 carpas diferentes" }
+    },
+    "festivals_attended": {
+      "t1": { "name": "Primer Festival", "description": "Asistí a tu primer festival" },
+      "t2": { "name": "Habitué de Festivales", "description": "Asistí a 3 festivales diferentes" },
+      "t3": { "name": "Veterano de Festivales", "description": "Asistí a 5 festivales diferentes" },
+      "t4": { "name": "Leyenda de Festivales", "description": "Asistí a 8 festivales diferentes" }
+    },
+    "festival_types": {
+      "t1": { "name": "Primer Estilo", "description": "Asistí a tu primer tipo de festival" },
+      "t2": { "name": "Ampliando Horizontes", "description": "Asistí a 2 tipos de festival diferentes" },
+      "t3": { "name": "Bien Viajado", "description": "Asistí a 3 tipos de festival diferentes" },
+      "t4": { "name": "Conocedor de Festivales", "description": "Asistí a 4 tipos de festival diferentes" }
+    },
+    "all_large_tents": {
+      "name": "Gran Recorrido",
+      "description": "Visitá todas las carpas grandes del festival"
+    },
     "complete": "Completar",
     "items": {
       "firstDrop": {

--- a/packages/shared/src/i18n/locales/es.json
+++ b/packages/shared/src/i18n/locales/es.json
@@ -867,16 +867,16 @@
       "t4": { "name": "Leyenda del Podio", "description": "Terminá entre los 3 primeros de un grupo 25 veces" }
     },
     "active_days": {
-      "t1": { "name": "Buen Comienzo", "description": "Estuviste activo 5 días diferentes" },
-      "t2": { "name": "Cara Conocida", "description": "Estuviste activo 25 días diferentes" },
-      "t3": { "name": "Veterano de Ley", "description": "Estuviste activo 75 días diferentes" },
-      "t4": { "name": "Pilar de la Casa", "description": "Estuviste activo 200 días diferentes" }
+      "t1": { "name": "Buen Comienzo", "description": "Registrá actividad en 5 días diferentes" },
+      "t2": { "name": "Cara Conocida", "description": "Registrá actividad en 25 días diferentes" },
+      "t3": { "name": "Veterano de Ley", "description": "Registrá actividad en 75 días diferentes" },
+      "t4": { "name": "Pilar de la Casa", "description": "Registrá actividad en 200 días diferentes" }
     },
     "active_day_streak": {
-      "t1": { "name": "Entrando en Calor", "description": "Estuviste activo 3 días seguidos" },
-      "t2": { "name": "En Llamas", "description": "Estuviste activo 7 días seguidos" },
-      "t3": { "name": "Hábito Formado", "description": "Estuviste activo 21 días seguidos" },
-      "t4": { "name": "Racha Imparable", "description": "Estuviste activo 60 días seguidos" }
+      "t1": { "name": "Entrando en Calor", "description": "Registrá actividad 3 días seguidos" },
+      "t2": { "name": "En Llamas", "description": "Registrá actividad 7 días seguidos" },
+      "t3": { "name": "Hábito Formado", "description": "Registrá actividad 21 días seguidos" },
+      "t4": { "name": "Racha Imparable", "description": "Registrá actividad 60 días seguidos" }
     },
     "crowd_reports": {
       "t1": { "name": "Primer Reporte", "description": "Enviá 1 reporte de aglomeración en este festival" },

--- a/packages/shared/src/i18n/locales/es.json
+++ b/packages/shared/src/i18n/locales/es.json
@@ -772,6 +772,34 @@
       "name": "Primera Gota",
       "description": "Registrá tu primera bebida de todas"
     },
+    "days_attended": {
+      "t1": { "name": "Presente", "description": "Asistí 1 día al festival" },
+      "t2": { "name": "Habitué", "description": "Asistí 3 días al festival" },
+      "t3": { "name": "Dedicado", "description": "Asistí 6 días al festival" },
+      "t4": { "name": "Fijo del Festival", "description": "Asistí 10 días al festival" }
+    },
+    "attendance_streak": {
+      "t1": { "name": "Dos Seguidos", "description": "Asistí 2 días seguidos" },
+      "t2": { "name": "En Racha", "description": "Asistí 3 días seguidos" },
+      "t3": { "name": "Maestro de Rachas", "description": "Asistí 5 días seguidos" },
+      "t4": { "name": "Cadena Inquebrantable", "description": "Asistí 7 días seguidos" }
+    },
+    "opening_day": {
+      "name": "Día de Apertura",
+      "description": "Asistí el día de apertura del festival"
+    },
+    "closing_day": {
+      "name": "Última Llamada",
+      "description": "Asistí el último día del festival"
+    },
+    "every_weekend_day": {
+      "name": "Guerrero de Fin de Semana",
+      "description": "Asistí todos los días de fin de semana del festival"
+    },
+    "full_festival": {
+      "name": "Festival Completo",
+      "description": "Asistí todos los días del festival"
+    },
     "complete": "Completar",
     "items": {
       "firstDrop": {

--- a/packages/shared/src/i18n/locales/es.json
+++ b/packages/shared/src/i18n/locales/es.json
@@ -822,6 +822,38 @@
       "name": "Gran Recorrido",
       "description": "Visitá todas las carpas grandes del festival"
     },
+    "groups_joined": {
+      "t1": { "name": "Sumado", "description": "Unite a 1 grupo en este festival" },
+      "t2": { "name": "Jugador de Equipo", "description": "Unite a 2 grupos en este festival" },
+      "t3": { "name": "Bien Conectado", "description": "Unite a 4 grupos en este festival" },
+      "t4": { "name": "Centro Social", "description": "Unite a 6 grupos en este festival" }
+    },
+    "friends_added": {
+      "t1": { "name": "Primer Amigo", "description": "Agregá tu primer amigo" },
+      "t2": { "name": "Círculo Creciente", "description": "Agregá 5 amigos" },
+      "t3": { "name": "Popular", "description": "Agregá 15 amigos" },
+      "t4": { "name": "Mariposa Social", "description": "Agregá 30 amigos" }
+    },
+    "photos_uploaded": {
+      "t1": { "name": "Decí Whisky", "description": "Subí 1 foto en este festival" },
+      "t2": { "name": "Entusiasta de Fotos", "description": "Subí 10 fotos en este festival" },
+      "t3": { "name": "Álbum de Fotos", "description": "Subí 25 fotos en este festival" },
+      "t4": { "name": "Guardián de Recuerdos", "description": "Subí 50 fotos en este festival" }
+    },
+    "reactions_given": {
+      "t1": { "name": "Mostrando Cariño", "description": "Reaccioná a 5 fotos en este festival" },
+      "t2": { "name": "Solidario", "description": "Reaccioná a 25 fotos en este festival" },
+      "t3": { "name": "Animador", "description": "Reaccioná a 75 fotos en este festival" },
+      "t4": { "name": "Máquina de Reacciones", "description": "Reaccioná a 150 fotos en este festival" }
+    },
+    "first_photo": {
+      "name": "Primera Foto",
+      "description": "Subí tu primerísima foto"
+    },
+    "created_group": {
+      "name": "Fundador de Grupo",
+      "description": "Creá un grupo"
+    },
     "complete": "Completar",
     "items": {
       "firstDrop": {

--- a/packages/shared/src/i18n/locales/es.json
+++ b/packages/shared/src/i18n/locales/es.json
@@ -854,6 +854,18 @@
       "name": "Fundador de Grupo",
       "description": "Creá un grupo"
     },
+    "group_wins": {
+      "t1": { "name": "Primera Victoria", "description": "Ganá el primer puesto en un grupo una vez" },
+      "t2": { "name": "Ganador en Serie", "description": "Ganá el primer puesto en un grupo 3 veces" },
+      "t3": { "name": "Campeón de Grupo", "description": "Ganá el primer puesto en un grupo 6 veces" },
+      "t4": { "name": "Dinastía", "description": "Ganá el primer puesto en un grupo 10 veces" }
+    },
+    "podium_finishes": {
+      "t1": { "name": "En el Podio", "description": "Terminá entre los 3 primeros de un grupo una vez" },
+      "t2": { "name": "Habitué del Podio", "description": "Terminá entre los 3 primeros de un grupo 5 veces" },
+      "t3": { "name": "Contendiente Constante", "description": "Terminá entre los 3 primeros de un grupo 12 veces" },
+      "t4": { "name": "Leyenda del Podio", "description": "Terminá entre los 3 primeros de un grupo 25 veces" }
+    },
     "complete": "Completar",
     "items": {
       "firstDrop": {

--- a/packages/shared/src/i18n/locales/es.json
+++ b/packages/shared/src/i18n/locales/es.json
@@ -732,6 +732,46 @@
       "gold": "Oro",
       "platinum": "Platino"
     },
+    "drinks_total": {
+      "t1": { "name": "Primera Ronda", "description": "Tomá 3 bebidas en este festival" },
+      "t2": { "name": "Bebedor Constante", "description": "Tomá 10 bebidas en este festival" },
+      "t3": { "name": "Maestro del Maß", "description": "Tomá 25 bebidas en este festival" },
+      "t4": { "name": "Sed Legendaria", "description": "Tomá 50 bebidas en este festival" }
+    },
+    "drinks_day_max": {
+      "t1": { "name": "Sesión Sólida", "description": "Tomá 3 cervezas en un solo día" },
+      "t2": { "name": "Gran Día", "description": "Tomá 5 cervezas en un solo día" },
+      "t3": { "name": "Peso Pesado", "description": "Tomá 8 cervezas en un solo día" },
+      "t4": { "name": "Imparable", "description": "Tomá 12 cervezas en un solo día" }
+    },
+    "drink_variety": {
+      "t1": { "name": "Degustador", "description": "Probá 2 tipos de bebida diferentes" },
+      "t2": { "name": "Explorador de Sabores", "description": "Probá 3 tipos de bebida diferentes" },
+      "t3": { "name": "Conocedor", "description": "Probá 4 tipos de bebida diferentes" },
+      "t4": { "name": "Carta Completa", "description": "Probá 5 tipos de bebida diferentes" }
+    },
+    "volume_total": {
+      "t1": { "name": "Primeros Litros", "description": "Tomá 5 litros en este festival" },
+      "t2": { "name": "Veinte Superados", "description": "Tomá 20 litros en este festival" },
+      "t3": { "name": "Medio Hectolitro", "description": "Tomá 50 litros en este festival" },
+      "t4": { "name": "Cien Litros", "description": "Tomá 100 litros en este festival" }
+    },
+    "tips_total": {
+      "t1": { "name": "Comienzo Generoso", "description": "Dejá un total de 5 € de propina en este festival" },
+      "t2": { "name": "Buen Propinador", "description": "Dejá un total de 20 € de propina en este festival" },
+      "t3": { "name": "Favorito del Público", "description": "Dejá un total de 50 € de propina en este festival" },
+      "t4": { "name": "Propinador Legendario", "description": "Dejá un total de 100 € de propina en este festival" }
+    },
+    "spend_total": {
+      "t1": { "name": "Billetera Abierta", "description": "Gastá 100 € en este festival" },
+      "t2": { "name": "Gran Gastador", "description": "Gastá 300 € en este festival" },
+      "t3": { "name": "Apostador Alto", "description": "Gastá 600 € en este festival" },
+      "t4": { "name": "Sin Límites", "description": "Gastá 1000 € en este festival" }
+    },
+    "first_drink": {
+      "name": "Primera Gota",
+      "description": "Registrá tu primera bebida de todas"
+    },
     "complete": "Completar",
     "items": {
       "firstDrop": {


### PR DESCRIPTION
## Summary
- Adds the missing i18n content for the new achievements engine: every achievement's `name`/`description` DB column stores a literal i18n key (e.g. `achievements.drinks_total.t1.name`), but no locale file had any of these keys, so the achievements page rendered raw keys in production
- Adds all 540 locale strings (90 slugs × name/description × en/de/es) plus tier and category labels
- Fixes the actual rendering bug: `AchievementCard.tsx` and mobile `achievement-card.tsx` each hardcoded a stale category lookup table keyed on a retired category set, causing the new `drinking`/`dedication` categories to silently fall through and render as raw text; replaced with direct i18n interpolation in both, plus a third call site (`achievements/page.tsx`'s filter dropdown) found during manual QA with the same bug
- Removes the forbidden `defaultValue` fallback from every achievement `t()` call across web and mobile (per repo convention)
- Adds a regression test (`locale-coverage.test.ts`) asserting every slug has non-empty copy in every locale — this is the safety net that would have caught the original bug

## Test plan
- [x] `pnpm test` — all packages green (api 321, shared 56, web 11)
- [x] `pnpm type-check` — clean, whole project
- [x] `pnpm lint` — clean, only pre-existing unrelated warnings
- [x] Manual verification on local dev server (Spanish + German): achievements page, category filter dropdown, drinking/dedication category cards specifically — no raw keys, no bare category slugs, correct umlauts/accents
- [x] Negative-checked the regression test actually fails when a slug's copy is removed
- [x] Independent whole-branch code review (Opus) — found and fixed a double-translation bug, two missed `defaultValue` calls, and a test assertion gap; verdict after fixes: clean

## Known follow-ups (not in this PR, pre-existing debt)
- `supabase/seed.sql` still seeds legacy achievement rows referencing dead `achievements.items.*` keys with retired categories — harmless in production (already migrated away), but will show raw category text on a fresh local `sup:db:reset`. Predates this branch; same "unrelated cleanup" bucket the design doc already flagged.
- Mobile's offline DB schema (`schema.ts` CHECK constraint / `enums.ts`) still only lists the old category set, so offline achievement sync silently fails to insert `drinking`/`dedication` rows. Pre-existing from the earlier engine migration, contained blast radius (mobile achievements screen reads the API directly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)