### PR TITLE
feat(achievements): scope tabs, close-to-unlocking rail, detail sheet

### DIFF
--- a/apps/mobile/app/achievements/index.tsx
+++ b/apps/mobile/app/achievements/index.tsx
@@ -1,4 +1,4 @@
-import { SERIES_CATEGORY_ORDER, splitCardsByCompletion } from "@prostcounter/shared/achievements";
+import { buildStats, SERIES_CATEGORY_ORDER, splitCardsByCompletion } from "@prostcounter/shared/achievements";
 import { useFestival } from "@prostcounter/shared/contexts";
 import { useAchievementsWithProgress } from "@prostcounter/shared/hooks";
 import { useTranslation } from "@prostcounter/shared/i18n";
@@ -100,8 +100,8 @@ export default function AchievementsScreen() {
   }, [achievementsResponse, activeScope]);
 
   const stats = useMemo(() => {
-    return achievementsResponse?.stats || null;
-  }, [achievementsResponse]);
+    return achievementsResponse ? buildStats(cards) : null;
+  }, [achievementsResponse, cards]);
 
   const visibleCategories = useMemo(() => {
     return activeCategory === "all"

--- a/apps/mobile/app/achievements/index.tsx
+++ b/apps/mobile/app/achievements/index.tsx
@@ -2,13 +2,19 @@ import { SERIES_CATEGORY_ORDER, splitCardsByCompletion } from "@prostcounter/sha
 import { useFestival } from "@prostcounter/shared/contexts";
 import { useAchievementsWithProgress } from "@prostcounter/shared/hooks";
 import { useTranslation } from "@prostcounter/shared/i18n";
-import type { SeriesCard as SeriesCardData, SeriesCategory } from "@prostcounter/shared/schemas";
+import type {
+  SeriesCard as SeriesCardData,
+  SeriesCategory,
+  SeriesScope,
+} from "@prostcounter/shared/schemas";
 import { Award } from "lucide-react-native";
 import { useCallback, useMemo, useState } from "react";
 import { RefreshControl, ScrollView } from "react-native";
 
 import { AchievementStatsSummary } from "@/components/achievements/achievement-stats-summary";
 import { CategoryChips, type CategoryFilter } from "@/components/achievements/category-chips";
+import { CloseToUnlockingRail } from "@/components/achievements/close-to-unlocking-rail";
+import { ScopeToggle } from "@/components/achievements/scope-toggle";
 import { SeriesCard } from "@/components/achievements/series-card";
 import { AchievementsSkeleton } from "@/components/skeletons";
 import { Card } from "@/components/ui/card";
@@ -77,6 +83,7 @@ export default function AchievementsScreen() {
   const { currentFestival, isLoading: festivalLoading } = useFestival();
   const { isOnline } = useOfflineSafe();
   const [activeCategory, setActiveCategory] = useState<CategoryFilter>("all");
+  const [activeScope, setActiveScope] = useState<SeriesScope>("festival");
 
   const {
     data: achievementsResponse,
@@ -86,9 +93,11 @@ export default function AchievementsScreen() {
     isRefetching = false,
   } = useAchievementsWithProgress(currentFestival?.id);
 
+  // Both scopes arrive in one response — the toggle is a filter, not a refetch.
   const cards = useMemo(() => {
-    return achievementsResponse?.cards || [];
-  }, [achievementsResponse]);
+    const allCards = achievementsResponse?.cards || [];
+    return allCards.filter((card: SeriesCardData) => card.scope === activeScope);
+  }, [achievementsResponse, activeScope]);
 
   const stats = useMemo(() => {
     return achievementsResponse?.stats || null;
@@ -176,7 +185,13 @@ export default function AchievementsScreen() {
       <VStack space="lg" className="p-4 pb-8">
         {stats && <AchievementStatsSummary stats={stats} />}
 
+        <ScopeToggle value={activeScope} onChange={setActiveScope} />
+
         <CategoryChips value={activeCategory} onChange={setActiveCategory} />
+
+        {/* Scope-filtered but deliberately not category-filtered — the rail is
+            a cross-category prompt. */}
+        <CloseToUnlockingRail cards={cards} />
 
         {cards.length === 0 ? (
           <Card variant="outline" size="md" className="items-center bg-white p-6">

--- a/apps/mobile/components/achievements/close-to-unlocking-rail.tsx
+++ b/apps/mobile/components/achievements/close-to-unlocking-rail.tsx
@@ -1,0 +1,82 @@
+import type { AchievementTier, GlyphId } from "@prostcounter/shared/achievements";
+import { getActiveTier, selectCloseToUnlocking } from "@prostcounter/shared/achievements";
+import { useTranslation } from "@prostcounter/shared/i18n";
+import type { SeriesCard as SeriesCardData } from "@prostcounter/shared/schemas";
+
+import { Card } from "@/components/ui/card";
+import { Heading } from "@/components/ui/heading";
+import { HStack } from "@/components/ui/hstack";
+import { Progress, ProgressFilledTrack } from "@/components/ui/progress";
+import { Text } from "@/components/ui/text";
+import { VStack } from "@/components/ui/vstack";
+
+import { AchievementBadge } from "./achievement-badge";
+
+interface CloseToUnlockingRailProps {
+  cards: SeriesCardData[];
+}
+
+/**
+ * The three series nearest their next rung. Renders nothing when nothing
+ * qualifies — a new user, or a scope with no series started, legitimately has
+ * none, and an empty section is dead space.
+ */
+export function CloseToUnlockingRail({ cards }: CloseToUnlockingRailProps) {
+  const { t } = useTranslation();
+  const entries = selectCloseToUnlocking(cards);
+
+  if (entries.length === 0) {
+    return null;
+  }
+
+  return (
+    <VStack space="sm">
+      <Heading size="md" className="text-typography-900">
+        {t("achievements.closeToUnlocking")}
+      </Heading>
+
+      <VStack space="sm">
+        {entries.map(({ card, currentValue, nextTarget, remaining, percentage }) => {
+          const activeTier = getActiveTier(card);
+
+          return (
+            <Card
+              key={card.id}
+              variant="outline"
+              size="sm"
+              className="border-yellow-200 bg-yellow-50/30"
+            >
+              <HStack space="sm" className="items-center p-3">
+                <AchievementBadge
+                  glyph={card.glyph as GlyphId}
+                  category={card.category}
+                  tier={activeTier.tier as AchievementTier}
+                  isUnlocked={card.currentTier > 0}
+                  size="md"
+                />
+
+                <VStack className="flex-1" space="xs">
+                  <Text className="text-base font-semibold text-typography-900" numberOfLines={1}>
+                    {t(activeTier.name)}
+                  </Text>
+                  <Progress value={percentage} size="sm">
+                    <ProgressFilledTrack />
+                  </Progress>
+                  <Text className="text-xs text-typography-500">
+                    {t("achievements.progressToNext", {
+                      current: currentValue,
+                      target: nextTarget,
+                      remaining,
+                    })}
+                  </Text>
+                </VStack>
+              </HStack>
+            </Card>
+          );
+        })}
+      </VStack>
+    </VStack>
+  );
+}
+
+CloseToUnlockingRail.displayName = "CloseToUnlockingRail";

--- a/apps/mobile/components/achievements/scope-toggle.tsx
+++ b/apps/mobile/components/achievements/scope-toggle.tsx
@@ -1,0 +1,57 @@
+import { useTranslation } from "@prostcounter/shared/i18n";
+import type { SeriesScope } from "@prostcounter/shared/schemas";
+import { cn } from "@prostcounter/ui";
+
+import { HStack } from "@/components/ui/hstack";
+import { Pressable } from "@/components/ui/pressable";
+import { Text } from "@/components/ui/text";
+
+interface ScopeToggleProps {
+  value: SeriesScope;
+  onChange: (value: SeriesScope) => void;
+}
+
+/**
+ * Two-segment festival / all-time selector. Built from Pressable rather than a
+ * tabs primitive because the mobile UI kit has none, and a two-value control
+ * does not justify a new dependency. Exactly one segment is always active —
+ * unlike CategoryChips, there is no "all" option.
+ */
+export function ScopeToggle({ value, onChange }: ScopeToggleProps) {
+  const { t } = useTranslation();
+
+  const segments: { key: SeriesScope; label: string }[] = [
+    { key: "festival", label: t("achievements.scope.festival") },
+    { key: "lifetime", label: t("achievements.scope.allTime") },
+  ];
+
+  return (
+    <HStack className="rounded-lg bg-background-100 p-1">
+      {segments.map((segment) => {
+        const isActive = segment.key === value;
+
+        return (
+          <Pressable
+            key={segment.key}
+            onPress={() => onChange(segment.key)}
+            accessibilityRole="button"
+            accessibilityState={{ selected: isActive }}
+            accessibilityLabel={segment.label}
+            className={cn("flex-1 rounded-md py-2", isActive && "bg-white shadow-sm")}
+          >
+            <Text
+              className={cn(
+                "text-center text-sm",
+                isActive ? "font-semibold text-typography-900" : "text-typography-500",
+              )}
+            >
+              {segment.label}
+            </Text>
+          </Pressable>
+        );
+      })}
+    </HStack>
+  );
+}
+
+ScopeToggle.displayName = "ScopeToggle";

--- a/apps/mobile/components/achievements/series-card-detail-sheet.tsx
+++ b/apps/mobile/components/achievements/series-card-detail-sheet.tsx
@@ -76,7 +76,7 @@ export function SeriesCardDetailSheet({ card, isOpen, onClose }: SeriesCardDetai
                         date: formatLocalized(new Date(tier.unlockedAt), "MMM d, yyyy"),
                       })}
                     </Text>
-                  ) : isNextRung && card.progress !== null ? (
+                  ) : isNextRung && card.progress != null ? (
                     <Text className="text-xs text-typography-500">
                       {t("achievements.progressToNext", {
                         current: card.progress.currentValue,

--- a/apps/mobile/components/achievements/series-card-detail-sheet.tsx
+++ b/apps/mobile/components/achievements/series-card-detail-sheet.tsx
@@ -1,0 +1,100 @@
+import type { AchievementTier } from "@prostcounter/shared/achievements";
+import { getActiveTier, TIER_NAMES } from "@prostcounter/shared/achievements";
+import { useTranslation } from "@prostcounter/shared/i18n";
+import type { SeriesCard as SeriesCardData } from "@prostcounter/shared/schemas";
+import { formatLocalized } from "@prostcounter/shared/utils";
+import { cn } from "@prostcounter/ui";
+
+import {
+  Actionsheet,
+  ActionsheetBackdrop,
+  ActionsheetContent,
+  ActionsheetDragIndicator,
+  ActionsheetDragIndicatorWrapper,
+} from "@/components/ui/actionsheet";
+import { Heading } from "@/components/ui/heading";
+import { HStack } from "@/components/ui/hstack";
+import { Text } from "@/components/ui/text";
+import { VStack } from "@/components/ui/vstack";
+
+interface SeriesCardDetailSheetProps {
+  card: SeriesCardData;
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+/** Every rung of one card: which are earned, when, and how far the next one is. */
+export function SeriesCardDetailSheet({ card, isOpen, onClose }: SeriesCardDetailSheetProps) {
+  const { t } = useTranslation();
+  const activeTier = getActiveTier(card);
+
+  return (
+    <Actionsheet isOpen={isOpen} onClose={onClose}>
+      <ActionsheetBackdrop />
+      <ActionsheetContent className="bg-background-0 pb-8">
+        <ActionsheetDragIndicatorWrapper>
+          <ActionsheetDragIndicator />
+        </ActionsheetDragIndicatorWrapper>
+
+        <VStack space="md" className="w-full px-4 py-4">
+          <VStack space="xs">
+            <Heading size="lg" className="text-typography-900">
+              {t(activeTier.name)}
+            </Heading>
+            <Text className="text-sm text-typography-500">
+              {t(`achievements.categories.${card.category}`)}
+            </Text>
+          </VStack>
+
+          <VStack space="sm">
+            {card.tiers.map((tier) => {
+              // Only a series has a "next" rung; a one-off's single rung carries
+              // a difficulty tier that never lines up with currentTier + 1.
+              const isNextRung = !tier.isUnlocked && tier.tier === card.currentTier + 1;
+
+              return (
+                <HStack
+                  key={tier.tier}
+                  space="sm"
+                  className={cn(
+                    "items-start justify-between rounded-md border p-3",
+                    tier.isUnlocked ? "border-green-200 bg-green-50/30" : "border-gray-200",
+                  )}
+                >
+                  <VStack className="flex-1" space="xs">
+                    <Text className="text-sm font-medium text-typography-900" numberOfLines={1}>
+                      {t(tier.name)}
+                    </Text>
+                    <Text className="text-xs text-typography-500">
+                      {t(`achievements.tiers.${TIER_NAMES[tier.tier as AchievementTier]}`)}
+                    </Text>
+                  </VStack>
+
+                  {tier.isUnlocked && tier.unlockedAt !== null ? (
+                    <Text className="text-xs text-green-700">
+                      {t("achievements.unlockedOn", {
+                        date: formatLocalized(new Date(tier.unlockedAt), "MMM d, yyyy"),
+                      })}
+                    </Text>
+                  ) : isNextRung && card.progress !== null ? (
+                    <Text className="text-xs text-typography-500">
+                      {t("achievements.progressToNext", {
+                        current: card.progress.currentValue,
+                        target: card.progress.nextTarget,
+                        remaining: card.progress.nextTarget - card.progress.currentValue,
+                      })}
+                    </Text>
+                  ) : (
+                    <Text className="text-xs text-typography-400">{t("achievements.locked")}</Text>
+                  )}
+                </HStack>
+              );
+            })}
+          </VStack>
+        </VStack>
+      </ActionsheetContent>
+    </Actionsheet>
+  );
+}
+
+SeriesCardDetailSheet.displayName = "SeriesCardDetailSheet";

--- a/apps/mobile/components/achievements/series-card.tsx
+++ b/apps/mobile/components/achievements/series-card.tsx
@@ -3,14 +3,17 @@ import { getActiveTier, getCategoryColor, TIER_NAMES } from "@prostcounter/share
 import { useTranslation } from "@prostcounter/shared/i18n";
 import type { SeriesCard as SeriesCardData } from "@prostcounter/shared/schemas";
 import { cn } from "@prostcounter/ui";
+import { useState } from "react";
 import { View } from "react-native";
 
 import { Card } from "@/components/ui/card";
 import { HStack } from "@/components/ui/hstack";
+import { Pressable } from "@/components/ui/pressable";
 import { Text } from "@/components/ui/text";
 import { VStack } from "@/components/ui/vstack";
 
 import { AchievementBadge } from "./achievement-badge";
+import { SeriesCardDetailSheet } from "./series-card-detail-sheet";
 
 const LOCKED_PIP_COLOR = "#D1D5DB";
 
@@ -24,6 +27,7 @@ interface SeriesCardProps {
  */
 export function SeriesCard({ card }: SeriesCardProps) {
   const { t } = useTranslation();
+  const [isDetailOpen, setIsDetailOpen] = useState(false);
 
   // Never card.currentTier: that counts rungs cleared, which is not the badge
   // tier for a one-off. See getActiveTier's doc comment.
@@ -32,54 +36,71 @@ export function SeriesCard({ card }: SeriesCardProps) {
   const categoryColor = getCategoryColor(card.category);
 
   return (
-    <Card
-      variant="outline"
-      size="sm"
-      className={cn(isUnlocked ? "border-green-200 bg-green-50/30" : "border-gray-200 bg-white")}
-    >
-      <HStack space="sm" className="items-center p-3">
-        <AchievementBadge
-          glyph={card.glyph as GlyphId}
-          category={card.category}
-          tier={activeTier.tier as AchievementTier}
-          isUnlocked={isUnlocked}
-          size="md"
-        />
-
-        <VStack className="flex-1" space="xs">
-          <Text
-            className={cn(
-              "text-base font-semibold",
-              isUnlocked ? "text-green-800" : "text-gray-700",
-            )}
-            numberOfLines={1}
-          >
-            {t(activeTier.name)}
-          </Text>
-          <Text className="text-xs text-typography-500">
-            {isUnlocked
-              ? t(`achievements.tiers.${TIER_NAMES[activeTier.tier as AchievementTier]}`)
-              : t("achievements.locked")}
-          </Text>
-        </VStack>
-
-        {/* Decorative: the tier label above already says this in words. The
-            per-category colour is data, so it cannot be a NativeWind class —
-            same reason achievement-badge.tsx styles its glow inline. */}
-        <HStack space="xs" className="items-center" accessibilityElementsHidden>
-          {card.tiers.map((tier) => (
-            <View
-              key={tier.tier}
-              className="h-2 w-2 rounded-full border"
-              style={{
-                backgroundColor: tier.isUnlocked ? categoryColor : "transparent",
-                borderColor: tier.isUnlocked ? categoryColor : LOCKED_PIP_COLOR,
-              }}
+    <>
+      <Pressable
+        onPress={() => setIsDetailOpen(true)}
+        accessibilityRole="button"
+        accessibilityLabel={t(activeTier.name)}
+        accessibilityHint={t("achievements.viewProgress")}
+      >
+        <Card
+          variant="outline"
+          size="sm"
+          className={cn(
+            isUnlocked ? "border-green-200 bg-green-50/30" : "border-gray-200 bg-white",
+          )}
+        >
+          <HStack space="sm" className="items-center p-3">
+            <AchievementBadge
+              glyph={card.glyph as GlyphId}
+              category={card.category}
+              tier={activeTier.tier as AchievementTier}
+              isUnlocked={isUnlocked}
+              size="md"
             />
-          ))}
-        </HStack>
-      </HStack>
-    </Card>
+
+            <VStack className="flex-1" space="xs">
+              <Text
+                className={cn(
+                  "text-base font-semibold",
+                  isUnlocked ? "text-green-800" : "text-gray-700",
+                )}
+                numberOfLines={1}
+              >
+                {t(activeTier.name)}
+              </Text>
+              <Text className="text-xs text-typography-500">
+                {isUnlocked
+                  ? t(`achievements.tiers.${TIER_NAMES[activeTier.tier as AchievementTier]}`)
+                  : t("achievements.locked")}
+              </Text>
+            </VStack>
+
+            {/* Decorative: the tier label above already says this in words. The
+                per-category colour is data, so it cannot be a NativeWind class —
+                same reason achievement-badge.tsx styles its glow inline. */}
+            <HStack space="xs" className="items-center" accessibilityElementsHidden>
+              {card.tiers.map((tier) => (
+                <View
+                  key={tier.tier}
+                  className="h-2 w-2 rounded-full border"
+                  style={{
+                    backgroundColor: tier.isUnlocked ? categoryColor : "transparent",
+                    borderColor: tier.isUnlocked ? categoryColor : LOCKED_PIP_COLOR,
+                  }}
+                />
+              ))}
+            </HStack>
+          </HStack>
+        </Card>
+      </Pressable>
+
+      <SeriesCardDetailSheet
+        card={card}
+        isOpen={isDetailOpen}
+        onClose={() => setIsDetailOpen(false)}
+      />
+    </>
   );
 }
 

--- a/apps/web/app/(private)/achievements/page.tsx
+++ b/apps/web/app/(private)/achievements/page.tsx
@@ -2,10 +2,16 @@
 
 import { SERIES_CATEGORY_ORDER, splitCardsByCompletion } from "@prostcounter/shared/achievements";
 import { useFestival } from "@prostcounter/shared/contexts";
-import type { SeriesCard as SeriesCardData, SeriesCategory } from "@prostcounter/shared/schemas";
+import type {
+  SeriesCard as SeriesCardData,
+  SeriesCategory,
+  SeriesScope,
+} from "@prostcounter/shared/schemas";
 import { useState } from "react";
 
 import { CategoryChips, type CategoryFilter } from "@/components/achievements/CategoryChips";
+import { CloseToUnlockingRail } from "@/components/achievements/CloseToUnlockingRail";
+import { ScopeTabs } from "@/components/achievements/ScopeTabs";
 import { SeriesCard } from "@/components/achievements/SeriesCard";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { useAchievementsWithProgress } from "@/hooks/useAchievements";
@@ -61,8 +67,11 @@ export default function AchievementsPage() {
   const { currentFestival } = useFestival();
   const { data, loading: isLoading } = useAchievementsWithProgress(currentFestival?.id);
   const [activeCategory, setActiveCategory] = useState<CategoryFilter>("all");
+  const [activeScope, setActiveScope] = useState<SeriesScope>("festival");
 
-  const cards = data?.cards || [];
+  const allCards: SeriesCardData[] = data?.cards || [];
+  // Both scopes arrive in one response — the tabs are a filter, not a refetch.
+  const cards = allCards.filter((card) => card.scope === activeScope);
   const stats = data?.stats;
 
   const visibleCategories =
@@ -187,7 +196,14 @@ export default function AchievementsPage() {
         </div>
       )}
 
+      <ScopeTabs value={activeScope} onChange={setActiveScope} />
+
       <CategoryChips value={activeCategory} onChange={setActiveCategory} />
+
+      {/* Scope-filtered but deliberately not category-filtered: the rail is a
+          cross-category prompt, and narrowing it to one chip would routinely
+          empty it. */}
+      <CloseToUnlockingRail cards={cards} />
 
       {cards.length === 0 ? (
         <div className="py-12 text-center">

--- a/apps/web/app/(private)/achievements/page.tsx
+++ b/apps/web/app/(private)/achievements/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { SERIES_CATEGORY_ORDER, splitCardsByCompletion } from "@prostcounter/shared/achievements";
+import { buildStats, SERIES_CATEGORY_ORDER, splitCardsByCompletion } from "@prostcounter/shared/achievements";
 import { useFestival } from "@prostcounter/shared/contexts";
 import type {
   SeriesCard as SeriesCardData,
@@ -72,7 +72,7 @@ export default function AchievementsPage() {
   const allCards: SeriesCardData[] = data?.cards || [];
   // Both scopes arrive in one response — the tabs are a filter, not a refetch.
   const cards = allCards.filter((card) => card.scope === activeScope);
-  const stats = data?.stats;
+  const stats = data ? buildStats(cards) : undefined;
 
   const visibleCategories =
     activeCategory === "all" ? SERIES_CATEGORY_ORDER : [activeCategory as SeriesCategory];

--- a/apps/web/components/achievements/CloseToUnlockingRail.tsx
+++ b/apps/web/components/achievements/CloseToUnlockingRail.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import type { AchievementTier } from "@prostcounter/shared/achievements";
+import {
+  getActiveTier,
+  selectCloseToUnlocking,
+  tierToRarity,
+} from "@prostcounter/shared/achievements";
+import type { SeriesCard as SeriesCardData } from "@prostcounter/shared/schemas";
+
+import { Card, CardContent } from "@/components/ui/card";
+import { Progress } from "@/components/ui/progress";
+import { useTranslation } from "@/lib/i18n/client";
+
+import { AchievementBadge } from "./AchievementBadge";
+
+interface CloseToUnlockingRailProps {
+  cards: SeriesCardData[];
+}
+
+/**
+ * The three series nearest their next rung. Renders nothing at all when
+ * nothing qualifies — an empty rail is dead space, and a new user or an
+ * untouched scope legitimately has none.
+ */
+export function CloseToUnlockingRail({ cards }: CloseToUnlockingRailProps) {
+  const { t } = useTranslation();
+  const entries = selectCloseToUnlocking(cards);
+
+  if (entries.length === 0) {
+    return null;
+  }
+
+  return (
+    <section className="space-y-3">
+      <h2 className="text-xl font-semibold">{t("achievements.closeToUnlocking")}</h2>
+
+      <div className="grid grid-cols-1 gap-3 md:grid-cols-3">
+        {entries.map(({ card, currentValue, nextTarget, remaining, percentage }) => {
+          const activeTier = getActiveTier(card);
+
+          return (
+            <Card key={card.id} className="border-yellow-200 bg-yellow-50/30">
+              <CardContent className="flex items-center gap-3 p-4">
+                <AchievementBadge
+                  name=""
+                  icon={card.glyph}
+                  category={card.category}
+                  tier={activeTier.tier as AchievementTier}
+                  rarity={tierToRarity(activeTier.tier)}
+                  points={activeTier.points}
+                  isUnlocked={card.currentTier > 0}
+                  size="md"
+                />
+
+                <div className="min-w-0 flex-1 space-y-1.5">
+                  <p className="truncate text-sm font-semibold text-gray-800">
+                    {t(activeTier.name)}
+                  </p>
+                  <Progress value={percentage} />
+                  <p className="text-xs text-gray-600">
+                    {t("achievements.progressToNext", {
+                      current: currentValue,
+                      target: nextTarget,
+                      remaining,
+                    })}
+                  </p>
+                </div>
+              </CardContent>
+            </Card>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/components/achievements/ScopeTabs.tsx
+++ b/apps/web/components/achievements/ScopeTabs.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import type { SeriesScope } from "@prostcounter/shared/schemas";
+
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { useTranslation } from "@/lib/i18n/client";
+
+interface ScopeTabsProps {
+  value: SeriesScope;
+  onChange: (value: SeriesScope) => void;
+}
+
+/**
+ * Festival / all-time selector. Both tabs render the same section tree from
+ * the same response with a different filter, so there is no TabsContent —
+ * this is a controlled selector and the page does the filtering.
+ */
+export function ScopeTabs({ value, onChange }: ScopeTabsProps) {
+  const { t } = useTranslation();
+
+  return (
+    <Tabs value={value} onValueChange={(next) => onChange(next as SeriesScope)}>
+      <TabsList className="w-full">
+        <TabsTrigger value="festival">{t("achievements.scope.festival")}</TabsTrigger>
+        <TabsTrigger value="lifetime">{t("achievements.scope.allTime")}</TabsTrigger>
+      </TabsList>
+    </Tabs>
+  );
+}

--- a/apps/web/components/achievements/SeriesCard.tsx
+++ b/apps/web/components/achievements/SeriesCard.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { useState } from "react";
+
 import type { AchievementTier } from "@prostcounter/shared/achievements";
 import {
   getActiveTier,
@@ -14,6 +16,7 @@ import { useTranslation } from "@/lib/i18n/client";
 import { cn } from "@/lib/utils";
 
 import { AchievementBadge } from "./AchievementBadge";
+import { SeriesCardDetailSheet } from "./SeriesCardDetailSheet";
 
 const LOCKED_PIP_COLOR = "#D1D5DB";
 
@@ -24,6 +27,7 @@ interface SeriesCardProps {
 
 export function SeriesCard({ card, className }: SeriesCardProps) {
   const { t } = useTranslation();
+  const [isDetailOpen, setIsDetailOpen] = useState(false);
 
   // Never card.currentTier: that counts rungs cleared, which is not the badge
   // tier for a one-off. See getActiveTier's doc comment.
@@ -32,55 +36,69 @@ export function SeriesCard({ card, className }: SeriesCardProps) {
   const categoryColor = getCategoryColor(card.category);
 
   return (
-    <Card
-      className={cn(
-        "transition-all duration-200 hover:shadow-md",
-        isUnlocked ? "border-green-200 bg-green-50/30" : "border-gray-200 bg-white",
-        className,
-      )}
-    >
-      <CardContent className="flex items-center gap-3 p-4">
-        <AchievementBadge
-          name=""
-          icon={card.glyph}
-          category={card.category}
-          tier={activeTier.tier as AchievementTier}
-          rarity={tierToRarity(activeTier.tier)}
-          points={activeTier.points}
-          isUnlocked={isUnlocked}
-          size="md"
-        />
+    <>
+      <Card
+        role="button"
+        tabIndex={0}
+        aria-haspopup="dialog"
+        onClick={() => setIsDetailOpen(true)}
+        onKeyDown={(event) => {
+          if (event.key === "Enter" || event.key === " ") {
+            event.preventDefault();
+            setIsDetailOpen(true);
+          }
+        }}
+        className={cn(
+          "cursor-pointer transition-all duration-200 hover:shadow-md",
+          "focus-visible:ring-ring focus-visible:ring-2 focus-visible:outline-none",
+          isUnlocked ? "border-green-200 bg-green-50/30" : "border-gray-200 bg-white",
+          className,
+        )}
+      >
+        <CardContent className="flex items-center gap-3 p-4">
+          <AchievementBadge
+            name=""
+            icon={card.glyph}
+            category={card.category}
+            tier={activeTier.tier as AchievementTier}
+            rarity={tierToRarity(activeTier.tier)}
+            points={activeTier.points}
+            isUnlocked={isUnlocked}
+            size="md"
+          />
 
-        <div className="min-w-0 flex-1">
-          <p
-            className={cn(
-              "truncate text-sm font-semibold",
-              isUnlocked ? "text-green-800" : "text-gray-700",
-            )}
-          >
-            {t(activeTier.name)}
-          </p>
-          <p className="text-xs text-gray-600">
-            {isUnlocked
-              ? t(`achievements.tiers.${TIER_NAMES[activeTier.tier as AchievementTier]}`)
-              : t("achievements.locked")}
-          </p>
-        </div>
+          <div className="min-w-0 flex-1">
+            <p
+              className={cn(
+                "truncate text-sm font-semibold",
+                isUnlocked ? "text-green-800" : "text-gray-700",
+              )}
+            >
+              {t(activeTier.name)}
+            </p>
+            <p className="text-xs text-gray-600">
+              {isUnlocked
+                ? t(`achievements.tiers.${TIER_NAMES[activeTier.tier as AchievementTier]}`)
+                : t("achievements.locked")}
+            </p>
+          </div>
 
-        {/* Decorative: the tier label above already says this in words. */}
-        <div className="flex shrink-0 items-center gap-1" aria-hidden="true">
-          {card.tiers.map((tier) => (
-            <span
-              key={tier.tier}
-              className="size-2 rounded-full border"
-              style={{
-                backgroundColor: tier.isUnlocked ? categoryColor : "transparent",
-                borderColor: tier.isUnlocked ? categoryColor : LOCKED_PIP_COLOR,
-              }}
-            />
-          ))}
-        </div>
-      </CardContent>
-    </Card>
+          {/* Decorative: the tier label above already says this in words. */}
+          <div className="flex shrink-0 items-center gap-1" aria-hidden="true">
+            {card.tiers.map((tier) => (
+              <span
+                key={tier.tier}
+                className="size-2 rounded-full border"
+                style={{
+                  backgroundColor: tier.isUnlocked ? categoryColor : "transparent",
+                  borderColor: tier.isUnlocked ? categoryColor : LOCKED_PIP_COLOR,
+                }}
+              />
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+      <SeriesCardDetailSheet card={card} open={isDetailOpen} onOpenChange={setIsDetailOpen} />
+    </>
   );
 }

--- a/apps/web/components/achievements/SeriesCardDetailSheet.tsx
+++ b/apps/web/components/achievements/SeriesCardDetailSheet.tsx
@@ -55,7 +55,7 @@ export function SeriesCardDetailSheet({ card, open, onOpenChange }: SeriesCardDe
                       date: formatLocalized(new Date(tier.unlockedAt), "MMM d, yyyy"),
                     })}
                   </p>
-                ) : isNextRung && card.progress !== null ? (
+                ) : isNextRung && card.progress != null ? (
                   <p className="text-xs text-gray-600">
                     {t("achievements.progressToNext", {
                       current: card.progress.currentValue,

--- a/apps/web/components/achievements/SeriesCardDetailSheet.tsx
+++ b/apps/web/components/achievements/SeriesCardDetailSheet.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import type { AchievementTier } from "@prostcounter/shared/achievements";
+import { getActiveTier, TIER_NAMES } from "@prostcounter/shared/achievements";
+import type { SeriesCard as SeriesCardData } from "@prostcounter/shared/schemas";
+import { formatLocalized } from "@prostcounter/shared/utils";
+
+import ResponsiveDialog from "@/components/ResponsiveDialog";
+import { useTranslation } from "@/lib/i18n/client";
+import { cn } from "@/lib/utils";
+
+interface SeriesCardDetailSheetProps {
+  card: SeriesCardData;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+/** Every rung of one card: which are earned, when, and how far the next one is. */
+export function SeriesCardDetailSheet({ card, open, onOpenChange }: SeriesCardDetailSheetProps) {
+  const { t } = useTranslation();
+  const activeTier = getActiveTier(card);
+
+  return (
+    <ResponsiveDialog
+      open={open}
+      onOpenChange={onOpenChange}
+      title={t(activeTier.name)}
+      description={t(`achievements.categories.${card.category}`)}
+    >
+      <div className="space-y-2 px-4 pb-4 md:px-0 md:pb-0">
+        {card.tiers.map((tier) => {
+          // Only a series has a "next" rung; a one-off's single rung carries a
+          // difficulty tier that never lines up with currentTier + 1.
+          const isNextRung = !tier.isUnlocked && tier.tier === card.currentTier + 1;
+
+          return (
+            <div
+              key={tier.tier}
+              className={cn(
+                "flex items-start justify-between gap-3 rounded-md border p-3",
+                tier.isUnlocked ? "border-green-200 bg-green-50/30" : "border-gray-200",
+              )}
+            >
+              <div className="min-w-0">
+                <p className="truncate text-sm font-medium text-gray-800">{t(tier.name)}</p>
+                <p className="text-xs text-gray-600">
+                  {t(`achievements.tiers.${TIER_NAMES[tier.tier as AchievementTier]}`)}
+                </p>
+              </div>
+
+              <div className="shrink-0 text-right">
+                {tier.isUnlocked && tier.unlockedAt !== null ? (
+                  <p className="text-xs text-green-700">
+                    {t("achievements.unlockedOn", {
+                      date: formatLocalized(new Date(tier.unlockedAt), "MMM d, yyyy"),
+                    })}
+                  </p>
+                ) : isNextRung && card.progress !== null ? (
+                  <p className="text-xs text-gray-600">
+                    {t("achievements.progressToNext", {
+                      current: card.progress.currentValue,
+                      target: card.progress.nextTarget,
+                      remaining: card.progress.nextTarget - card.progress.currentValue,
+                    })}
+                  </p>
+                ) : (
+                  <p className="text-xs text-gray-500">{t("achievements.locked")}</p>
+                )}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </ResponsiveDialog>
+  );
+}

--- a/packages/api-client/src/generated.ts
+++ b/packages/api-client/src/generated.ts
@@ -3791,8 +3791,13 @@ export interface paths {
                                     name: string;
                                     points: number;
                                     isUnlocked: boolean;
+                                    /** Format: date-time */
                                     unlockedAt: string | null;
                                 }[];
+                                progress: {
+                                    currentValue: number;
+                                    nextTarget: number;
+                                } | null;
                             }[];
                             recentUnlocks: {
                                 id: string;
@@ -3804,6 +3809,7 @@ export interface paths {
                                 /** @enum {string} */
                                 scope: "festival" | "lifetime";
                                 points: number;
+                                /** Format: date-time */
                                 unlockedAt: string;
                             }[];
                             stats: {

--- a/packages/api/openapi.json
+++ b/packages/api/openapi.json
@@ -6781,7 +6781,8 @@
                                 },
                                 "unlockedAt": {
                                   "type": "string",
-                                  "nullable": true
+                                  "nullable": true,
+                                  "format": "date-time"
                                 }
                               },
                               "required": [
@@ -6791,7 +6792,27 @@
                                 "isUnlocked",
                                 "unlockedAt"
                               ]
-                            }
+                            },
+                            "minItems": 1
+                          },
+                          "progress": {
+                            "type": "object",
+                            "nullable": true,
+                            "properties": {
+                              "currentValue": {
+                                "type": "number",
+                                "minimum": 0
+                              },
+                              "nextTarget": {
+                                "type": "number",
+                                "minimum": 0,
+                                "exclusiveMinimum": true
+                              }
+                            },
+                            "required": [
+                              "currentValue",
+                              "nextTarget"
+                            ]
                           }
                         },
                         "required": [
@@ -6800,7 +6821,8 @@
                           "scope",
                           "glyph",
                           "currentTier",
-                          "tiers"
+                          "tiers",
+                          "progress"
                         ]
                       }
                     },
@@ -6845,7 +6867,8 @@
                             "type": "integer"
                           },
                           "unlockedAt": {
-                            "type": "string"
+                            "type": "string",
+                            "format": "date-time"
                           }
                         },
                         "required": [

--- a/packages/api/src/__tests__/helpers/achievement-metrics.ts
+++ b/packages/api/src/__tests__/helpers/achievement-metrics.ts
@@ -1,0 +1,38 @@
+import type { AchievementMetrics } from "@prostcounter/shared/achievements";
+
+/** Every metric at its zero value, for tests that care about only one or two. */
+export function emptyMetrics(overrides: Partial<AchievementMetrics> = {}): AchievementMetrics {
+  return {
+    drinks_total: 0,
+    drinks_day_max: 0,
+    drink_types_distinct: 0,
+    volume_ml_total: 0,
+    tip_cents_total: 0,
+    spend_cents_total: 0,
+    days_attended: 0,
+    attendance_streak_max: 0,
+    tents_distinct: 0,
+    groups_joined: 0,
+    photos_uploaded: 0,
+    reactions_given: 0,
+    crowd_reports: 0,
+    festivals_attended: 0,
+    festival_types_distinct: 0,
+    friends_accepted: 0,
+    group_wins: 0,
+    podium_finishes: 0,
+    active_days_total: 0,
+    active_day_streak_max: 0,
+    attended_opening_day: false,
+    attended_closing_day: false,
+    attended_every_day: false,
+    attended_every_weekend_day: false,
+    visited_all_large_tents: false,
+    created_group: false,
+    logged_first_drink: false,
+    uploaded_first_photo: false,
+    profile_complete: false,
+    wrapped_viewed: false,
+    ...overrides,
+  };
+}

--- a/packages/api/src/routes/__tests__/achievement.route.test.ts
+++ b/packages/api/src/routes/__tests__/achievement.route.test.ts
@@ -6,6 +6,7 @@ import {
   mockSupabaseError,
   mockSupabaseSuccess,
 } from "../../__tests__/helpers/mock-supabase";
+import { emptyMetrics } from "../../__tests__/helpers/achievement-metrics";
 import {
   createAuthRequest,
   createMockUser,
@@ -524,6 +525,23 @@ describe("Achievement Routes - Unit Tests", () => {
         ),
       );
 
+      // getProgress -> getMetrics
+      vi.mocked(mockSupabase.rpc).mockResolvedValueOnce({
+        data: emptyMetrics({ drinks_total: 7 }),
+        error: null,
+      } as any);
+
+      // getProgress -> getHeldSlugs
+      vi.mocked(mockSupabase.from).mockReturnValueOnce(
+        createMockChain(
+          mockSupabaseSuccess([
+            { achievements: { slug: "drinks_total.t1" } },
+            { achievements: { slug: "drinks_total.t2" } },
+            { achievements: { slug: "first_drink" } },
+          ]),
+        ),
+      );
+
       const req = createAuthRequest(`/achievements/with-progress?festivalId=${festivalId}`, {
         method: "GET",
       });
@@ -555,6 +573,8 @@ describe("Achievement Routes - Unit Tests", () => {
       expect(body.stats.unlocked_achievements).toBe(3);
       expect(body.stats.total_achievements).toBe(90);
       expect(Object.keys(body.stats.breakdown_by_category)).not.toContain("consumption");
+      expect(drinksTotal.progress).toEqual({ currentValue: 7, nextTarget: expect.any(Number) });
+      expect(firstDrink.progress).toBeNull();
     });
 
     it("returns every card locked when the user holds nothing", async () => {
@@ -563,6 +583,13 @@ describe("Achievement Routes - Unit Tests", () => {
       vi.mocked(mockSupabase.from).mockReturnValueOnce(
         createMockChain(mockSupabaseSuccess([])),
       );
+
+      vi.mocked(mockSupabase.rpc).mockResolvedValueOnce({
+        data: emptyMetrics(),
+        error: null,
+      } as any);
+
+      vi.mocked(mockSupabase.from).mockReturnValueOnce(createMockChain(mockSupabaseSuccess([])));
 
       const req = createAuthRequest(`/achievements/with-progress?festivalId=${festivalId}`, {
         method: "GET",
@@ -581,6 +608,7 @@ describe("Achievement Routes - Unit Tests", () => {
       expect(body.recentUnlocks).toEqual([]);
       expect(body.stats.unlocked_achievements).toBe(0);
       expect(body.stats.total_points).toBe(0);
+      expect(body.cards.every((card: any) => card.progress !== undefined)).toBe(true);
     });
   });
 

--- a/packages/api/src/routes/__tests__/achievement.route.test.ts
+++ b/packages/api/src/routes/__tests__/achievement.route.test.ts
@@ -1,12 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { emptyMetrics } from "../../__tests__/helpers/achievement-metrics";
 import {
   createMockChain,
   createMockSupabase,
   mockSupabaseError,
   mockSupabaseSuccess,
 } from "../../__tests__/helpers/mock-supabase";
-import { emptyMetrics } from "../../__tests__/helpers/achievement-metrics";
 import {
   createAuthRequest,
   createMockUser,
@@ -531,17 +531,6 @@ describe("Achievement Routes - Unit Tests", () => {
         error: null,
       } as any);
 
-      // getProgress -> getHeldSlugs
-      vi.mocked(mockSupabase.from).mockReturnValueOnce(
-        createMockChain(
-          mockSupabaseSuccess([
-            { achievements: { slug: "drinks_total.t1" } },
-            { achievements: { slug: "drinks_total.t2" } },
-            { achievements: { slug: "first_drink" } },
-          ]),
-        ),
-      );
-
       const req = createAuthRequest(`/achievements/with-progress?festivalId=${festivalId}`, {
         method: "GET",
       });
@@ -580,16 +569,12 @@ describe("Achievement Routes - Unit Tests", () => {
     it("returns every card locked when the user holds nothing", async () => {
       const festivalId = "123e4567-e89b-12d3-a456-426614174000";
 
-      vi.mocked(mockSupabase.from).mockReturnValueOnce(
-        createMockChain(mockSupabaseSuccess([])),
-      );
+      vi.mocked(mockSupabase.from).mockReturnValueOnce(createMockChain(mockSupabaseSuccess([])));
 
       vi.mocked(mockSupabase.rpc).mockResolvedValueOnce({
         data: emptyMetrics(),
         error: null,
       } as any);
-
-      vi.mocked(mockSupabase.from).mockReturnValueOnce(createMockChain(mockSupabaseSuccess([])));
 
       const req = createAuthRequest(`/achievements/with-progress?festivalId=${festivalId}`, {
         method: "GET",

--- a/packages/api/src/routes/__tests__/achievement.route.test.ts
+++ b/packages/api/src/routes/__tests__/achievement.route.test.ts
@@ -525,7 +525,7 @@ describe("Achievement Routes - Unit Tests", () => {
         ),
       );
 
-      // getProgress -> getMetrics
+      // getMetrics
       vi.mocked(mockSupabase.rpc).mockResolvedValueOnce({
         data: emptyMetrics({ drinks_total: 7 }),
         error: null,

--- a/packages/api/src/routes/achievement.route.ts
+++ b/packages/api/src/routes/achievement.route.ts
@@ -1,8 +1,5 @@
 import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi";
-import type {
-  AchievementLeaderboardEntry,
-  AvailableAchievement,
-} from "@prostcounter/shared";
+import type { AchievementLeaderboardEntry, AvailableAchievement } from "@prostcounter/shared";
 import {
   EvaluateAchievementsResponseSchema,
   EvaluateAchievementsSchema,
@@ -12,16 +9,12 @@ import {
   ListAchievementsResponseSchema,
   ListAvailableAchievementsResponseSchema,
 } from "@prostcounter/shared";
+import { evaluate } from "@prostcounter/shared/achievements";
 
 import type { AuthContext } from "../middleware/auth";
 import { AchievementMetricsRepository } from "../repositories/supabase/achievement-metrics.repository";
 import { SupabaseAchievementRepository } from "../repositories/supabase";
-import {
-  buildRecentUnlocks,
-  buildSeriesCards,
-  buildStats,
-} from "../services/achievement-cards";
-import { AchievementService } from "../services/achievement.service";
+import { buildRecentUnlocks, buildSeriesCards, buildStats } from "../services/achievement-cards";
 
 // Create router
 const app = new OpenAPIHono<AuthContext>();
@@ -193,20 +186,27 @@ app.openapi(getAchievementsWithProgressRoute, async (c) => {
   const query = c.req.valid("query");
 
   const metricsRepo = new AchievementMetricsRepository(supabase);
-  const achievementService = new AchievementService(metricsRepo);
 
   // The definition tables already describe every card; the database answers
   // which slugs this user holds and when they landed, plus the raw metric
   // values the rail needs. currentTier still comes from the unlock rows, so it
   // cannot contradict the per-rung unlocked flags — see buildCardProgress for
   // why the metrics-derived nextTarget is deliberately ignored.
-  const [unlockDates, evaluation] = await Promise.all([
+  //
+  // Calls getMetrics + evaluate() directly instead of going through
+  // AchievementService.getProgress(), which would also issue its own
+  // getHeldSlugs() query — a second, redundant read of the exact same
+  // user_achievements rows unlockDates below already fetched, whose only
+  // output (evaluation.unlocked) this route never uses.
+  const [unlockDates, metrics] = await Promise.all([
     metricsRepo.getHeldSlugsWithUnlockDates(user.id, query.festivalId),
-    achievementService.getProgress(user.id, query.festivalId),
+    metricsRepo.getMetrics(user.id, query.festivalId),
   ]);
 
+  const { progress } = evaluate(metrics, new Set(unlockDates.keys()));
+
   const progressBySeriesId = new Map(
-    evaluation.progress.map((seriesProgress) => [seriesProgress.seriesId, seriesProgress]),
+    progress.map((seriesProgress) => [seriesProgress.seriesId, seriesProgress]),
   );
   const cards = buildSeriesCards(unlockDates, progressBySeriesId);
 

--- a/packages/api/src/routes/achievement.route.ts
+++ b/packages/api/src/routes/achievement.route.ts
@@ -9,8 +9,7 @@ import {
   ListAchievementsResponseSchema,
   ListAvailableAchievementsResponseSchema,
 } from "@prostcounter/shared";
-import { evaluate } from "@prostcounter/shared/achievements";
-import { buildStats } from "@prostcounter/shared/achievements";
+import { buildStats, evaluate } from "@prostcounter/shared/achievements";
 
 import type { AuthContext } from "../middleware/auth";
 import { AchievementMetricsRepository } from "../repositories/supabase/achievement-metrics.repository";

--- a/packages/api/src/routes/achievement.route.ts
+++ b/packages/api/src/routes/achievement.route.ts
@@ -21,6 +21,7 @@ import {
   buildSeriesCards,
   buildStats,
 } from "../services/achievement-cards";
+import { AchievementService } from "../services/achievement.service";
 
 // Create router
 const app = new OpenAPIHono<AuthContext>();
@@ -192,13 +193,22 @@ app.openapi(getAchievementsWithProgressRoute, async (c) => {
   const query = c.req.valid("query");
 
   const metricsRepo = new AchievementMetricsRepository(supabase);
+  const achievementService = new AchievementService(metricsRepo);
 
-  // The definition tables already describe every card; the only thing the
-  // database has to answer is which slugs this user holds and when they
-  // landed. Deriving currentTier from those rows rather than from live
-  // metrics keeps it from contradicting the per-rung unlocked flags.
-  const unlockDates = await metricsRepo.getHeldSlugsWithUnlockDates(user.id, query.festivalId);
-  const cards = buildSeriesCards(unlockDates);
+  // The definition tables already describe every card; the database answers
+  // which slugs this user holds and when they landed, plus the raw metric
+  // values the rail needs. currentTier still comes from the unlock rows, so it
+  // cannot contradict the per-rung unlocked flags — see buildCardProgress for
+  // why the metrics-derived nextTarget is deliberately ignored.
+  const [unlockDates, evaluation] = await Promise.all([
+    metricsRepo.getHeldSlugsWithUnlockDates(user.id, query.festivalId),
+    achievementService.getProgress(user.id, query.festivalId),
+  ]);
+
+  const progressBySeriesId = new Map(
+    evaluation.progress.map((seriesProgress) => [seriesProgress.seriesId, seriesProgress]),
+  );
+  const cards = buildSeriesCards(unlockDates, progressBySeriesId);
 
   return c.json(
     {

--- a/packages/api/src/routes/achievement.route.ts
+++ b/packages/api/src/routes/achievement.route.ts
@@ -10,11 +10,12 @@ import {
   ListAvailableAchievementsResponseSchema,
 } from "@prostcounter/shared";
 import { evaluate } from "@prostcounter/shared/achievements";
+import { buildStats } from "@prostcounter/shared/achievements";
 
 import type { AuthContext } from "../middleware/auth";
 import { AchievementMetricsRepository } from "../repositories/supabase/achievement-metrics.repository";
 import { SupabaseAchievementRepository } from "../repositories/supabase";
-import { buildRecentUnlocks, buildSeriesCards, buildStats } from "../services/achievement-cards";
+import { buildRecentUnlocks, buildSeriesCards } from "../services/achievement-cards";
 
 // Create router
 const app = new OpenAPIHono<AuthContext>();

--- a/packages/api/src/services/__tests__/achievement-cards.test.ts
+++ b/packages/api/src/services/__tests__/achievement-cards.test.ts
@@ -1,6 +1,8 @@
+import { SeriesCardSchema } from "@prostcounter/shared";
 import type { SeriesProgress } from "@prostcounter/shared/achievements";
-import { ONE_OFFS, SERIES } from "@prostcounter/shared/achievements";
+import { ONE_OFFS, selectCloseToUnlocking, SERIES } from "@prostcounter/shared/achievements";
 import { describe, expect, it } from "vitest";
+import { z } from "zod";
 
 import { buildRecentUnlocks, buildSeriesCards, buildStats } from "../achievement-cards";
 
@@ -18,7 +20,9 @@ describe("buildSeriesCards", () => {
   });
 
   it("gives an untouched series four locked rungs and currentTier 0", () => {
-    const card = buildSeriesCards(new Map(), new Map()).find((entry) => entry.id === "drinks_total");
+    const card = buildSeriesCards(new Map(), new Map()).find(
+      (entry) => entry.id === "drinks_total",
+    );
 
     expect(card?.currentTier).toBe(0);
     expect(card?.tiers).toHaveLength(4);
@@ -33,7 +37,9 @@ describe("buildSeriesCards", () => {
       ["drinks_total.t2", "2026-09-21T10:00:00Z"],
     ]);
 
-    const card = buildSeriesCards(unlockDates, new Map()).find((entry) => entry.id === "drinks_total");
+    const card = buildSeriesCards(unlockDates, new Map()).find(
+      (entry) => entry.id === "drinks_total",
+    );
 
     expect(card?.currentTier).toBe(2);
     expect(card?.tiers.map((tier) => tier.isUnlocked)).toEqual([true, true, false, false]);
@@ -45,11 +51,16 @@ describe("buildSeriesCards", () => {
       [1, 2, 3, 4].map((tier) => [`drinks_total.t${tier}`, "2026-09-20T10:00:00Z"] as const),
     );
 
-    expect(buildSeriesCards(unlockDates, new Map()).find((entry) => entry.id === "drinks_total")?.currentTier).toBe(4);
+    expect(
+      buildSeriesCards(unlockDates, new Map()).find((entry) => entry.id === "drinks_total")
+        ?.currentTier,
+    ).toBe(4);
   });
 
   it("maps a one-off to a single-rung card keeping its difficulty tier", () => {
-    const locked = buildSeriesCards(new Map(), new Map()).find((entry) => entry.id === "full_festival");
+    const locked = buildSeriesCards(new Map(), new Map()).find(
+      (entry) => entry.id === "full_festival",
+    );
 
     expect(locked?.tiers).toHaveLength(1);
     expect(locked?.currentTier).toBe(0);
@@ -177,10 +188,9 @@ describe("buildSeriesCards progress", () => {
   });
 
   it("is always null for a one-off", () => {
-    const card = buildSeriesCards(
-      new Map(),
-      progressFor("first_drink", 1),
-    ).find((entry) => entry.id === "first_drink");
+    const card = buildSeriesCards(new Map(), progressFor("first_drink", 1)).find(
+      (entry) => entry.id === "first_drink",
+    );
 
     expect(card?.progress).toBeNull();
   });
@@ -216,5 +226,18 @@ describe("buildSeriesCards progress", () => {
     );
 
     expect(card?.progress).toBeNull();
+  });
+});
+
+describe("buildSeriesCards pipeline", () => {
+  it("produces cards that satisfy the response schema and feed the rail", () => {
+    const unlockDates = new Map([
+      ["drinks_total.t1", "2026-09-20T10:00:00Z"],
+      ["drinks_total.t2", "2026-09-21T10:00:00Z"],
+    ]);
+    const cards = buildSeriesCards(unlockDates, progressFor("drinks_total", 30));
+
+    expect(() => z.array(SeriesCardSchema).parse(cards)).not.toThrow();
+    expect(selectCloseToUnlocking(cards).length).toBeGreaterThan(0);
   });
 });

--- a/packages/api/src/services/__tests__/achievement-cards.test.ts
+++ b/packages/api/src/services/__tests__/achievement-cards.test.ts
@@ -4,7 +4,7 @@ import { ONE_OFFS, selectCloseToUnlocking, SERIES } from "@prostcounter/shared/a
 import { describe, expect, it } from "vitest";
 import { z } from "zod";
 
-import { buildRecentUnlocks, buildSeriesCards, buildStats } from "../achievement-cards";
+import { buildRecentUnlocks, buildSeriesCards } from "../achievement-cards";
 
 describe("buildSeriesCards", () => {
   it("returns one card per definition, series first, in definition order", () => {
@@ -116,47 +116,6 @@ describe("buildRecentUnlocks", () => {
 
     expect(buildRecentUnlocks(buildSeriesCards(unlockDates, new Map()))).toHaveLength(10);
     expect(buildRecentUnlocks(buildSeriesCards(unlockDates, new Map()), 3)).toHaveLength(3);
-  });
-});
-
-describe("buildStats", () => {
-  it("counts every rung, not every card", () => {
-    const stats = buildStats(buildSeriesCards(new Map(), new Map()));
-
-    expect(stats.total_achievements).toBe(SERIES.length * 4 + ONE_OFFS.length);
-    expect(stats.unlocked_achievements).toBe(0);
-    expect(stats.total_points).toBe(0);
-  });
-
-  it("has exactly the six live category buckets", () => {
-    const stats = buildStats(buildSeriesCards(new Map(), new Map()));
-
-    expect(Object.keys(stats.breakdown_by_category).sort()).toEqual([
-      "attendance",
-      "competitive",
-      "dedication",
-      "drinking",
-      "explorer",
-      "social",
-    ]);
-  });
-
-  it("accumulates unlocked counts and points into both breakdowns", () => {
-    const unlockDates = new Map([
-      ["drinks_total.t1", "2026-09-20T10:00:00Z"],
-      ["drinks_total.t2", "2026-09-21T10:00:00Z"],
-      ["full_festival", "2026-10-05T10:00:00Z"],
-    ]);
-
-    const stats = buildStats(buildSeriesCards(unlockDates, new Map()));
-
-    expect(stats.unlocked_achievements).toBe(3);
-    expect(stats.total_points).toBe(10 + 50 + 600);
-    expect(stats.breakdown_by_category.drinking).toMatchObject({ unlocked: 2, points: 60 });
-    expect(stats.breakdown_by_category.attendance).toMatchObject({ unlocked: 1, points: 600 });
-    expect(stats.breakdown_by_rarity.common).toMatchObject({ unlocked: 1, points: 10 });
-    expect(stats.breakdown_by_rarity.rare).toMatchObject({ unlocked: 1, points: 50 });
-    expect(stats.breakdown_by_rarity.legendary).toMatchObject({ unlocked: 1, points: 600 });
   });
 });
 

--- a/packages/api/src/services/__tests__/achievement-cards.test.ts
+++ b/packages/api/src/services/__tests__/achievement-cards.test.ts
@@ -1,3 +1,4 @@
+import type { SeriesProgress } from "@prostcounter/shared/achievements";
 import { ONE_OFFS, SERIES } from "@prostcounter/shared/achievements";
 import { describe, expect, it } from "vitest";
 
@@ -5,7 +6,7 @@ import { buildRecentUnlocks, buildSeriesCards, buildStats } from "../achievement
 
 describe("buildSeriesCards", () => {
   it("returns one card per definition, series first, in definition order", () => {
-    const cards = buildSeriesCards(new Map());
+    const cards = buildSeriesCards(new Map(), new Map());
 
     expect(cards).toHaveLength(SERIES.length + ONE_OFFS.length);
     expect(cards.slice(0, SERIES.length).map((card) => card.id)).toEqual(
@@ -17,7 +18,7 @@ describe("buildSeriesCards", () => {
   });
 
   it("gives an untouched series four locked rungs and currentTier 0", () => {
-    const card = buildSeriesCards(new Map()).find((entry) => entry.id === "drinks_total");
+    const card = buildSeriesCards(new Map(), new Map()).find((entry) => entry.id === "drinks_total");
 
     expect(card?.currentTier).toBe(0);
     expect(card?.tiers).toHaveLength(4);
@@ -32,7 +33,7 @@ describe("buildSeriesCards", () => {
       ["drinks_total.t2", "2026-09-21T10:00:00Z"],
     ]);
 
-    const card = buildSeriesCards(unlockDates).find((entry) => entry.id === "drinks_total");
+    const card = buildSeriesCards(unlockDates, new Map()).find((entry) => entry.id === "drinks_total");
 
     expect(card?.currentTier).toBe(2);
     expect(card?.tiers.map((tier) => tier.isUnlocked)).toEqual([true, true, false, false]);
@@ -44,11 +45,11 @@ describe("buildSeriesCards", () => {
       [1, 2, 3, 4].map((tier) => [`drinks_total.t${tier}`, "2026-09-20T10:00:00Z"] as const),
     );
 
-    expect(buildSeriesCards(unlockDates).find((entry) => entry.id === "drinks_total")?.currentTier).toBe(4);
+    expect(buildSeriesCards(unlockDates, new Map()).find((entry) => entry.id === "drinks_total")?.currentTier).toBe(4);
   });
 
   it("maps a one-off to a single-rung card keeping its difficulty tier", () => {
-    const locked = buildSeriesCards(new Map()).find((entry) => entry.id === "full_festival");
+    const locked = buildSeriesCards(new Map(), new Map()).find((entry) => entry.id === "full_festival");
 
     expect(locked?.tiers).toHaveLength(1);
     expect(locked?.currentTier).toBe(0);
@@ -57,6 +58,7 @@ describe("buildSeriesCards", () => {
 
     const unlocked = buildSeriesCards(
       new Map([["full_festival", "2026-10-05T10:00:00Z"]]),
+      new Map(),
     ).find((entry) => entry.id === "full_festival");
 
     expect(unlocked?.currentTier).toBe(1);
@@ -67,7 +69,7 @@ describe("buildSeriesCards", () => {
 
 describe("buildRecentUnlocks", () => {
   it("returns nothing when nothing is unlocked", () => {
-    expect(buildRecentUnlocks(buildSeriesCards(new Map()))).toEqual([]);
+    expect(buildRecentUnlocks(buildSeriesCards(new Map(), new Map()))).toEqual([]);
   });
 
   it("sorts newest first and keys each unlock by its slug", () => {
@@ -77,7 +79,7 @@ describe("buildRecentUnlocks", () => {
       ["first_drink", "2026-09-21T10:00:00Z"],
     ]);
 
-    const recent = buildRecentUnlocks(buildSeriesCards(unlockDates));
+    const recent = buildRecentUnlocks(buildSeriesCards(unlockDates, new Map()));
 
     expect(recent.map((unlock) => unlock.id)).toEqual([
       "drinks_total.t2",
@@ -101,14 +103,14 @@ describe("buildRecentUnlocks", () => {
       ),
     );
 
-    expect(buildRecentUnlocks(buildSeriesCards(unlockDates))).toHaveLength(10);
-    expect(buildRecentUnlocks(buildSeriesCards(unlockDates), 3)).toHaveLength(3);
+    expect(buildRecentUnlocks(buildSeriesCards(unlockDates, new Map()))).toHaveLength(10);
+    expect(buildRecentUnlocks(buildSeriesCards(unlockDates, new Map()), 3)).toHaveLength(3);
   });
 });
 
 describe("buildStats", () => {
   it("counts every rung, not every card", () => {
-    const stats = buildStats(buildSeriesCards(new Map()));
+    const stats = buildStats(buildSeriesCards(new Map(), new Map()));
 
     expect(stats.total_achievements).toBe(SERIES.length * 4 + ONE_OFFS.length);
     expect(stats.unlocked_achievements).toBe(0);
@@ -116,7 +118,7 @@ describe("buildStats", () => {
   });
 
   it("has exactly the six live category buckets", () => {
-    const stats = buildStats(buildSeriesCards(new Map()));
+    const stats = buildStats(buildSeriesCards(new Map(), new Map()));
 
     expect(Object.keys(stats.breakdown_by_category).sort()).toEqual([
       "attendance",
@@ -135,7 +137,7 @@ describe("buildStats", () => {
       ["full_festival", "2026-10-05T10:00:00Z"],
     ]);
 
-    const stats = buildStats(buildSeriesCards(unlockDates));
+    const stats = buildStats(buildSeriesCards(unlockDates, new Map()));
 
     expect(stats.unlocked_achievements).toBe(3);
     expect(stats.total_points).toBe(10 + 50 + 600);
@@ -144,5 +146,75 @@ describe("buildStats", () => {
     expect(stats.breakdown_by_rarity.common).toMatchObject({ unlocked: 1, points: 10 });
     expect(stats.breakdown_by_rarity.rare).toMatchObject({ unlocked: 1, points: 50 });
     expect(stats.breakdown_by_rarity.legendary).toMatchObject({ unlocked: 1, points: 600 });
+  });
+});
+
+function progressFor(seriesId: string, currentValue: number): Map<string, SeriesProgress> {
+  return new Map([
+    [
+      seriesId,
+      {
+        seriesId,
+        category: "drinking",
+        scope: "festival",
+        glyph: "masskrug",
+        // Deliberately wrong on purpose: the builder must ignore these two and
+        // read the definition table instead.
+        currentTier: 4,
+        nextTarget: 1,
+        currentValue,
+        percentage: 0,
+      } satisfies SeriesProgress,
+    ],
+  ]);
+}
+
+describe("buildSeriesCards progress", () => {
+  it("is null for every card when no progress is supplied", () => {
+    const cards = buildSeriesCards(new Map(), new Map());
+
+    expect(cards.every((card) => card.progress === null)).toBe(true);
+  });
+
+  it("is always null for a one-off", () => {
+    const card = buildSeriesCards(
+      new Map(),
+      progressFor("first_drink", 1),
+    ).find((entry) => entry.id === "first_drink");
+
+    expect(card?.progress).toBeNull();
+  });
+
+  it("targets the rung after the highest one actually unlocked", () => {
+    const unlockDates = new Map([["drinks_total.t1", "2026-09-20T10:00:00Z"]]);
+    const card = buildSeriesCards(unlockDates, progressFor("drinks_total", 7)).find(
+      (entry) => entry.id === "drinks_total",
+    );
+
+    const tierTwoTarget = SERIES.find((series) => series.id === "drinks_total")?.tiers[1].target;
+
+    expect(card?.currentTier).toBe(1);
+    expect(card?.progress).toEqual({ currentValue: 7, nextTarget: tierTwoTarget });
+  });
+
+  it("caps currentValue at the target when metrics run ahead of unlock rows", () => {
+    const card = buildSeriesCards(new Map(), progressFor("drinks_total", 9999)).find(
+      (entry) => entry.id === "drinks_total",
+    );
+
+    const tierOneTarget = SERIES.find((series) => series.id === "drinks_total")?.tiers[0].target;
+
+    expect(card?.progress).toEqual({ currentValue: tierOneTarget, nextTarget: tierOneTarget });
+  });
+
+  it("is null once every rung is unlocked", () => {
+    const unlockDates = new Map(
+      [1, 2, 3, 4].map((tier) => [`drinks_total.t${tier}`, "2026-09-20T10:00:00Z"] as const),
+    );
+    const card = buildSeriesCards(unlockDates, progressFor("drinks_total", 500)).find(
+      (entry) => entry.id === "drinks_total",
+    );
+
+    expect(card?.progress).toBeNull();
   });
 });

--- a/packages/api/src/services/__tests__/achievement.service.test.ts
+++ b/packages/api/src/services/__tests__/achievement.service.test.ts
@@ -1,43 +1,8 @@
 import type { AchievementMetrics, UnlockedAchievement } from "@prostcounter/shared/achievements";
 import { describe, expect, it } from "vitest";
 
+import { emptyMetrics } from "../../__tests__/helpers/achievement-metrics";
 import { AchievementService } from "../achievement.service";
-
-function emptyMetrics(overrides: Partial<AchievementMetrics> = {}): AchievementMetrics {
-  return {
-    drinks_total: 0,
-    drinks_day_max: 0,
-    drink_types_distinct: 0,
-    volume_ml_total: 0,
-    tip_cents_total: 0,
-    spend_cents_total: 0,
-    days_attended: 0,
-    attendance_streak_max: 0,
-    tents_distinct: 0,
-    groups_joined: 0,
-    photos_uploaded: 0,
-    reactions_given: 0,
-    crowd_reports: 0,
-    festivals_attended: 0,
-    festival_types_distinct: 0,
-    friends_accepted: 0,
-    group_wins: 0,
-    podium_finishes: 0,
-    active_days_total: 0,
-    active_day_streak_max: 0,
-    attended_opening_day: false,
-    attended_closing_day: false,
-    attended_every_day: false,
-    attended_every_weekend_day: false,
-    visited_all_large_tents: false,
-    created_group: false,
-    logged_first_drink: false,
-    uploaded_first_photo: false,
-    profile_complete: false,
-    wrapped_viewed: false,
-    ...overrides,
-  };
-}
 
 function makeRepo(metrics: AchievementMetrics, held: Set<string> = new Set()) {
   const inserted: UnlockedAchievement[] = [];

--- a/packages/api/src/services/achievement-cards.ts
+++ b/packages/api/src/services/achievement-cards.ts
@@ -1,12 +1,4 @@
-import type {
-  AchievementRarity,
-  AchievementStats,
-  BreakdownStats,
-  RecentUnlock,
-  SeriesCard,
-  SeriesCategory,
-  SeriesTier,
-} from "@prostcounter/shared";
+import type { RecentUnlock, SeriesCard, SeriesTier } from "@prostcounter/shared";
 import type { SeriesProgress } from "@prostcounter/shared/achievements";
 import { ONE_OFFS, SERIES, slugFor, tierToRarity } from "@prostcounter/shared/achievements";
 
@@ -20,10 +12,6 @@ function nameKeyFor(slug: string): string {
 /** A rung's slug, recovered from the card it belongs to. One-offs have a single rung. */
 function slugForCardTier(card: SeriesCard, tier: SeriesTier): string {
   return card.tiers.length > 1 ? `${card.id}.t${tier.tier}` : card.id;
-}
-
-function emptyBreakdown(): BreakdownStats {
-  return { total: 0, unlocked: 0, points: 0 };
 }
 
 /**
@@ -164,59 +152,4 @@ export function buildRecentUnlocks(
   unlocks.sort((a, b) => Date.parse(b.unlockedAt) - Date.parse(a.unlockedAt));
 
   return unlocks.slice(0, limit);
-}
-
-/**
- * Totals over rungs, not cards: 90 unlockable slugs across 30 cards. Rarity
- * buckets come from each rung's own tier, so a card contributes to several.
- */
-export function buildStats(cards: SeriesCard[]): AchievementStats {
-  const breakdownByCategory: Record<SeriesCategory, BreakdownStats> = {
-    drinking: emptyBreakdown(),
-    attendance: emptyBreakdown(),
-    explorer: emptyBreakdown(),
-    social: emptyBreakdown(),
-    competitive: emptyBreakdown(),
-    dedication: emptyBreakdown(),
-  };
-
-  const breakdownByRarity: Record<AchievementRarity, BreakdownStats> = {
-    common: emptyBreakdown(),
-    rare: emptyBreakdown(),
-    epic: emptyBreakdown(),
-    legendary: emptyBreakdown(),
-  };
-
-  let totalAchievements = 0;
-  let unlockedAchievements = 0;
-  let totalPoints = 0;
-
-  for (const card of cards) {
-    const categoryBucket = breakdownByCategory[card.category];
-
-    for (const tier of card.tiers) {
-      const rarityBucket = breakdownByRarity[tierToRarity(tier.tier)];
-
-      totalAchievements++;
-      categoryBucket.total++;
-      rarityBucket.total++;
-
-      if (tier.isUnlocked) {
-        unlockedAchievements++;
-        totalPoints += tier.points;
-        categoryBucket.unlocked++;
-        categoryBucket.points += tier.points;
-        rarityBucket.unlocked++;
-        rarityBucket.points += tier.points;
-      }
-    }
-  }
-
-  return {
-    total_achievements: totalAchievements,
-    unlocked_achievements: unlockedAchievements,
-    total_points: totalPoints,
-    breakdown_by_category: breakdownByCategory,
-    breakdown_by_rarity: breakdownByRarity,
-  };
 }

--- a/packages/api/src/services/achievement-cards.ts
+++ b/packages/api/src/services/achievement-cards.ts
@@ -1,6 +1,6 @@
 import type { RecentUnlock, SeriesCard, SeriesTier } from "@prostcounter/shared";
 import type { SeriesProgress } from "@prostcounter/shared/achievements";
-import { ONE_OFFS, SERIES, slugFor, tierToRarity } from "@prostcounter/shared/achievements";
+import { ONE_OFFS, SERIES, slugFor } from "@prostcounter/shared/achievements";
 
 const DEFAULT_RECENT_UNLOCK_LIMIT = 10;
 

--- a/packages/api/src/services/achievement-cards.ts
+++ b/packages/api/src/services/achievement-cards.ts
@@ -7,6 +7,7 @@ import type {
   SeriesCategory,
   SeriesTier,
 } from "@prostcounter/shared";
+import type { SeriesProgress } from "@prostcounter/shared/achievements";
 import { ONE_OFFS, SERIES, slugFor, tierToRarity } from "@prostcounter/shared/achievements";
 
 const DEFAULT_RECENT_UNLOCK_LIMIT = 10;
@@ -26,6 +27,39 @@ function emptyBreakdown(): BreakdownStats {
 }
 
 /**
+ * Progress toward the rung after the last one the user actually holds.
+ *
+ * `nextTarget` comes from the definition table indexed by the card's
+ * `currentTier` — which counts unlock rows — rather than from
+ * `SeriesProgress.nextTarget`, which counts metrics. The two disagree while a
+ * metric has passed a target whose unlock row has not been written yet, and
+ * the metrics answer would point the card past the rung whose pip is still
+ * unfilled.
+ *
+ * `currentValue` is capped at that target so the same window can never render
+ * "30/25", and so no consumer has to clamp a negative remainder.
+ */
+function buildCardProgress(
+  series: (typeof SERIES)[number],
+  currentTier: number,
+  seriesProgress: SeriesProgress | undefined,
+): SeriesCard["progress"] {
+  if (seriesProgress === undefined) {
+    return null;
+  }
+
+  const nextTierDef = series.tiers.find((tierDef) => tierDef.tier === currentTier + 1);
+  if (nextTierDef === undefined) {
+    return null;
+  }
+
+  return {
+    currentValue: Math.min(seriesProgress.currentValue, nextTierDef.target),
+    nextTarget: nextTierDef.target,
+  };
+}
+
+/**
  * One card per definition: the 20 tiered series, then the 10 one-offs.
  *
  * The order is part of the contract — both apps sort cards by rungs cleared
@@ -37,8 +71,12 @@ function emptyBreakdown(): BreakdownStats {
  * `isUnlocked` flags the pips render.
  *
  * @param unlockDates slug -> ISO unlock timestamp, for slugs the user holds.
+ * @param progressBySeriesId seriesId -> live metrics standing, for the 20 series.
  */
-export function buildSeriesCards(unlockDates: Map<string, string>): SeriesCard[] {
+export function buildSeriesCards(
+  unlockDates: Map<string, string>,
+  progressBySeriesId: Map<string, SeriesProgress>,
+): SeriesCard[] {
   const seriesCards: SeriesCard[] = SERIES.map((series) => {
     const tiers: SeriesTier[] = series.tiers.map((tierDef) => {
       const unlockedAt = unlockDates.get(slugFor(series, tierDef.tier)) ?? null;
@@ -65,6 +103,7 @@ export function buildSeriesCards(unlockDates: Map<string, string>): SeriesCard[]
       glyph: series.glyph,
       currentTier,
       tiers,
+      progress: buildCardProgress(series, currentTier, progressBySeriesId.get(series.id)),
     };
   });
 
@@ -88,6 +127,8 @@ export function buildSeriesCards(unlockDates: Map<string, string>): SeriesCard[]
           unlockedAt,
         },
       ],
+      // One-offs are binary: there is no partial state to report.
+      progress: null,
     };
   });
 

--- a/packages/shared/src/achievements/locale-coverage.test.ts
+++ b/packages/shared/src/achievements/locale-coverage.test.ts
@@ -69,6 +69,29 @@ describe("achievement locale coverage", () => {
           expect((filterLabel as string) ?? "").not.toBe("");
         }
       });
+
+      it(`${localeName}: has the scope, rail and progress copy`, () => {
+        const paths = [
+          ["scope", "festival"],
+          ["scope", "allTime"],
+          ["closeToUnlocking"],
+          ["progressToNext"],
+        ];
+
+        for (const path of paths) {
+          const label = resolve(node, path);
+          expect(typeof label).toBe("string");
+          expect((label as string) ?? "").not.toBe("");
+        }
+      });
+
+      it(`${localeName}: keeps every placeholder in progressToNext`, () => {
+        const label = resolve(node, ["progressToNext"]) as string;
+
+        for (const placeholder of ["{{current}}", "{{target}}", "{{remaining}}"]) {
+          expect(label).toContain(placeholder);
+        }
+      });
     }
   });
 

--- a/packages/shared/src/achievements/series-card-display.test.ts
+++ b/packages/shared/src/achievements/series-card-display.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 
 import { tierToRarity } from "./badge-tokens";
 import {
+  buildStats,
   getActiveTier,
   isCardCompleted,
   SERIES_CATEGORY_ORDER,
@@ -189,5 +190,41 @@ describe("selectCloseToUnlocking", () => {
     expect(entry.percentage).toBe(88);
     expect(entry.currentValue).toBe(22);
     expect(entry.nextTarget).toBe(25);
+  });
+});
+
+describe("buildStats", () => {
+  it("counts every rung, not every card", () => {
+    const stats = buildStats([seriesCard("drinks_total", 0), oneOffCard("full_festival", 4, false)]);
+
+    expect(stats.total_achievements).toBe(5); // 4 rungs + 1 one-off rung
+    expect(stats.unlocked_achievements).toBe(0);
+    expect(stats.total_points).toBe(0);
+  });
+
+  it("has exactly the six live category buckets", () => {
+    const stats = buildStats([seriesCard("drinks_total", 0)]);
+
+    expect(Object.keys(stats.breakdown_by_category).sort()).toEqual([
+      "attendance",
+      "competitive",
+      "dedication",
+      "drinking",
+      "explorer",
+      "social",
+    ]);
+  });
+
+  it("accumulates unlocked counts and points into both breakdowns", () => {
+    const stats = buildStats([seriesCard("drinks_total", 2), oneOffCard("full_festival", 4, true)]);
+
+    // seriesCard(id, 2) unlocks tiers 1-2 at points 10 and 20 (tier * 10); oneOffCard difficulty 4 is 600 points.
+    expect(stats.unlocked_achievements).toBe(3);
+    expect(stats.total_points).toBe(10 + 20 + 600);
+    expect(stats.breakdown_by_category.drinking).toMatchObject({ unlocked: 2, points: 30 });
+    expect(stats.breakdown_by_category.attendance).toMatchObject({ unlocked: 1, points: 600 });
+    expect(stats.breakdown_by_rarity.common).toMatchObject({ unlocked: 1, points: 10 });
+    expect(stats.breakdown_by_rarity.rare).toMatchObject({ unlocked: 1, points: 20 });
+    expect(stats.breakdown_by_rarity.legendary).toMatchObject({ unlocked: 1, points: 600 });
   });
 });

--- a/packages/shared/src/achievements/series-card-display.test.ts
+++ b/packages/shared/src/achievements/series-card-display.test.ts
@@ -6,10 +6,15 @@ import {
   getActiveTier,
   isCardCompleted,
   SERIES_CATEGORY_ORDER,
+  selectCloseToUnlocking,
   splitCardsByCompletion,
 } from "./series-card-display";
 
-function seriesCard(id: string, currentTier: number): SeriesCard {
+function seriesCard(
+  id: string,
+  currentTier: number,
+  progress: SeriesCard["progress"] = null,
+): SeriesCard {
   return {
     id,
     category: "drinking",
@@ -23,6 +28,7 @@ function seriesCard(id: string, currentTier: number): SeriesCard {
       isUnlocked: tier <= currentTier,
       unlockedAt: tier <= currentTier ? "2026-09-20T10:00:00Z" : null,
     })),
+    progress,
   };
 }
 
@@ -42,6 +48,7 @@ function oneOffCard(id: string, difficulty: number, unlocked: boolean): SeriesCa
         unlockedAt: unlocked ? "2026-09-20T10:00:00Z" : null,
       },
     ],
+    progress: null,
   };
 }
 
@@ -128,5 +135,59 @@ describe("tierToRarity", () => {
   it("falls back to common for missing tiers", () => {
     expect(tierToRarity(null)).toBe("common");
     expect(tierToRarity(undefined)).toBe("common");
+  });
+});
+
+describe("selectCloseToUnlocking", () => {
+  it("returns nothing when no card has progress", () => {
+    expect(selectCloseToUnlocking([seriesCard("a", 0), oneOffCard("b", 4, false)])).toEqual([]);
+  });
+
+  it("skips one-offs and fully cleared series", () => {
+    const entries = selectCloseToUnlocking([
+      oneOffCard("one_off", 4, false),
+      seriesCard("maxed", 4),
+      seriesCard("live", 1, { currentValue: 8, nextTarget: 10 }),
+    ]);
+
+    expect(entries.map((entry) => entry.card.id)).toEqual(["live"]);
+  });
+
+  it("ranks by remaining count ascending, not by percentage", () => {
+    const entries = selectCloseToUnlocking([
+      seriesCard("far", 0, { currentValue: 90, nextTarget: 100 }),
+      seriesCard("near", 0, { currentValue: 1, nextTarget: 4 }),
+    ]);
+
+    expect(entries.map((entry) => entry.card.id)).toEqual(["near", "far"]);
+    expect(entries.map((entry) => entry.remaining)).toEqual([3, 10]);
+  });
+
+  it("keeps the input order between cards with the same remaining count", () => {
+    const entries = selectCloseToUnlocking([
+      seriesCard("first", 0, { currentValue: 2, nextTarget: 5 }),
+      seriesCard("second", 0, { currentValue: 7, nextTarget: 10 }),
+    ]);
+
+    expect(entries.map((entry) => entry.card.id)).toEqual(["first", "second"]);
+  });
+
+  it("caps the list at three by default and honours an explicit limit", () => {
+    const cards = [1, 2, 3, 4, 5].map((index) =>
+      seriesCard(`s${index}`, 0, { currentValue: 0, nextTarget: index }),
+    );
+
+    expect(selectCloseToUnlocking(cards)).toHaveLength(3);
+    expect(selectCloseToUnlocking(cards, 1).map((entry) => entry.card.id)).toEqual(["s1"]);
+  });
+
+  it("reports the percentage as the share of the next target", () => {
+    const [entry] = selectCloseToUnlocking([
+      seriesCard("live", 1, { currentValue: 22, nextTarget: 25 }),
+    ]);
+
+    expect(entry.percentage).toBe(88);
+    expect(entry.currentValue).toBe(22);
+    expect(entry.nextTarget).toBe(25);
   });
 });

--- a/packages/shared/src/achievements/series-card-display.ts
+++ b/packages/shared/src/achievements/series-card-display.ts
@@ -73,3 +73,50 @@ export function splitCardsByCompletion(cards: SeriesCard[]): {
     inProgress: inProgress.sort(byRungsClearedDesc),
   };
 }
+
+/** One rail entry: a card plus the numbers the rail prints beside it. */
+export interface CloseToUnlockingEntry {
+  card: SeriesCard;
+  currentValue: number;
+  nextTarget: number;
+  /** Units still needed for the next rung. Never negative — the API caps currentValue. */
+  remaining: number;
+  /** 0-100, currentValue as a share of nextTarget, so the bar agrees with the "22/25" text. */
+  percentage: number;
+}
+
+/**
+ * The cards closest to their next rung, nearest first.
+ *
+ * Ranked by raw remaining count rather than percentage: "3 to go" is a more
+ * useful prompt than "88% of the way" regardless of how large the target is.
+ * `progress === null` already excludes one-offs and fully cleared series, so
+ * there is no separate completion test here.
+ *
+ * The sort is stable, so cards needing the same amount keep the order the API
+ * sent them in — definition order, the same tie-break splitCardsByCompletion uses.
+ */
+export function selectCloseToUnlocking(
+  cards: SeriesCard[],
+  limit = 3,
+): CloseToUnlockingEntry[] {
+  const entries: CloseToUnlockingEntry[] = [];
+
+  for (const card of cards) {
+    if (card.progress === null) {
+      continue;
+    }
+
+    const { currentValue, nextTarget } = card.progress;
+
+    entries.push({
+      card,
+      currentValue,
+      nextTarget,
+      remaining: nextTarget - currentValue,
+      percentage: Math.round((currentValue / nextTarget) * 100),
+    });
+  }
+
+  return entries.sort((a, b) => a.remaining - b.remaining).slice(0, limit);
+}

--- a/packages/shared/src/achievements/series-card-display.ts
+++ b/packages/shared/src/achievements/series-card-display.ts
@@ -124,7 +124,7 @@ export function selectCloseToUnlocking(cards: SeriesCard[], limit = 3): CloseToU
     });
   }
 
-  return entries.sort((a, b) => a.remaining - b.remaining).slice(0, limit);
+  return entries.toSorted((a, b) => a.remaining - b.remaining).slice(0, limit);
 }
 
 function emptyBreakdown(): BreakdownStats {

--- a/packages/shared/src/achievements/series-card-display.ts
+++ b/packages/shared/src/achievements/series-card-display.ts
@@ -96,14 +96,11 @@ export interface CloseToUnlockingEntry {
  * The sort is stable, so cards needing the same amount keep the order the API
  * sent them in — definition order, the same tie-break splitCardsByCompletion uses.
  */
-export function selectCloseToUnlocking(
-  cards: SeriesCard[],
-  limit = 3,
-): CloseToUnlockingEntry[] {
+export function selectCloseToUnlocking(cards: SeriesCard[], limit = 3): CloseToUnlockingEntry[] {
   const entries: CloseToUnlockingEntry[] = [];
 
   for (const card of cards) {
-    if (card.progress === null) {
+    if (card.progress == null) {
       continue;
     }
 

--- a/packages/shared/src/achievements/series-card-display.ts
+++ b/packages/shared/src/achievements/series-card-display.ts
@@ -1,5 +1,14 @@
 // packages/shared/src/achievements/series-card-display.ts
-import type { SeriesCard, SeriesCategory, SeriesTier } from "../schemas/achievement.schema";
+import type {
+  AchievementRarity,
+  AchievementStats,
+  BreakdownStats,
+  SeriesCard,
+  SeriesCategory,
+  SeriesTier,
+} from "../schemas/achievement.schema";
+
+import { tierToRarity } from "./badge-tokens";
 
 /**
  * Render order of the category sections, shared so web and mobile cannot
@@ -116,4 +125,63 @@ export function selectCloseToUnlocking(cards: SeriesCard[], limit = 3): CloseToU
   }
 
   return entries.sort((a, b) => a.remaining - b.remaining).slice(0, limit);
+}
+
+function emptyBreakdown(): BreakdownStats {
+  return { total: 0, unlocked: 0, points: 0 };
+}
+
+/**
+ * Totals over rungs, not cards: 90 unlockable slugs across 30 cards. Rarity
+ * buckets come from each rung's own tier, so a card contributes to several.
+ */
+export function buildStats(cards: SeriesCard[]): AchievementStats {
+  const breakdownByCategory: Record<SeriesCategory, BreakdownStats> = {
+    drinking: emptyBreakdown(),
+    attendance: emptyBreakdown(),
+    explorer: emptyBreakdown(),
+    social: emptyBreakdown(),
+    competitive: emptyBreakdown(),
+    dedication: emptyBreakdown(),
+  };
+
+  const breakdownByRarity: Record<AchievementRarity, BreakdownStats> = {
+    common: emptyBreakdown(),
+    rare: emptyBreakdown(),
+    epic: emptyBreakdown(),
+    legendary: emptyBreakdown(),
+  };
+
+  let totalAchievements = 0;
+  let unlockedAchievements = 0;
+  let totalPoints = 0;
+
+  for (const card of cards) {
+    const categoryBucket = breakdownByCategory[card.category];
+
+    for (const tier of card.tiers) {
+      const rarityBucket = breakdownByRarity[tierToRarity(tier.tier)];
+
+      totalAchievements++;
+      categoryBucket.total++;
+      rarityBucket.total++;
+
+      if (tier.isUnlocked) {
+        unlockedAchievements++;
+        totalPoints += tier.points;
+        categoryBucket.unlocked++;
+        categoryBucket.points += tier.points;
+        rarityBucket.unlocked++;
+        rarityBucket.points += tier.points;
+      }
+    }
+  }
+
+  return {
+    total_achievements: totalAchievements,
+    unlocked_achievements: unlockedAchievements,
+    total_points: totalPoints,
+    breakdown_by_category: breakdownByCategory,
+    breakdown_by_rarity: breakdownByRarity,
+  };
 }

--- a/packages/shared/src/i18n/locales/de.json
+++ b/packages/shared/src/i18n/locales/de.json
@@ -643,6 +643,12 @@
     "trackProgress": "Verfolge deinen Fortschritt und schalte Erfolge beim {{festival}} frei",
     "completed": "Abgeschlossen",
     "inProgress": "In Bearbeitung",
+    "closeToUnlocking": "Fast freigeschaltet",
+    "progressToNext": "{{current}}/{{target}} · noch {{remaining}}",
+    "scope": {
+      "festival": "Dieses Festival",
+      "allTime": "Gesamt"
+    },
     "stats": {
       "totalProgress": "Gesamtfortschritt",
       "percentUnlocked": "{{percent}}% freigeschaltet",

--- a/packages/shared/src/i18n/locales/en.json
+++ b/packages/shared/src/i18n/locales/en.json
@@ -678,6 +678,12 @@
     "trackProgress": "Track your progress and unlock achievements at {{festival}}",
     "completed": "Completed",
     "inProgress": "In Progress",
+    "closeToUnlocking": "Close to unlocking",
+    "progressToNext": "{{current}}/{{target}} · {{remaining}} to go",
+    "scope": {
+      "festival": "This festival",
+      "allTime": "All time"
+    },
     "stats": {
       "totalProgress": "Total Progress",
       "percentUnlocked": "{{percent}}% unlocked",

--- a/packages/shared/src/i18n/locales/es.json
+++ b/packages/shared/src/i18n/locales/es.json
@@ -678,6 +678,12 @@
     "trackProgress": "Seguí tu progreso y desbloqueá logros en {{festival}}",
     "completed": "Completado",
     "inProgress": "En progreso",
+    "closeToUnlocking": "Cerca de desbloquear",
+    "progressToNext": "{{current}}/{{target}} · faltan {{remaining}}",
+    "scope": {
+      "festival": "Este festival",
+      "allTime": "Histórico"
+    },
     "stats": {
       "totalProgress": "Progreso total",
       "percentUnlocked": "{{percent}}% desbloqueado",

--- a/packages/shared/src/schemas/achievement.schema.test.ts
+++ b/packages/shared/src/schemas/achievement.schema.test.ts
@@ -91,6 +91,15 @@ describe("SeriesCardSchema", () => {
       }).success,
     ).toBe(false);
   });
+
+  it("rejects a currentValue above nextTarget", () => {
+    expect(
+      SeriesCardSchema.safeParse({
+        ...validCard,
+        progress: { currentValue: 30, nextTarget: 25 },
+      }).success,
+    ).toBe(false);
+  });
 });
 
 describe("GetAchievementsWithProgressResponseSchema", () => {

--- a/packages/shared/src/schemas/achievement.schema.test.ts
+++ b/packages/shared/src/schemas/achievement.schema.test.ts
@@ -17,6 +17,7 @@ const validCard = {
     { tier: 3, name: "achievements.drinks_total.t3.name", points: 150, isUnlocked: false, unlockedAt: null },
     { tier: 4, name: "achievements.drinks_total.t4.name", points: 400, isUnlocked: false, unlockedAt: null },
   ],
+  progress: { currentValue: 12, nextTarget: 25 },
 };
 
 const emptyBreakdown = { total: 0, unlocked: 0, points: 0 };
@@ -56,6 +57,7 @@ describe("SeriesCardSchema", () => {
       tiers: [
         { tier: 1, name: "achievements.first_drink.name", points: 10, isUnlocked: true, unlockedAt: "2026-09-20T10:00:00Z" },
       ],
+      progress: null,
     };
     expect(SeriesCardSchema.parse(oneOff)).toEqual(oneOff);
   });
@@ -70,6 +72,24 @@ describe("SeriesCardSchema", () => {
 
   it("rejects a currentTier above 4", () => {
     expect(SeriesCardSchema.safeParse({ ...validCard, currentTier: 5 }).success).toBe(false);
+  });
+
+  it("accepts a null progress for a card with nothing left to earn", () => {
+    expect(SeriesCardSchema.parse({ ...validCard, progress: null }).progress).toBeNull();
+  });
+
+  it("rejects a missing progress field", () => {
+    const withoutProgress = { ...validCard, progress: undefined };
+    expect(SeriesCardSchema.safeParse(withoutProgress).success).toBe(false);
+  });
+
+  it("rejects a non-positive nextTarget", () => {
+    expect(
+      SeriesCardSchema.safeParse({
+        ...validCard,
+        progress: { currentValue: 0, nextTarget: 0 },
+      }).success,
+    ).toBe(false);
   });
 });
 

--- a/packages/shared/src/schemas/achievement.schema.ts
+++ b/packages/shared/src/schemas/achievement.schema.ts
@@ -177,6 +177,10 @@ export const SeriesCardSchema = z
         currentValue: z.number().nonnegative(),
         nextTarget: z.number().positive(),
       })
+      .refine((progress) => progress.currentValue <= progress.nextTarget, {
+        message: "currentValue cannot exceed nextTarget",
+        path: ["currentValue"],
+      })
       .nullable(),
   })
   .refine((card) => card.currentTier <= card.tiers.length, {

--- a/packages/shared/src/schemas/achievement.schema.ts
+++ b/packages/shared/src/schemas/achievement.schema.ts
@@ -161,6 +161,23 @@ export const SeriesCardSchema = z
      */
     currentTier: z.number().int().min(0).max(4),
     tiers: z.array(SeriesTierSchema).min(1),
+    /**
+     * Progress toward the rung after the last one the user holds. Null for
+     * one-offs (binary — no partial state) and for series with every rung
+     * unlocked.
+     *
+     * `nextTarget` is the definition's target for tier `currentTier + 1`, not
+     * the metrics-derived target: the two diverge while metrics run ahead of
+     * unlock rows, and the definition answer is the one that agrees with the
+     * pips. `currentValue` is capped at `nextTarget` by the builder, so
+     * `nextTarget - currentValue` is never negative.
+     */
+    progress: z
+      .object({
+        currentValue: z.number().nonnegative(),
+        nextTarget: z.number().positive(),
+      })
+      .nullable(),
   })
   .refine((card) => card.currentTier <= card.tiers.length, {
     message: "currentTier cannot exceed the number of tiers",

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -10,7 +10,7 @@
     "noEmit": true,
     "declaration": true,
     "declarationMap": true,
-    "lib": ["ES2022"],
+    "lib": ["ES2022", "ES2023"],
     "module": "ESNext",
     "target": "ES2022",
     "jsx": "react-jsx"


### PR DESCRIPTION
## Summary
- Add festival/all-time scope tabs to the Achievements screen (web + mobile), with a stats header and close-to-unlocking rail that both recompute per active scope
- Add a tap-to-open detail sheet showing all tier rungs for a series card (unlock date on cleared rungs, live progress on the next rung, locked state on the rest)
- Move `buildStats()` into shared code so both apps can derive scope-filtered stats client-side from the already-fetched card list, instead of relying on the API's unscoped total
