### PR TITLE
feat(achievements): category-colored tier badges with glyph fallback icons

### DIFF
--- a/apps/mobile/components/achievements/achievement-badge.tsx
+++ b/apps/mobile/components/achievements/achievement-badge.tsx
@@ -1,0 +1,138 @@
+import type { AchievementCategory, AchievementTier, GlyphId } from "@prostcounter/shared/achievements";
+import { GLYPH_FALLBACK_ICONS, getCategoryColor, TIER_RING_WIDTH } from "@prostcounter/shared/achievements";
+import {
+  Award,
+  Beaker,
+  Beer,
+  Camera,
+  CalendarCheck,
+  Compass,
+  Coins,
+  Crown,
+  Droplet,
+  FerrisWheel,
+  Flag,
+  Flame,
+  GlassWater,
+  Handshake,
+  Heart,
+  Hourglass,
+  IdCard,
+  Image as ImageIconLucide,
+  Link,
+  ScrollText,
+  Sun,
+  Sunrise,
+  Sunset,
+  Tent,
+  Trophy,
+  Users,
+  Wallet,
+} from "lucide-react-native";
+import { Image, View } from "react-native";
+import Svg, { Circle } from "react-native-svg";
+
+import { IconColors } from "@/lib/constants/colors";
+
+import { getGlyphImage } from "./glyph-images";
+
+const FALLBACK_ICON_COMPONENTS = {
+  Award,
+  Beaker,
+  Beer,
+  Camera,
+  CalendarCheck,
+  Compass,
+  Coins,
+  Crown,
+  Droplet,
+  FerrisWheel,
+  Flag,
+  Flame,
+  GlassWater,
+  Handshake,
+  Heart,
+  Hourglass,
+  IdCard,
+  Image: ImageIconLucide,
+  Link,
+  ScrollText,
+  Sun,
+  Sunrise,
+  Sunset,
+  Tent,
+  Trophy,
+  Users,
+  Wallet,
+} as const;
+
+const SIZE_PX: Record<"sm" | "md" | "lg", number> = {
+  sm: 32,
+  md: 40,
+  lg: 56,
+};
+
+interface AchievementBadgeProps {
+  glyph: GlyphId;
+  category: AchievementCategory;
+  tier: AchievementTier;
+  isUnlocked: boolean;
+  size?: "sm" | "md" | "lg";
+}
+
+export function AchievementBadge({
+  glyph,
+  category,
+  tier,
+  isUnlocked,
+  size = "md",
+}: AchievementBadgeProps) {
+  const diameter = SIZE_PX[size];
+  const strokeWidth = TIER_RING_WIDTH[tier];
+  const ringColor = getCategoryColor(category);
+  const glowsForTier = tier >= 3;
+  const imageSource = getGlyphImage(glyph);
+  const FallbackIcon =
+    FALLBACK_ICON_COMPONENTS[
+      GLYPH_FALLBACK_ICONS[glyph] as keyof typeof FALLBACK_ICON_COMPONENTS
+    ];
+
+  return (
+    <View
+      style={{
+        width: diameter,
+        height: diameter,
+        alignItems: "center",
+        justifyContent: "center",
+        opacity: isUnlocked ? 1 : 0.4,
+        shadowColor: glowsForTier ? ringColor : undefined,
+        shadowOpacity: glowsForTier ? 0.6 : 0,
+        shadowRadius: glowsForTier ? 6 : 0,
+        elevation: glowsForTier ? 6 : 0,
+      }}
+    >
+      <Svg width={diameter} height={diameter} style={{ position: "absolute" }}>
+        <Circle
+          cx={diameter / 2}
+          cy={diameter / 2}
+          r={(diameter - strokeWidth) / 2}
+          stroke={ringColor}
+          strokeWidth={strokeWidth}
+          fill="none"
+        />
+      </Svg>
+      {imageSource ? (
+        <Image
+          source={imageSource}
+          style={{ width: diameter * 0.6, height: diameter * 0.6 }}
+          resizeMode="contain"
+          alt=""
+        />
+      ) : (
+        <FallbackIcon size={diameter * 0.5} color={IconColors.primary} />
+      )}
+    </View>
+  );
+}
+
+AchievementBadge.displayName = "AchievementBadge";

--- a/apps/mobile/components/achievements/achievement-badge.tsx
+++ b/apps/mobile/components/achievements/achievement-badge.tsx
@@ -1,5 +1,6 @@
 import type { AchievementCategory, AchievementTier, GlyphId } from "@prostcounter/shared/achievements";
 import { GLYPH_FALLBACK_ICONS, getCategoryColor, TIER_RING_WIDTH } from "@prostcounter/shared/achievements";
+import { cn } from "@prostcounter/ui";
 import {
   Award,
   Beaker,
@@ -72,6 +73,12 @@ const SIZE_PX: Record<"sm" | "md" | "lg", number> = {
   lg: 56,
 };
 
+const SIZE_CLASSES: Record<"sm" | "md" | "lg", string> = {
+  sm: "w-8 h-8",
+  md: "w-10 h-10",
+  lg: "w-14 h-14",
+};
+
 interface AchievementBadgeProps {
   glyph: GlyphId;
   category: AchievementCategory;
@@ -95,16 +102,16 @@ export function AchievementBadge({
   const FallbackIcon =
     FALLBACK_ICON_COMPONENTS[
       GLYPH_FALLBACK_ICONS[glyph] as keyof typeof FALLBACK_ICON_COMPONENTS
-    ];
+    ] ?? Trophy;
 
   return (
     <View
+      className={cn(
+        "items-center justify-center",
+        SIZE_CLASSES[size],
+        isUnlocked ? "opacity-100" : "opacity-40",
+      )}
       style={{
-        width: diameter,
-        height: diameter,
-        alignItems: "center",
-        justifyContent: "center",
-        opacity: isUnlocked ? 1 : 0.4,
         shadowColor: glowsForTier ? ringColor : undefined,
         shadowOpacity: glowsForTier ? 0.6 : 0,
         shadowRadius: glowsForTier ? 6 : 0,

--- a/apps/mobile/components/achievements/achievement-card.tsx
+++ b/apps/mobile/components/achievements/achievement-card.tsx
@@ -1,3 +1,8 @@
+import type {
+  AchievementCategory,
+  AchievementTier,
+  GlyphId,
+} from "@prostcounter/shared/achievements";
 import { useTranslation } from "@prostcounter/shared/i18n";
 import type { AchievementRarity, AchievementWithProgress } from "@prostcounter/shared/schemas";
 import { formatLocalized } from "@prostcounter/shared/utils";
@@ -12,54 +17,8 @@ import { HStack } from "@/components/ui/hstack";
 import { Text } from "@/components/ui/text";
 import { VStack } from "@/components/ui/vstack";
 
+import { AchievementBadge } from "./achievement-badge";
 import { AchievementProgressBar } from "./achievement-progress-bar";
-
-// Icon mapping from achievement icon key to emoji
-export const ICON_MAP: Record<string, string> = {
-  // Consumption
-  first_beer: "🍺",
-  beer_mug: "🍺",
-  beer_bottle: "🍻",
-  beer_cheers: "🍻",
-  trophy: "🏆",
-  fire: "🔥",
-  lightning: "⚡",
-  // Attendance
-  wave: "👋",
-  calendar: "📅",
-  star: "⭐",
-  crown: "👑",
-  flame: "🔥",
-  weekend: "🎉",
-  sunrise: "🌅",
-  // Explorer
-  tent: "⛺",
-  map: "🗺️",
-  compass: "🧭",
-  guide: "🗺️",
-  master: "🎯",
-  // Social
-  handshake: "🤝",
-  butterfly: "🦋",
-  leader: "🚀",
-  medal: "🥇",
-  podium: "🏆",
-  camera: "📸",
-  photo_album: "📚",
-  // Competitive
-  competition: "🏁",
-  rising_star: "🌟",
-  legend: "👑",
-  multi_trophy: "🏆",
-  // Special
-  veteran: "🎖️",
-  multi_year: "🎖️",
-  money_bag: "💰",
-  consistency: "📊",
-  perfect: "💯",
-  first_day: "🎯",
-  closing: "🎊",
-};
 
 // Rarity styling configuration
 const RARITY_STYLES: Record<AchievementRarity, { bg: string; text: string; border: string }> = {
@@ -100,6 +59,7 @@ export function AchievementCard({ achievement, showProgress = true }: Achievemen
     description,
     category,
     rarity,
+    tier,
     points,
     icon,
     is_unlocked,
@@ -107,7 +67,6 @@ export function AchievementCard({ achievement, showProgress = true }: Achievemen
     user_progress,
   } = achievement;
 
-  const displayIcon = ICON_MAP[icon] || "🏆";
   const rarityStyle = RARITY_STYLES[rarity];
 
   // Translate name and description (real i18n keys from the achievements table)
@@ -136,14 +95,17 @@ export function AchievementCard({ achievement, showProgress = true }: Achievemen
         {/* Header: Icon + Name/Description + Rarity */}
         <HStack space="sm" className="items-start">
           {/* Icon */}
-          <View
-            className={cn(
-              "items-center justify-center rounded-lg p-2",
-              is_unlocked ? "bg-green-100" : "bg-gray-100",
-            )}
-          >
-            <Text className="text-2xl">{displayIcon}</Text>
-          </View>
+          {/* category/tier are DB-sourced (schema-typed as a wider legacy-inclusive category
+              set and a bare number); AchievementBadge's getCategoryColor/ring-width lookups
+              handle any value gracefully at runtime, so these are safe narrowing casts, same
+              rationale as the icon-as-GlyphId cast above. */}
+          <AchievementBadge
+            glyph={icon as GlyphId}
+            category={category as AchievementCategory}
+            tier={tier as AchievementTier}
+            isUnlocked={is_unlocked}
+            size="md"
+          />
 
           {/* Name and Description */}
           <VStack className="flex-1" space="xs">

--- a/apps/mobile/components/achievements/glyph-images.ts
+++ b/apps/mobile/components/achievements/glyph-images.ts
@@ -1,0 +1,19 @@
+import type { GlyphId } from "@prostcounter/shared/achievements";
+import type { ImageSourcePropType } from "react-native";
+
+/**
+ * Static require() registry of generated glyph images. React Native's
+ * bundler needs static require() calls to include an asset in the bundle
+ * — a dynamic require(`...${id}...`) will not work. Add one line here
+ * per PNG you drop into apps/mobile/assets/achievements/glyphs/. Ids not
+ * present here fall back to a lucide icon (see achievement-badge.tsx).
+ *
+ * Starts empty: no glyph art exists yet.
+ */
+export const GLYPH_IMAGES: Partial<Record<GlyphId, ImageSourcePropType>> = {
+  // masskrug: require("@/assets/achievements/glyphs/masskrug.png"),
+};
+
+export function getGlyphImage(glyphId: GlyphId): ImageSourcePropType | undefined {
+  return GLYPH_IMAGES[glyphId];
+}

--- a/apps/mobile/components/wrapped/slides/achievements-slide.tsx
+++ b/apps/mobile/components/wrapped/slides/achievements-slide.tsx
@@ -1,4 +1,5 @@
 import { Motion } from "@legendapp/motion";
+import type { GlyphId } from "@prostcounter/shared/achievements";
 import { useTranslation } from "@prostcounter/shared/i18n";
 import type { WrappedData } from "@prostcounter/shared/wrapped";
 import {
@@ -9,7 +10,7 @@ import {
 import { useMemo } from "react";
 import { View } from "react-native";
 
-import { ICON_MAP } from "@/components/achievements/achievement-card";
+import { AchievementBadge } from "@/components/achievements/achievement-badge";
 import { HStack } from "@/components/ui/hstack";
 import { Text } from "@/components/ui/text";
 import { VStack } from "@/components/ui/vstack";
@@ -62,7 +63,13 @@ export function AchievementsSlide({ data, isActive }: AchievementsSlideProps) {
               className="flex-row items-center rounded-xl bg-white/70 px-4 py-3"
             >
               <View style={{ width: 36, alignItems: "center" }}>
-                <Text className="text-2xl">{ICON_MAP[achievement.icon] || "🏆"}</Text>
+                <AchievementBadge
+                  glyph={achievement.icon as GlyphId}
+                  category={achievement.category}
+                  tier={achievement.tier as 1 | 2 | 3 | 4}
+                  isUnlocked
+                  size="sm"
+                />
               </View>
               <VStack space="xs" className="ml-2 flex-1">
                 <Text className="text-sm font-semibold text-gray-800">

--- a/apps/mobile/components/wrapped/slides/achievements-slide.tsx
+++ b/apps/mobile/components/wrapped/slides/achievements-slide.tsx
@@ -1,5 +1,5 @@
 import { Motion } from "@legendapp/motion";
-import type { GlyphId } from "@prostcounter/shared/achievements";
+import type { AchievementCategory, GlyphId } from "@prostcounter/shared/achievements";
 import { useTranslation } from "@prostcounter/shared/i18n";
 import type { WrappedData } from "@prostcounter/shared/wrapped";
 import {
@@ -62,10 +62,10 @@ export function AchievementsSlide({ data, isActive }: AchievementsSlideProps) {
               }}
               className="flex-row items-center rounded-xl bg-white/70 px-4 py-3"
             >
-              <View style={{ width: 36, alignItems: "center" }}>
+              <View className="w-9 items-center">
                 <AchievementBadge
                   glyph={achievement.icon as GlyphId}
-                  category={achievement.category}
+                  category={achievement.category as AchievementCategory}
                   tier={achievement.tier as 1 | 2 | 3 | 4}
                   isUnlocked
                   size="sm"

--- a/apps/mobile/lib/__tests__/achievements/glyph-images.test.ts
+++ b/apps/mobile/lib/__tests__/achievements/glyph-images.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+
+import { GLYPH_IMAGES, getGlyphImage } from "@/components/achievements/glyph-images";
+
+describe("getGlyphImage", () => {
+  it("returns undefined for a glyph id with no registered image (registry starts empty)", () => {
+    expect(getGlyphImage("masskrug")).toBeUndefined();
+  });
+
+  it("returns the registered source for a glyph id present in GLYPH_IMAGES", () => {
+    const fakeSource = { uri: "fake" };
+    (GLYPH_IMAGES as Record<string, unknown>).masskrug = fakeSource;
+    expect(getGlyphImage("masskrug")).toBe(fakeSource);
+    delete (GLYPH_IMAGES as Record<string, unknown>).masskrug;
+  });
+});

--- a/apps/web/components/achievements/AchievementBadge.tsx
+++ b/apps/web/components/achievements/AchievementBadge.tsx
@@ -41,7 +41,8 @@ export function AchievementBadge({
   className,
 }: AchievementBadgeProps) {
   const { t } = useTranslation();
-  const [imageFailed, setImageFailed] = useState(false);
+  const [failedIcon, setFailedIcon] = useState<string | null>(null);
+  const imageFailed = failedIcon === icon;
 
   const translatedName = t(name);
   const diameter = SIZE_PX[size];
@@ -69,7 +70,7 @@ export function AchievementBadge({
             alt=""
             width={diameter * 0.6}
             height={diameter * 0.6}
-            onError={() => setImageFailed(true)}
+            onError={() => setFailedIcon(icon)}
           />
         ) : (
           <GlyphIcon glyph={icon as GlyphId} sizePx={diameter * 0.5} />

--- a/apps/web/components/achievements/AchievementBadge.tsx
+++ b/apps/web/components/achievements/AchievementBadge.tsx
@@ -1,91 +1,20 @@
 "use client";
 
-import { Badge } from "@/components/ui/badge";
+import type { AchievementCategory, AchievementTier, GlyphId } from "@prostcounter/shared/achievements";
+import { getCategoryColor, TIER_RING_WIDTH } from "@prostcounter/shared/achievements";
+import { useState } from "react";
+
 import { useTranslation } from "@/lib/i18n/client";
 import type { AchievementRarity } from "@/lib/types/achievements";
 import { cn } from "@/lib/utils";
 
-const rarityConfig = {
-  common: {
-    bgColor: "bg-gray-100 hover:bg-gray-200",
-    textColor: "text-gray-800",
-    borderColor: "border-gray-300",
-    variant: "outline" as const,
-  },
-  rare: {
-    bgColor: "bg-blue-100 hover:bg-blue-200",
-    textColor: "text-blue-800",
-    borderColor: "border-blue-300",
-    variant: "secondary" as const,
-  },
-  epic: {
-    bgColor: "bg-purple-100 hover:bg-purple-200",
-    textColor: "text-purple-800",
-    borderColor: "border-purple-300",
-    variant: "default" as const,
-  },
-  legendary: {
-    bgColor: "bg-yellow-100 hover:bg-yellow-200",
-    textColor: "text-yellow-800",
-    borderColor: "border-yellow-300",
-    variant: "default" as const,
-  },
-} as const;
-
-const iconMap = {
-  // Consumption
-  first_beer: "🍺",
-  beer_mug: "🍺",
-  beer_bottle: "🍻",
-  beer_cheers: "🍻",
-  trophy: "🏆",
-  fire: "🔥",
-  lightning: "⚡",
-
-  // Attendance
-  wave: "👋",
-  calendar: "📅",
-  star: "⭐",
-  crown: "👑",
-  flame: "🔥",
-  weekend: "🎉",
-  sunrise: "🌅",
-
-  // Explorer
-  tent: "⛺",
-  map: "🗺️",
-  compass: "🧭",
-  guide: "🗺️",
-  master: "🎯",
-
-  // Social
-  handshake: "🤝",
-  butterfly: "🦋",
-  leader: "🚀",
-  medal: "🥇",
-  podium: "🏆",
-  camera: "📸",
-  photo_album: "📚",
-
-  // Competitive
-  competition: "🏁",
-  rising_star: "🌟",
-  legend: "👑",
-  multi_trophy: "🏆",
-
-  // Special
-  veteran: "🎖️",
-  multi_year: "🎖️",
-  money_bag: "💰",
-  consistency: "📊",
-  perfect: "💯",
-  first_day: "🎯",
-  closing: "🎊",
-} as const;
+import { GlyphIcon } from "./GlyphIcon";
 
 interface AchievementBadgeProps {
   name: string;
   icon: string;
+  category?: AchievementCategory;
+  tier?: AchievementTier;
   rarity: AchievementRarity;
   points: number;
   isUnlocked: boolean;
@@ -94,10 +23,17 @@ interface AchievementBadgeProps {
   className?: string;
 }
 
+const SIZE_PX: Record<"sm" | "md" | "lg", number> = {
+  sm: 32,
+  md: 40,
+  lg: 56,
+};
+
 export function AchievementBadge({
   name,
   icon,
-  rarity,
+  category,
+  tier,
   points,
   isUnlocked,
   size = "md",
@@ -105,39 +41,46 @@ export function AchievementBadge({
   className,
 }: AchievementBadgeProps) {
   const { t } = useTranslation();
-  const config = rarityConfig[rarity];
-  const displayIcon = iconMap[icon as keyof typeof iconMap] || "🏆";
+  const [imageFailed, setImageFailed] = useState(false);
 
-  // Achievement name is stored as an i18n key, so translate it
   const translatedName = t(name);
-
-  const sizeStyles = {
-    sm: "text-xs px-1.5 py-0.5",
-    md: "text-sm px-2 py-1",
-    lg: "text-base px-3 py-2",
-  };
+  const diameter = SIZE_PX[size];
+  const strokeWidth = tier !== undefined ? TIER_RING_WIDTH[tier] : TIER_RING_WIDTH[1];
+  const ringColor = category !== undefined ? getCategoryColor(category) : getCategoryColor("");
+  const glowsForTier = tier !== undefined && tier >= 3;
+  const imagePath = `/achievements/glyphs/${icon}.png`;
 
   return (
-    <Badge
-      variant={config.variant}
-      className={cn(
-        "inline-flex items-center gap-1.5 font-medium transition-colors",
-        sizeStyles[size],
-        isUnlocked
-          ? `${config.bgColor} ${config.textColor} ${config.borderColor}`
-          : "border-gray-200 bg-gray-50 text-gray-400 opacity-60",
-        className,
-      )}
-    >
-      <span className={cn("text-base", size === "sm" && "text-sm")}>{displayIcon}</span>
+    <span className={cn("inline-flex items-center gap-1.5", className)}>
+      <span
+        className="relative inline-flex shrink-0 items-center justify-center rounded-full"
+        style={{
+          width: diameter,
+          height: diameter,
+          border: `${strokeWidth}px solid ${ringColor}`,
+          opacity: isUnlocked ? 1 : 0.4,
+          boxShadow: glowsForTier ? `0 0 8px ${ringColor}` : undefined,
+        }}
+      >
+        {!imageFailed ? (
+          // eslint-disable-next-line nextjs/no-img-element -- dynamic, possibly-missing static asset; next/image requires a known-good src
+          <img
+            src={imagePath}
+            alt=""
+            width={diameter * 0.6}
+            height={diameter * 0.6}
+            onError={() => setImageFailed(true)}
+          />
+        ) : (
+          <GlyphIcon glyph={icon as GlyphId} sizePx={diameter * 0.5} />
+        )}
+      </span>
 
-      <span className="truncate">{translatedName}</span>
+      {name !== "" && <span className="truncate text-sm">{translatedName}</span>}
 
       {showPoints && (
-        <span className={cn("ml-1 text-xs font-normal opacity-75", size === "sm" && "text-xs")}>
-          {points}pts
-        </span>
+        <span className="ml-1 text-xs font-normal opacity-75">{points}pts</span>
       )}
-    </Badge>
+    </span>
   );
 }

--- a/apps/web/components/achievements/AchievementCard.tsx
+++ b/apps/web/components/achievements/AchievementCard.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { AchievementCategory, AchievementTier } from "@prostcounter/shared/achievements";
 import type { AchievementWithProgress } from "@prostcounter/shared/schemas";
 
 import { Badge } from "@/components/ui/badge";
@@ -27,6 +28,7 @@ export function AchievementCard({
     description,
     category,
     rarity,
+    tier,
     points,
     icon,
     is_unlocked,
@@ -68,6 +70,8 @@ export function AchievementCard({
             <AchievementBadge
               name=""
               icon={icon}
+              category={category as AchievementCategory}
+              tier={tier as AchievementTier}
               rarity={rarity}
               points={points}
               isUnlocked={is_unlocked}

--- a/apps/web/components/achievements/AchievementHighlight.tsx
+++ b/apps/web/components/achievements/AchievementHighlight.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { AchievementCategory, AchievementTier } from "@prostcounter/shared/achievements";
 import { useFestival } from "@prostcounter/shared/contexts";
 import type { AchievementWithProgress } from "@prostcounter/shared/schemas";
 import { Link } from "next-view-transitions";
@@ -80,6 +81,8 @@ export function AchievementHighlight({ className }: AchievementHighlightProps) {
                     <AchievementBadge
                       name={achievement.name}
                       icon={achievement.icon}
+                      category={achievement.category as AchievementCategory}
+                      tier={achievement.tier as AchievementTier}
                       rarity={achievement.rarity}
                       points={achievement.points}
                       isUnlocked={true}

--- a/apps/web/components/achievements/GlyphIcon.tsx
+++ b/apps/web/components/achievements/GlyphIcon.tsx
@@ -71,6 +71,6 @@ export function GlyphIcon({ glyph, sizePx }: GlyphIconProps) {
   const FallbackIcon =
     FALLBACK_ICON_COMPONENTS[
       GLYPH_FALLBACK_ICONS[glyph] as keyof typeof FALLBACK_ICON_COMPONENTS
-    ];
+    ] ?? Trophy;
   return <FallbackIcon size={sizePx} />;
 }

--- a/apps/web/components/achievements/GlyphIcon.tsx
+++ b/apps/web/components/achievements/GlyphIcon.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import type { GlyphId } from "@prostcounter/shared/achievements";
+import { GLYPH_FALLBACK_ICONS } from "@prostcounter/shared/achievements";
+import {
+  Award,
+  Beaker,
+  Beer,
+  Camera,
+  CalendarCheck,
+  Compass,
+  Coins,
+  Crown,
+  Droplet,
+  FerrisWheel,
+  Flag,
+  Flame,
+  GlassWater,
+  Handshake,
+  Heart,
+  Hourglass,
+  IdCard,
+  Image as ImageIconLucide,
+  Link,
+  ScrollText,
+  Sun,
+  Sunrise,
+  Sunset,
+  Tent,
+  Trophy,
+  Users,
+  Wallet,
+} from "lucide-react";
+
+const FALLBACK_ICON_COMPONENTS = {
+  Award,
+  Beaker,
+  Beer,
+  Camera,
+  CalendarCheck,
+  Compass,
+  Coins,
+  Crown,
+  Droplet,
+  FerrisWheel,
+  Flag,
+  Flame,
+  GlassWater,
+  Handshake,
+  Heart,
+  Hourglass,
+  IdCard,
+  Image: ImageIconLucide,
+  Link,
+  ScrollText,
+  Sun,
+  Sunrise,
+  Sunset,
+  Tent,
+  Trophy,
+  Users,
+  Wallet,
+} as const;
+
+interface GlyphIconProps {
+  glyph: GlyphId;
+  sizePx: number;
+}
+
+export function GlyphIcon({ glyph, sizePx }: GlyphIconProps) {
+  const FallbackIcon =
+    FALLBACK_ICON_COMPONENTS[
+      GLYPH_FALLBACK_ICONS[glyph] as keyof typeof FALLBACK_ICON_COMPONENTS
+    ];
+  return <FallbackIcon size={sizePx} />;
+}

--- a/apps/web/components/wrapped/slides/AchievementsSlide.tsx
+++ b/apps/web/components/wrapped/slides/AchievementsSlide.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { AchievementCategory } from "@prostcounter/shared/achievements";
 import { useTranslation } from "@prostcounter/shared/i18n";
 import type { WrappedData } from "@prostcounter/shared/wrapped";
 import { calculateTotalPoints, sortAchievements } from "@prostcounter/shared/wrapped";
@@ -56,7 +57,7 @@ export function AchievementsSlide({ data, isActive = false }: AchievementsSlideP
               <AchievementBadge
                 name={achievement.name}
                 icon={achievement.icon}
-                category={achievement.category}
+                category={achievement.category as AchievementCategory}
                 tier={achievement.tier as 1 | 2 | 3 | 4}
                 rarity={achievement.rarity as AchievementRarity}
                 points={achievement.points}

--- a/apps/web/components/wrapped/slides/AchievementsSlide.tsx
+++ b/apps/web/components/wrapped/slides/AchievementsSlide.tsx
@@ -56,6 +56,8 @@ export function AchievementsSlide({ data, isActive = false }: AchievementsSlideP
               <AchievementBadge
                 name={achievement.name}
                 icon={achievement.icon}
+                category={achievement.category}
+                tier={achievement.tier as 1 | 2 | 3 | 4}
                 rarity={achievement.rarity as AchievementRarity}
                 points={achievement.points}
                 isUnlocked={true}

--- a/docs/design/achievement-glyph-brief.md
+++ b/docs/design/achievement-glyph-brief.md
@@ -1,0 +1,291 @@
+# Achievement Glyph Art Brief
+
+This document is source material for generating the 30 achievement glyph images by
+hand, one at a time, in an external AI image-generation tool. It is not consumed by
+any code or build step. Paste the shared style/context section (or a condensed form
+of it) alongside each individual glyph prompt when generating that glyph, since each
+generation is a separate, independent request with no memory of the others.
+
+The 30 glyph ids below are exactly `GLYPH_IDS` from
+`packages/shared/src/achievements/glyphs.ts`. Each is currently rendered as a
+placeholder `lucide` icon (see `GLYPH_FALLBACK_ICONS` in the same file); the images
+generated from this brief are meant to replace those placeholders one file at a time,
+with no code changes required beyond swapping the asset.
+
+## Shared style & context
+
+Apply this to every glyph, regardless of category:
+
+- **Canvas**: 48×48, with all artwork kept inside a 40×40 safe area (4px margin on
+  every side).
+- **Grid**: build on a 24px construction grid scaled 2× to the 48×48 canvas, so major
+  shape edges land on whole-pixel boundaries.
+- **Style**: solid-fill silhouette. No outlines, no interior linework, no shading or
+  gradients used to imply depth or texture — the recognizable shape is the entire
+  drawing. Must stay legible as a shape at 32px, since that's the render size used in
+  the achievement grid and the unlock toast.
+- **Colour**: this plan renders full-color raster art rather than the flat monochrome
+  vector paths the original master spec called for, so the strict "single-path
+  monochrome, no fill colour" rule from that spec does **not** apply here. In its
+  place: keep a clear, uncluttered silhouette that reads at 32px, exactly one clear
+  subject per glyph, no background scene or environment behind the subject, and a
+  style consistent across all 30 (same rendering treatment, same level of detail,
+  same implied light/material handling) so the full set reads as one family rather
+  than 30 unrelated pieces.
+- **Framing**: each glyph sits inside a category-coloured ring in the finished badge
+  (handled by existing code, not part of this brief) — so the glyph art itself should
+  be self-contained and centered, without its own border, background plate, or frame.
+- **Subject count**: one clear subject per glyph. Where a glyph description mentions
+  multiple small elements (three glasses, three figures, four tents), those elements
+  together form a single readable composition, not a scene.
+
+## Per-glyph prompts
+
+Prompts are grouped and ordered exactly as `GLYPH_IDS`, which mirrors the category
+grouping in `packages/shared/src/achievements/definitions.ts` (the 20 tiered series
+first, by category, then the 10 one-off achievements, by category). The italic line
+under each heading names the achievement(s) that glyph illustrates, for traceability
+back to `definitions.ts` and the `achievements.<slug>.*` copy in
+`packages/shared/src/i18n/locales/en.json` — it is not part of the prompt itself.
+
+### Drinking
+
+#### masskrug
+
+*Series: `drinks_total` — total drinks logged this festival (First Round → Legendary Thirst).*
+
+masskrug is a one-litre stein with a hinged lid seen three-quarter on, its handle
+facing right and a slight forward tilt as if it's mid-raise for a toast.
+
+#### sunburst-stein
+
+*Series: `drinks_day_max` — most drinks logged in a single day (Solid Session → Unstoppable).*
+
+sunburst-stein is a shorter, wider dimpled beer mug viewed straight-on, with short
+triangular rays fanning out symmetrically behind its rim like a single day's session
+caught in one bright burst.
+
+#### three-glasses
+
+*Series: `drink_variety` — number of distinct drink types tried (Sampler → Full Menu).*
+
+three-glasses is a lineup of three differently shaped drinking vessels — a tall
+pilsner glass, a squat dimpled stein, and a stemmed glass — standing shoulder to
+shoulder at slightly staggered heights.
+
+#### measuring-jug
+
+*Series: `volume_total` — total litres consumed this festival (First Litres → Century Litres).*
+
+measuring-jug is a glass pitcher with a pouring spout at the upper left and three
+short horizontal gradation marks etched across its belly, reading as a vessel for
+measuring volume rather than one for drinking directly from.
+
+#### coin-hand
+
+*Series: `tips_total` — total tip amount given this festival (Generous Start → Legendary Tipper).*
+
+coin-hand is an open palm seen from above with a single large coin balanced just
+above it mid-drop, a thin crescent highlight along the coin's upper edge.
+
+#### purse
+
+*Series: `spend_total` — total money spent this festival (Opening the Wallet → No Limits).*
+
+purse is a round drawstring pouch cinched tight at the neck, the two drawstring ends
+splaying outward and the body bulging slightly to read as full rather than empty.
+
+### Attendance
+
+#### calendar-check
+
+*Series: `days_attended` — number of distinct festival days attended (Showed Up → Festival Fixture).*
+
+calendar-check is a single calendar page with a spiral-bound top edge and a bold
+checkmark stamped diagonally across its date grid, corner to corner.
+
+#### chain-links
+
+*Series: `attendance_streak` — longest run of consecutive days attended (Two in a Row → Unbroken Chain).*
+
+chain-links is three oval links interlocked in a straight horizontal row, the center
+link drawn slightly larger than its neighbours to lead the eye along the sequence.
+
+### Explorer
+
+#### tent-peaks
+
+*Series: `tents_visited` — number of distinct tents visited this festival (Tent Curious → Tent Master).*
+
+tent-peaks is two overlapping tent-triangle peaks with a small dotted arc arcing
+between their tips, tracing a path from one tent over to the next.
+
+#### ferris-wheel
+
+*Series: `festivals_attended` — number of distinct festivals attended, lifetime (First Festival → Festival Legend).*
+
+ferris-wheel is a spoked wheel silhouette on a single support strut, with four small
+cabin shapes hanging off the rim at the top, bottom, left, and right like stops on a
+repeating circuit.
+
+#### compass-rose
+
+*Series: `festival_types` — number of distinct festival types attended, lifetime (First Style → Festival Connoisseur).*
+
+compass-rose is a four-pointed star compass with its north point drawn long and
+narrow and the other three points shortened, evoking a traveller orienting toward
+new, unvisited ground.
+
+### Social
+
+#### three-figures
+
+*Series: `groups_joined` — number of groups joined this festival (Joined Up → Social Hub).*
+
+three-figures is three simplified standing human silhouettes side by side, the outer
+two angled slightly inward toward the center one so the trio reads as a huddle
+rather than a queue.
+
+#### clasped-hands
+
+*Series: `friends_added` — number of friends added, lifetime (First Friend → Social Butterfly).*
+
+clasped-hands is two forearms entering from the lower-left and lower-right corners,
+meeting and gripping at the center in a single overlapping handshake.
+
+#### camera-shutter
+
+*Series: `photos_uploaded` — number of photos uploaded this festival (Say Cheese → Memory Keeper).*
+
+camera-shutter is a circular iris built from six overlapping curved blades
+converging toward a small open aperture at the center, caught mid-click.
+
+#### spark-heart
+
+*Series: `reactions_given` — number of reactions given to others' photos this festival (Showing Love → Reaction Machine).*
+
+spark-heart is a rounded heart shape with three short spark lines radiating from its
+upper-right lobe, as though it just lit up in response to something.
+
+### Competitive
+
+#### laurel-cup
+
+*Series: `group_wins` — number of first-place group finishes, lifetime (First Win → Dynasty).*
+
+laurel-cup is a two-handled trophy cup on a short stem, with a laurel branch curving
+up and inward along each handle to nearly meet above the rim.
+
+#### podium-steps
+
+*Series: `podium_finishes` — number of top-three group finishes, lifetime (On the Podium → Podium Legend).*
+
+podium-steps is a three-block winner's podium seen from the front, stepping up left
+to right with the tallest block on the right and a small five-point star hovering
+just above it.
+
+### Dedication
+
+#### hourglass
+
+*Series: `active_days` — number of distinct days active in the app, lifetime (Getting Started → Lifer).*
+
+hourglass is a classic pinched hourglass silhouette with sand piled thick in the
+bottom bulb and only a thin remaining layer at the top, reading as accumulated time
+rather than time running out.
+
+#### flame-steady
+
+*Series: `active_day_streak` — longest run of consecutive active days, lifetime (Warming Up → Unstoppable Streak).*
+
+flame-steady is a single upright teardrop flame with a straight, unwavering left
+edge and only a gentle flicker curling off the right side, reading as sustained
+rather than guttering.
+
+#### signal-flag
+
+*Series: `crowd_reports` — number of crowd reports submitted this festival (First Report → Community Pillar).*
+
+signal-flag is a triangular pennant on a short vertical pole, its trailing edge cut
+with a sharp inward notch so it reads as snapping mid-signal rather than hanging
+limp.
+
+### One-off achievements
+
+#### first-drop
+
+*One-off: `first_drink` — "First Drop", logging your very first drink ever.*
+
+first-drop is a single teardrop-shaped liquid drop frozen mid-fall, with a small
+crescent highlight near its top and nothing else in frame, isolated to mark a single
+first instance.
+
+#### sunrise-gate
+
+*One-off: `opening_day` — "Opening Day", attending the festival's opening day.*
+
+sunrise-gate is a simple arched festival entrance gate with a rising half-sun
+directly behind its peak, short rays fanning upward from a low horizon line at the
+gate's base.
+
+#### sunset-gate
+
+*One-off: `closing_day` — "Last Call", attending the festival's closing day.*
+
+sunset-gate reuses the same arched gate silhouette as sunrise-gate, but the sun now
+sits low and sinking behind it — only its upper arc shows above the horizon, and the
+rays angle downward instead of up — so the two glyphs read as a clear pair at
+opposite ends of the day.
+
+#### double-sun
+
+*One-off: `every_weekend_day` — "Weekend Warrior", attending every weekend day of the festival.*
+
+double-sun is two identical sun discs, each with short radiating rays, overlapping
+side by side like two consecutive days sharing one sky.
+
+#### wiesn-crown
+
+*One-off: `full_festival` — "Full Festival", attending every single day of the festival.*
+
+wiesn-crown is a Bavarian crown with a pretzel where the central cross would be, its
+peaks alternating tall and short around the band.
+
+#### tent-ring
+
+*One-off: `all_large_tents` — "Grand Tour", visiting every large tent at the festival.*
+
+tent-ring is four small tent-peak triangles arranged evenly around an implied
+circle, each base angled inward so together they enclose a shared center point.
+
+#### polaroid
+
+*One-off: `first_photo` — "First Snap", uploading your very first photo ever.*
+
+polaroid is a square instant-photo frame with a thick white border along the bottom
+edge and a small rounded nick cut into its top-right corner, the picture area left
+blank.
+
+#### banner-pole
+
+*One-off: `created_group` — "Group Founder", creating a group.*
+
+banner-pole is a tall, slightly tapered vertical pole with a rectangular flag
+jutting from its upper right, the flag's outer edge cut in a swallowtail notch as if
+just run up and still catching the wind.
+
+#### id-card
+
+*One-off: `profile_complete` — "Profile Complete", setting an avatar, username, and full name.*
+
+id-card is a rounded-rectangle card in portrait orientation with a small circular
+portrait cutout in the upper-left corner and two short horizontal bars beside it
+standing in for a name and a detail line.
+
+#### ribbon-scroll
+
+*One-off: `wrapped_viewed` — "Year in Review", viewing your Wrapped summary.*
+
+ribbon-scroll is a horizontal parchment scroll with both ends rolled inward toward
+the center, a diagonal ribbon seal draped across its middle as if the year it
+records has just been closed and sealed.

--- a/packages/api/src/routes/achievement.route.ts
+++ b/packages/api/src/routes/achievement.route.ts
@@ -283,6 +283,7 @@ app.openapi(getAchievementsWithProgressRoute, async (c) => {
       icon: row.icon,
       points: row.points,
       rarity: tierToRarity(row.tier),
+      tier: row.tier ?? 1,
       conditions: {},
       is_active: true,
       created_at: "",

--- a/packages/shared/src/achievements/badge-tokens.test.ts
+++ b/packages/shared/src/achievements/badge-tokens.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+
+import { CATEGORY_COLORS, getCategoryColor, TIER_RING_WIDTH } from "./badge-tokens";
+import type { AchievementCategory, AchievementTier } from "./types";
+
+const CATEGORIES: AchievementCategory[] = [
+  "drinking",
+  "attendance",
+  "explorer",
+  "social",
+  "competitive",
+  "dedication",
+];
+
+const TIERS: AchievementTier[] = [1, 2, 3, 4];
+
+describe("badge tokens", () => {
+  it("has a color for every current category", () => {
+    for (const category of CATEGORIES) {
+      expect(CATEGORY_COLORS[category]).toMatch(/^#[0-9A-Fa-f]{6}$/);
+    }
+  });
+
+  it("getCategoryColor returns the mapped color for current categories", () => {
+    expect(getCategoryColor("drinking")).toBe(CATEGORY_COLORS.drinking);
+  });
+
+  it("getCategoryColor falls back to gray for unrecognized/legacy categories", () => {
+    expect(getCategoryColor("consumption")).toBe("#9CA3AF");
+    expect(getCategoryColor("special")).toBe("#9CA3AF");
+    expect(getCategoryColor("not-a-real-category")).toBe("#9CA3AF");
+  });
+
+  it("has a ring width for every tier, strictly increasing", () => {
+    let previous = 0;
+    for (const tier of TIERS) {
+      expect(TIER_RING_WIDTH[tier]).toBeGreaterThan(previous);
+      previous = TIER_RING_WIDTH[tier];
+    }
+  });
+});

--- a/packages/shared/src/achievements/badge-tokens.ts
+++ b/packages/shared/src/achievements/badge-tokens.ts
@@ -1,0 +1,39 @@
+import type { AchievementCategory, AchievementTier } from "./types";
+
+/**
+ * Ring color per category, shown behind/around the achievement's glyph.
+ * Same plain-hex-map pattern as RARITY_COLORS in wrapped/config.ts.
+ */
+export const CATEGORY_COLORS: Record<AchievementCategory, string> = {
+  drinking: "#F97316",
+  attendance: "#10B981",
+  explorer: "#8B5CF6",
+  social: "#EC4899",
+  competitive: "#EF4444",
+  dedication: "#6366F1",
+};
+
+const FALLBACK_CATEGORY_COLOR = "#9CA3AF";
+
+/**
+ * Safe accessor for CATEGORY_COLORS. `AchievementWithProgress.category` is
+ * typed against the schema's 8-value enum (6 current categories plus
+ * legacy `consumption`/`special`, kept for old rows — see Plan 3a's
+ * design doc). This returns a neutral gray for anything not in the
+ * 6-entry map instead of a type error or crash.
+ */
+export function getCategoryColor(category: string): string {
+  return CATEGORY_COLORS[category as AchievementCategory] ?? FALLBACK_CATEGORY_COLOR;
+}
+
+/**
+ * Ring stroke width in px per tier (1=bronze .. 4=platinum). The only
+ * portable part of tier styling — glow is implemented natively per
+ * platform (see AchievementBadge components), not shared as data.
+ */
+export const TIER_RING_WIDTH: Record<AchievementTier, number> = {
+  1: 2,
+  2: 3,
+  3: 4,
+  4: 5,
+};

--- a/packages/shared/src/achievements/glyphs.test.ts
+++ b/packages/shared/src/achievements/glyphs.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+
+import { ALL_DEFINITIONS } from "./definitions";
+import { GLYPH_FALLBACK_ICONS, GLYPH_IDS } from "./glyphs";
+
+describe("glyph registry", () => {
+  it("GLYPH_IDS matches every distinct glyph used in definitions.ts", () => {
+    const usedGlyphs = new Set(ALL_DEFINITIONS.map((def) => def.glyph));
+    expect(new Set(GLYPH_IDS)).toEqual(usedGlyphs);
+  });
+
+  it("every glyph id has a fallback icon name", () => {
+    for (const id of GLYPH_IDS) {
+      expect(typeof GLYPH_FALLBACK_ICONS[id]).toBe("string");
+      expect(GLYPH_FALLBACK_ICONS[id]).not.toBe("");
+    }
+  });
+
+  it("GLYPH_FALLBACK_ICONS has no entries for unknown glyph ids", () => {
+    expect(Object.keys(GLYPH_FALLBACK_ICONS).sort()).toEqual([...GLYPH_IDS].sort());
+  });
+});

--- a/packages/shared/src/achievements/glyphs.ts
+++ b/packages/shared/src/achievements/glyphs.ts
@@ -1,0 +1,78 @@
+// The 30 distinct glyph ids used across all achievement definitions
+// (20 series + 10 one-offs). Verify against ALL_DEFINITIONS if
+// definitions.ts changes - the exhaustiveness test in glyphs.test.ts
+// will fail if this list drifts.
+export const GLYPH_IDS = [
+  "masskrug",
+  "sunburst-stein",
+  "three-glasses",
+  "measuring-jug",
+  "coin-hand",
+  "purse",
+  "calendar-check",
+  "chain-links",
+  "tent-peaks",
+  "ferris-wheel",
+  "compass-rose",
+  "three-figures",
+  "clasped-hands",
+  "camera-shutter",
+  "spark-heart",
+  "laurel-cup",
+  "podium-steps",
+  "hourglass",
+  "flame-steady",
+  "signal-flag",
+  "first-drop",
+  "sunrise-gate",
+  "sunset-gate",
+  "double-sun",
+  "wiesn-crown",
+  "tent-ring",
+  "polaroid",
+  "banner-pole",
+  "id-card",
+  "ribbon-scroll",
+] as const;
+
+export type GlyphId = (typeof GLYPH_IDS)[number];
+
+// Nearest-match lucide icon name per glyph, used whenever no generated
+// image exists yet for that id (see apps/*/components/achievements for
+// the per-platform image registries). Plain strings only - this module
+// must not import lucide, to stay framework-agnostic like the rest of
+// packages/shared. Every name here must exist in both lucide-react and
+// lucide-react-native (verified during planning against the installed
+// lucide-react package - both packages are pinned to the same version).
+export const GLYPH_FALLBACK_ICONS: Record<GlyphId, string> = {
+  masskrug: "Beer",
+  "sunburst-stein": "Beer",
+  "three-glasses": "GlassWater",
+  "measuring-jug": "Beaker",
+  "coin-hand": "Coins",
+  purse: "Wallet",
+  "calendar-check": "CalendarCheck",
+  "chain-links": "Link",
+  "tent-peaks": "Tent",
+  "ferris-wheel": "FerrisWheel",
+  "compass-rose": "Compass",
+  "three-figures": "Users",
+  "clasped-hands": "Handshake",
+  "camera-shutter": "Camera",
+  "spark-heart": "Heart",
+  "laurel-cup": "Trophy",
+  "podium-steps": "Award",
+  hourglass: "Hourglass",
+  "flame-steady": "Flame",
+  "signal-flag": "Flag",
+  "first-drop": "Droplet",
+  "sunrise-gate": "Sunrise",
+  "sunset-gate": "Sunset",
+  "double-sun": "Sun",
+  "wiesn-crown": "Crown",
+  "tent-ring": "Tent",
+  polaroid: "Image",
+  "banner-pole": "Flag",
+  "id-card": "IdCard",
+  "ribbon-scroll": "ScrollText",
+};

--- a/packages/shared/src/achievements/index.ts
+++ b/packages/shared/src/achievements/index.ts
@@ -3,3 +3,4 @@ export * from "./types";
 export * from "./definitions";
 export * from "./evaluator";
 export * from "./glyphs";
+export * from "./badge-tokens";

--- a/packages/shared/src/achievements/index.ts
+++ b/packages/shared/src/achievements/index.ts
@@ -2,3 +2,4 @@
 export * from "./types";
 export * from "./definitions";
 export * from "./evaluator";
+export * from "./glyphs";

--- a/packages/shared/src/schemas/achievement.schema.ts
+++ b/packages/shared/src/schemas/achievement.schema.ts
@@ -120,6 +120,7 @@ export const AchievementWithProgressSchema = z.object({
   icon: z.string(),
   points: z.number().int(),
   rarity: AchievementRaritySchema,
+  tier: z.number().int().min(1).max(4),
   conditions: z.record(z.string(), z.unknown()).default({}),
   is_active: z.boolean(),
   created_at: z.string(),

--- a/packages/shared/src/wrapped/types.ts
+++ b/packages/shared/src/wrapped/types.ts
@@ -3,6 +3,8 @@
  * Provider-agnostic type definitions for the Wrapped slide system
  */
 
+import type { AchievementCategory } from "../achievements/types";
+
 /**
  * Slide type enumeration
  */
@@ -131,6 +133,8 @@ export interface WrappedData {
     name: string;
     description: string;
     icon: string;
+    category: AchievementCategory;
+    tier: number;
     points: number;
     rarity: string;
     unlocked_at: string;

--- a/packages/shared/src/wrapped/types.ts
+++ b/packages/shared/src/wrapped/types.ts
@@ -3,7 +3,7 @@
  * Provider-agnostic type definitions for the Wrapped slide system
  */
 
-import type { AchievementCategory } from "../achievements/types";
+import type { AchievementCategory as AchievementCategoryDb } from "../schemas/achievement.schema";
 
 /**
  * Slide type enumeration
@@ -133,7 +133,7 @@ export interface WrappedData {
     name: string;
     description: string;
     icon: string;
-    category: AchievementCategory;
+    category: AchievementCategoryDb;
     tier: number;
     points: number;
     rarity: string;

--- a/supabase/migrations/20260806120000_wrapped_achievement_category_tier.sql
+++ b/supabase/migrations/20260806120000_wrapped_achievement_category_tier.sql
@@ -371,7 +371,7 @@ BEGIN
         'description', a.description,
         'icon', a.icon,
         'category', a.category,
-        'tier', a.tier,
+        'tier', COALESCE(a.tier, 1),
         'points', a.points,
         'rarity', a.rarity,
         'unlocked_at', ua.unlocked_at

--- a/supabase/migrations/20260806120000_wrapped_achievement_category_tier.sql
+++ b/supabase/migrations/20260806120000_wrapped_achievement_category_tier.sql
@@ -1,0 +1,606 @@
+-- Adds category and tier to get_wrapped_data()'s achievements payload so the
+-- wrapped achievements-slide can render the same category+tier badge ring
+-- as the main achievements screen (Plan 3b).
+--
+-- This redefines the whole get_wrapped_data function (Postgres requires
+-- CREATE OR REPLACE FUNCTION with the complete body). The body below is
+-- copied verbatim from supabase/migrations/20260726190000_fix_wrapped_rls_and_comparisons.sql
+-- with exactly one change: the achievements jsonb_build_object call now also
+-- includes 'category' and 'tier'.
+--
+-- Grants are NOT part of this statement and do not need to be repeated:
+-- supabase/migrations/20260726190000_fix_wrapped_rls_and_comparisons.sql
+-- issues get_wrapped_data's REVOKE/GRANT as separate statements, well after
+-- the function body ends, and PostgreSQL's CREATE OR REPLACE FUNCTION does
+-- not reset existing grants.
+
+CREATE OR REPLACE FUNCTION "public"."get_wrapped_data"("p_user_id" "uuid", "p_festival_id" "uuid") RETURNS "jsonb"
+    LANGUAGE "plpgsql"
+    SECURITY DEFINER
+    SET search_path = public
+    AS $$
+DECLARE
+  v_result JSONB := '{}'::JSONB;
+  v_festival RECORD;
+  v_user RECORD;
+  v_basic_stats JSONB;
+  v_tent_stats JSONB;
+  v_peak_moments JSONB;
+  v_social_stats JSONB;
+  v_global_positions JSONB;
+  v_achievements JSONB;
+  v_timeline JSONB;
+  v_comparisons JSONB;
+  v_personality JSONB;
+  v_drink_stats JSONB;
+  v_beer_cost DECIMAL(5,2);
+BEGIN
+  -- SECURITY DEFINER: this function reads across all users to build festival-wide
+  -- averages and rankings, so it must not be callable for someone else's user id.
+  -- auth.uid() IS NULL means there is no JWT (service_role, or the internal call from
+  -- regenerate_wrapped_data_cache), which is allowed; anon is revoked below instead.
+  IF auth.uid() IS NOT NULL
+     AND p_user_id <> auth.uid()
+     AND NOT public.is_super_admin() THEN
+    RAISE EXCEPTION 'Not authorized to read wrapped data for another user'
+      USING ERRCODE = '42501';
+  END IF;
+
+  -- Get festival info
+  SELECT * INTO v_festival FROM festivals WHERE id = p_festival_id;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Festival not found';
+  END IF;
+
+  -- Get user profile
+  SELECT * INTO v_user FROM profiles WHERE id = p_user_id;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'User not found';
+  END IF;
+
+  -- Get default beer cost from festival or use global default
+  v_beer_cost := COALESCE(v_festival.beer_cost, 16.20);
+
+  -- Build user_info
+  v_result := jsonb_build_object(
+    'user_info', jsonb_build_object(
+      'username', v_user.username,
+      'full_name', v_user.full_name,
+      'avatar_url', v_user.avatar_url
+    ),
+    'festival_info', jsonb_build_object(
+      'name', v_festival.name,
+      'start_date', v_festival.start_date,
+      'end_date', v_festival.end_date,
+      'location', v_festival.location
+    )
+  );
+
+  -- Calculate basic stats using consumptions (with beer_count fallback)
+  WITH attendance_drinks AS (
+    SELECT
+      a.id,
+      a.date,
+      _get_effective_drink_count(a.id) AS drink_count
+    FROM attendances a
+    WHERE a.user_id = p_user_id AND a.festival_id = p_festival_id
+  ),
+  attendance_agg AS (
+    SELECT
+      COUNT(DISTINCT ad.date) AS days_attended,
+      COALESCE(SUM(ad.drink_count), 0) AS total_beers,
+      CASE
+        WHEN COUNT(DISTINCT ad.date) > 0 THEN
+          ROUND(COALESCE(SUM(ad.drink_count), 0)::NUMERIC / COUNT(DISTINCT ad.date)::NUMERIC, 2)
+        ELSE 0
+      END AS avg_beers
+    FROM attendance_drinks ad
+  )
+  SELECT jsonb_build_object(
+    'total_beers', total_beers,
+    'days_attended', days_attended,
+    'avg_beers', avg_beers,
+    'total_spent', ROUND(total_beers * v_beer_cost, 2),
+    'beer_cost', v_beer_cost
+  ) INTO v_basic_stats
+  FROM attendance_agg;
+
+  v_result := v_result || jsonb_build_object('basic_stats', v_basic_stats);
+
+  -- Calculate tent stats
+  WITH tent_stats AS (
+    SELECT
+      tv.tent_id,
+      t.name as tent_name,
+      COUNT(*) AS visit_count
+    FROM tent_visits tv
+    JOIN tents t ON tv.tent_id = t.id
+    WHERE tv.user_id = p_user_id
+      AND tv.festival_id = p_festival_id
+    GROUP BY tv.tent_id, t.name
+  ),
+  tent_agg AS (
+    SELECT
+      COUNT(DISTINCT tent_id) AS unique_tents,
+      (
+        SELECT tent_name
+        FROM tent_stats ts
+        ORDER BY ts.visit_count DESC, ts.tent_name ASC
+        LIMIT 1
+      ) AS favorite_tent,
+      (
+        SELECT jsonb_agg(
+          jsonb_build_object(
+            'tent_name', tent_name,
+            'visit_count', visit_count
+          ) ORDER BY visit_count DESC, tent_name ASC
+        )
+        FROM tent_stats ts
+      ) AS tent_breakdown
+    FROM tent_stats
+  ),
+  tent_total AS (
+    SELECT COUNT(*) AS total_tents FROM tents
+  )
+  SELECT jsonb_build_object(
+    'unique_tents', COALESCE(ta.unique_tents, 0),
+    'favorite_tent', ta.favorite_tent,
+    'tent_diversity_pct', CASE
+      WHEN tt.total_tents > 0 THEN ROUND((COALESCE(ta.unique_tents, 0)::NUMERIC / tt.total_tents::NUMERIC) * 100, 1)
+      ELSE 0
+    END,
+    'tent_breakdown', COALESCE(ta.tent_breakdown, '[]'::JSONB)
+  ) INTO v_tent_stats
+  FROM tent_agg ta, tent_total tt;
+
+  v_result := v_result || jsonb_build_object('tent_stats', v_tent_stats);
+
+  -- Calculate peak moments using consumptions (with beer_count fallback)
+  WITH daily_base AS (
+    SELECT
+      a.date,
+      _get_effective_drink_count(a.id) AS drink_count,
+      COALESCE(tv.tent_count, 0) as tents_visited
+    FROM attendances a
+    LEFT JOIN (
+      SELECT
+        tv.visit_date::date as date,
+        COUNT(DISTINCT tv.tent_id) as tent_count
+      FROM tent_visits tv
+      WHERE tv.user_id = p_user_id
+        AND tv.festival_id = p_festival_id
+      GROUP BY tv.visit_date::date
+    ) tv ON a.date = tv.date
+    WHERE a.user_id = p_user_id AND a.festival_id = p_festival_id
+  ),
+  daily_scores AS (
+    SELECT
+      db.date,
+      db.drink_count,
+      db.tents_visited,
+      (db.drink_count + db.tents_visited) as combined_score,
+      ROUND(db.drink_count * v_beer_cost, 2) AS spent
+    FROM daily_base db
+  ),
+  best_day AS (
+    SELECT
+      ds.date,
+      ds.drink_count,
+      ds.tents_visited,
+      ds.spent
+    FROM daily_scores ds
+    ORDER BY ds.combined_score DESC, ds.date DESC
+    LIMIT 1
+  ),
+  max_session AS (
+    SELECT COALESCE(MAX(ds.drink_count), 0) AS max_beers
+    FROM daily_scores ds
+  ),
+  most_expensive AS (
+    SELECT
+      ds.date,
+      ds.spent AS amount
+    FROM daily_scores ds
+    ORDER BY ds.spent DESC
+    LIMIT 1
+  )
+  SELECT jsonb_build_object(
+    'best_day', CASE
+      WHEN bd.date IS NOT NULL THEN
+        jsonb_build_object(
+          'date', bd.date,
+          'beer_count', bd.drink_count,
+          'tents_visited', bd.tents_visited,
+          'spent', bd.spent
+        )
+      ELSE NULL
+    END,
+    'max_single_session', ms.max_beers,
+    'most_expensive_day', CASE
+      WHEN me.date IS NOT NULL THEN
+        jsonb_build_object(
+          'date', me.date,
+          'amount', me.amount
+        )
+      ELSE NULL
+    END
+  ) INTO v_peak_moments
+  FROM best_day bd, max_session ms, most_expensive me;
+
+  v_result := v_result || jsonb_build_object('peak_moments', v_peak_moments);
+
+  -- Calculate social stats (rankings use consumptions via helper)
+  WITH user_groups AS (
+    SELECT
+      COUNT(DISTINCT gm.group_id) AS groups_joined,
+      COUNT(DISTINCT gm2.user_id) AS total_group_members
+    FROM group_members gm
+    JOIN groups g ON gm.group_id = g.id
+    LEFT JOIN group_members gm2 ON g.id = gm2.group_id AND gm2.user_id != p_user_id
+    WHERE gm.user_id = p_user_id AND g.festival_id = p_festival_id
+  ),
+  top_rankings AS (
+    SELECT jsonb_agg(
+      jsonb_build_object(
+        'group_name', group_name,
+        'position', user_rank
+      ) ORDER BY user_rank ASC
+    ) AS rankings
+    FROM (
+      SELECT
+        g.name AS group_name,
+        wc.name AS winning_criteria,
+        CASE
+          WHEN wc.name = 'days_attended' THEN
+            ROW_NUMBER() OVER (
+              PARTITION BY g.id
+              ORDER BY COUNT(DISTINCT a.date) DESC, p.username ASC
+            )
+          WHEN wc.name = 'total_beers' THEN
+            ROW_NUMBER() OVER (
+              PARTITION BY g.id
+              ORDER BY COALESCE(SUM(_get_effective_drink_count(a.id)), 0) DESC, p.username ASC
+            )
+          WHEN wc.name = 'avg_beers' THEN
+            ROW_NUMBER() OVER (
+              PARTITION BY g.id
+              ORDER BY COALESCE(AVG(_get_effective_drink_count(a.id)), 0) DESC, p.username ASC
+            )
+          ELSE 1
+        END AS user_rank
+      FROM groups g
+      JOIN group_members gm ON g.id = gm.group_id
+      LEFT JOIN attendances a ON gm.user_id = a.user_id AND a.festival_id = p_festival_id
+      LEFT JOIN profiles p ON gm.user_id = p.id
+      LEFT JOIN winning_criteria wc ON g.winning_criteria_id = wc.id
+      WHERE g.festival_id = p_festival_id AND gm.user_id = p_user_id
+      GROUP BY g.id, g.name, wc.name, p.username
+    ) ranked
+    WHERE user_rank <= 3
+  ),
+  photo_count AS (
+    SELECT COUNT(*) AS photos_uploaded
+    FROM beer_pictures bp
+    JOIN attendances a ON bp.attendance_id = a.id
+    WHERE bp.user_id = p_user_id
+      AND a.date >= v_festival.start_date
+      AND a.date <= v_festival.end_date
+      AND a.festival_id = p_festival_id
+  ),
+  user_pictures AS (
+    SELECT
+      bp.id,
+      bp.picture_url,
+      bp.created_at,
+      a.date as attendance_date
+    FROM beer_pictures bp
+    JOIN attendances a ON bp.attendance_id = a.id
+    WHERE bp.user_id = p_user_id
+      AND a.date >= v_festival.start_date
+      AND a.date <= v_festival.end_date
+      AND a.festival_id = p_festival_id
+    ORDER BY bp.created_at DESC
+    LIMIT 20
+  )
+  SELECT jsonb_build_object(
+    'groups_joined', ug.groups_joined,
+    'top_3_rankings', COALESCE(tr.rankings, '[]'::JSONB),
+    'photos_uploaded', pc.photos_uploaded,
+    'total_group_members', ug.total_group_members,
+    'pictures', COALESCE(
+      (SELECT jsonb_agg(
+        jsonb_build_object(
+          'id', up.id,
+          'picture_url', up.picture_url,
+          'created_at', up.created_at,
+          'attendance_date', up.attendance_date
+        )
+      ) FROM user_pictures up),
+      '[]'::JSONB
+    )
+  ) INTO v_social_stats
+  FROM user_groups ug, top_rankings tr, photo_count pc;
+
+  v_result := v_result || jsonb_build_object('social_stats', v_social_stats);
+
+  -- Calculate global leaderboard positions for days_attended, total_beers, and avg_beers
+  -- Note: get_global_leaderboard uses its own logic; wrapped-specific positions calculated here
+  WITH global_positions AS (
+    SELECT
+      'days_attended' as criteria,
+      CASE
+        WHEN array_length(array_agg(gl.user_id ORDER BY gl.days_attended DESC, gl.username ASC), 1) > 0
+        THEN array_position(array_agg(gl.user_id ORDER BY gl.days_attended DESC, gl.username ASC), p_user_id)
+        ELSE NULL
+      END as position
+    FROM get_global_leaderboard(1, p_festival_id) gl
+    UNION ALL
+    SELECT
+      'total_beers' as criteria,
+      CASE
+        WHEN array_length(array_agg(gl.user_id ORDER BY gl.total_beers DESC, gl.username ASC), 1) > 0
+        THEN array_position(array_agg(gl.user_id ORDER BY gl.total_beers DESC, gl.username ASC), p_user_id)
+        ELSE NULL
+      END as position
+    FROM get_global_leaderboard(2, p_festival_id) gl
+    UNION ALL
+    SELECT
+      'avg_beers' as criteria,
+      CASE
+        WHEN array_length(array_agg(gl.user_id ORDER BY gl.avg_beers DESC, gl.username ASC), 1) > 0
+        THEN array_position(array_agg(gl.user_id ORDER BY gl.avg_beers DESC, gl.username ASC), p_user_id)
+        ELSE NULL
+      END as position
+    FROM get_global_leaderboard(3, p_festival_id) gl
+  )
+  SELECT jsonb_build_object(
+    'days_attended', MAX(CASE WHEN criteria = 'days_attended' THEN position END),
+    'total_beers', MAX(CASE WHEN criteria = 'total_beers' THEN position END),
+    'avg_beers', MAX(CASE WHEN criteria = 'avg_beers' THEN position END)
+  ) INTO v_global_positions
+  FROM global_positions;
+
+  v_result := v_result || jsonb_build_object('global_leaderboard_positions', v_global_positions);
+
+  -- Get achievements
+  SELECT COALESCE(
+    jsonb_agg(
+      jsonb_build_object(
+        'id', a.id,
+        'name', a.name,
+        'description', a.description,
+        'icon', a.icon,
+        'category', a.category,
+        'tier', a.tier,
+        'points', a.points,
+        'rarity', a.rarity,
+        'unlocked_at', ua.unlocked_at
+      ) ORDER BY ua.unlocked_at DESC
+    ),
+    '[]'::JSONB
+  ) INTO v_achievements
+  FROM user_achievements ua
+  JOIN achievements a ON ua.achievement_id = a.id
+  WHERE ua.user_id = p_user_id AND ua.festival_id = p_festival_id;
+
+  v_result := v_result || jsonb_build_object('achievements', v_achievements);
+
+  -- Build timeline (daily progression) using consumptions
+  SELECT COALESCE(
+    jsonb_agg(
+      jsonb_build_object(
+        'date', a.date,
+        'beer_count', _get_effective_drink_count(a.id),
+        'spent', ROUND(_get_effective_drink_count(a.id) * v_beer_cost, 2),
+        'tents_visited', (
+          SELECT COUNT(DISTINCT tent_id)
+          FROM tent_visits tv
+          WHERE tv.user_id = p_user_id
+            AND tv.festival_id = p_festival_id
+            AND tv.visit_date::date = a.date
+        )
+      ) ORDER BY a.date ASC
+    ),
+    '[]'::JSONB
+  ) INTO v_timeline
+  FROM attendances a
+  WHERE a.user_id = p_user_id AND a.festival_id = p_festival_id;
+
+  v_result := v_result || jsonb_build_object('timeline', v_timeline);
+
+  -- Calculate comparisons using consumptions.
+  -- Set-based rather than per-row _get_effective_drink_count: that helper re-reads the
+  -- attendances row by id even though we already have it here, which cost ~600 extra
+  -- buffer hits per festival. COUNT(*) rather than COUNT(DISTINCT a.date) is safe
+  -- because of the unique_user_date_festival index on (user_id, date, festival_id).
+  WITH festival_user_stats AS (
+    SELECT
+      a.user_id,
+      COUNT(*) AS days_attended,
+      COALESCE(SUM(COALESCE(NULLIF(c.drink_count, 0), a.beer_count)), 0) AS total_drinks
+    FROM attendances a
+    LEFT JOIN (
+      SELECT cc.attendance_id, COUNT(*)::int AS drink_count
+      FROM consumptions cc
+      JOIN attendances aa ON aa.id = cc.attendance_id
+      WHERE aa.festival_id = p_festival_id
+      GROUP BY cc.attendance_id
+    ) c ON c.attendance_id = a.id
+    WHERE a.festival_id = p_festival_id
+    GROUP BY a.user_id
+  ),
+  festival_avg AS (
+    SELECT
+      ROUND(AVG(total_drinks), 2) AS avg_beers,
+      ROUND(AVG(days_attended), 2) AS avg_days,
+      ROUND(PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY total_drinks)::NUMERIC, 2) AS median_beers,
+      ROUND(PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY days_attended)::NUMERIC, 2) AS median_days
+    FROM festival_user_stats
+  ),
+  -- Percentile rank: share of attendees strictly below the user. More meaningful than
+  -- the mean diff, which is skewed by one-day attendees and by the top of the range.
+  user_percentile AS (
+    SELECT
+      COUNT(*) AS total_users,
+      COUNT(*) FILTER (
+        WHERE fus.total_drinks < (v_basic_stats->>'total_beers')::NUMERIC
+      ) AS below_beers,
+      COUNT(*) FILTER (
+        WHERE fus.days_attended < (v_basic_stats->>'days_attended')::NUMERIC
+      ) AS below_days
+    FROM festival_user_stats fus
+  ),
+  user_current AS (
+    SELECT
+      (v_basic_stats->>'total_beers')::NUMERIC AS user_beers,
+      (v_basic_stats->>'days_attended')::NUMERIC AS user_days
+  ),
+  previous_festival AS (
+    SELECT
+      f.id as festival_id,
+      f.name as festival_name,
+      COUNT(DISTINCT a.date) AS prev_days,
+      COALESCE(SUM(_get_effective_drink_count(a.id)), 0) AS prev_beers,
+      COALESCE(SUM(_get_effective_drink_count(a.id)) * v_beer_cost, 0) AS prev_spent
+    FROM attendances a
+    JOIN festivals f ON a.festival_id = f.id
+    WHERE a.user_id = p_user_id
+      AND f.festival_type = v_festival.festival_type
+      AND f.start_date < v_festival.start_date
+      AND f.id != p_festival_id
+    GROUP BY f.id, f.name, f.start_date
+    ORDER BY f.start_date DESC
+    LIMIT 1
+  )
+  SELECT jsonb_build_object(
+    'vs_festival_avg', jsonb_build_object(
+      'beers_diff_pct', CASE
+        WHEN fa.avg_beers > 0 THEN ROUND(((uc.user_beers - fa.avg_beers) / fa.avg_beers) * 100, 1)
+        ELSE 0
+      END,
+      'days_diff_pct', CASE
+        WHEN fa.avg_days > 0 THEN ROUND(((uc.user_days - fa.avg_days) / fa.avg_days) * 100, 1)
+        ELSE 0
+      END,
+      'avg_beers', fa.avg_beers,
+      'avg_days', fa.avg_days,
+      'median_beers', fa.median_beers,
+      'median_days', fa.median_days,
+      'beers_percentile', CASE
+        WHEN up.total_users > 0 THEN ROUND((up.below_beers::NUMERIC / up.total_users) * 100, 1)
+        ELSE 0
+      END,
+      'days_percentile', CASE
+        WHEN up.total_users > 0 THEN ROUND((up.below_days::NUMERIC / up.total_users) * 100, 1)
+        ELSE 0
+      END
+    ),
+    'vs_last_year', CASE
+      WHEN pf.prev_beers > 0 THEN
+        jsonb_build_object(
+          'beers_diff', uc.user_beers - pf.prev_beers,
+          'days_diff', uc.user_days - pf.prev_days,
+          'spent_diff', ROUND((uc.user_beers * v_beer_cost) - pf.prev_spent, 2),
+          'prev_beers', pf.prev_beers,
+          'prev_days', pf.prev_days,
+          'prev_festival_name', pf.festival_name
+        )
+      ELSE NULL
+    END
+  ) INTO v_comparisons
+  -- festival_avg / user_percentile / user_current are unGROUPed aggregates or constant
+  -- selects, so they always yield exactly one row. previous_festival yields zero rows for
+  -- a first-time attendee, which under the old CROSS JOIN collapsed the whole comparisons
+  -- object to NULL and hid the festival average too.
+  FROM festival_avg fa
+  CROSS JOIN user_percentile up
+  CROSS JOIN user_current uc
+  LEFT JOIN previous_festival pf ON TRUE;
+
+  v_result := v_result || jsonb_build_object('comparisons', v_comparisons);
+
+  -- Calculate personality type using consumptions
+  WITH attendance_drinks AS (
+    SELECT
+      a.id,
+      a.date,
+      _get_effective_drink_count(a.id) AS drink_count
+    FROM attendances a
+    WHERE a.user_id = p_user_id AND a.festival_id = p_festival_id
+  ),
+  user_patterns AS (
+    SELECT
+      (v_basic_stats->>'total_beers')::INT AS total_beers,
+      (v_basic_stats->>'days_attended')::INT AS days_attended,
+      (v_basic_stats->>'avg_beers')::NUMERIC AS avg_beers,
+      (v_tent_stats->>'unique_tents')::INT AS unique_tents,
+      (SELECT COUNT(*) FROM tents) AS total_tents,
+      EXISTS (
+        SELECT 1 FROM attendances
+        WHERE user_id = p_user_id
+          AND festival_id = p_festival_id
+          AND date = v_festival.start_date
+      ) AS attended_first_day,
+      COALESCE(STDDEV(ad.drink_count), 0) AS beer_variance
+    FROM attendance_drinks ad
+  )
+  SELECT jsonb_build_object(
+    'type', CASE
+      WHEN up.unique_tents >= up.total_tents * 0.7 THEN 'Explorer'
+      WHEN up.avg_beers >= 8 THEN 'Champion'
+      WHEN up.days_attended >= (v_festival.end_date - v_festival.start_date + 1) * 0.8 THEN 'Loyalist'
+      WHEN up.avg_beers <= 3 AND up.days_attended >= 5 THEN 'Social Butterfly'
+      WHEN up.beer_variance < 2 THEN 'Consistent'
+      ELSE 'Casual Enjoyer'
+    END,
+    'traits', jsonb_build_array(
+      CASE WHEN up.attended_first_day THEN 'Early Bird' END,
+      CASE WHEN up.beer_variance < 2 THEN 'Steady Pace' ELSE 'Variable' END,
+      CASE WHEN up.unique_tents >= up.total_tents * 0.5 THEN 'Tent Explorer' ELSE 'Tent Loyalist' END,
+      CASE WHEN up.avg_beers >= 6 THEN 'Heavy Hitter'
+           WHEN up.avg_beers >= 4 THEN 'Moderate'
+           ELSE 'Light Drinker' END
+    ) - ARRAY[NULL]::TEXT[]
+  ) INTO v_personality
+  FROM user_patterns up;
+
+  v_result := v_result || jsonb_build_object('personality', v_personality);
+
+  -- Calculate drink stats from consumptions table (type breakdown)
+  WITH drink_breakdown AS (
+    SELECT
+      c.drink_type::text AS drink_type,
+      COUNT(*) AS count
+    FROM consumptions c
+    JOIN attendances a ON c.attendance_id = a.id
+    WHERE a.user_id = p_user_id
+      AND a.festival_id = p_festival_id
+    GROUP BY c.drink_type
+  ),
+  totals AS (
+    SELECT SUM(count) AS total FROM drink_breakdown
+  )
+  SELECT jsonb_build_object(
+    'total_drinks', COALESCE((SELECT total FROM totals), 0),
+    'top_drink_type', (SELECT drink_type FROM drink_breakdown ORDER BY count DESC LIMIT 1),
+    'breakdown', COALESCE(
+      (SELECT jsonb_agg(
+         jsonb_build_object(
+           'drink_type', db.drink_type,
+           'count', db.count,
+           'percentage', CASE WHEN t.total > 0
+             THEN ROUND((db.count::numeric / t.total::numeric) * 100, 1)
+             ELSE 0 END
+         ) ORDER BY db.count DESC
+       ) FROM drink_breakdown db, totals t),
+      '[]'::jsonb
+    )
+  ) INTO v_drink_stats;
+
+  v_result := v_result || jsonb_build_object('drink_stats', v_drink_stats);
+
+  RETURN v_result;
+END;
+$$;
+
+COMMENT ON FUNCTION "public"."get_wrapped_data"("p_user_id" "uuid", "p_festival_id" "uuid") IS 'Returns comprehensive wrapped statistics for a user''s festival experience. Uses consumptions table as source of truth for drink counts, with fallback to legacy attendances.beer_count for backwards compatibility. SECURITY DEFINER because it aggregates across all festival attendees; callers are restricted to their own user id unless super admin.';


### PR DESCRIPTION
## Summary
- Replaces the stale, broken achievement badge system (three independent emoji lookup tables keyed by a legacy vocabulary that no longer matches any real achievement data, so every badge silently fell back to a generic trophy) with a real visual badge: a category-colored ring with tier-based thickness/glow, wrapping either generated glyph art (none exists yet, separate follow-up) or an automatic lucide-icon fallback
- Implemented in parallel on web and mobile, backed by small additive API/DB changes (`tier` exposed on the achievements API response, `category`/`tier` added to the wrapped-data RPC via a new migration)
- Includes an art brief doc (`docs/design/achievement-glyph-brief.md`) with 30 per-glyph prompts, grounded in each achievement's actual name/description, for the user's own follow-up work generating the real glyph art

