### PR TITLE
fix(web): stop reporting expected auth failures to Sentry

### DIFF
--- a/apps/web/components/Auth/actions.ts
+++ b/apps/web/components/Auth/actions.ts
@@ -5,7 +5,7 @@ import "server-only";
 import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
 
-import { reportSupabaseAuthException } from "@/utils/sentry";
+import { INVALID_CREDENTIALS_MESSAGE, reportSupabaseAuthException } from "@/utils/sentry";
 import { createClient } from "@/utils/supabase/server";
 
 function revalidateBase() {
@@ -30,7 +30,7 @@ export async function login(
   if (error) {
     reportSupabaseAuthException("login", error, { email: formData.email });
     // Don't reveal if email exists - use generic message
-    throw new Error("Invalid email or password");
+    throw new Error(INVALID_CREDENTIALS_MESSAGE);
   }
 
   revalidateBase();

--- a/apps/web/sentry.server.config.ts
+++ b/apps/web/sentry.server.config.ts
@@ -5,9 +5,16 @@
 import * as Sentry from "@sentry/nextjs";
 
 import { APP_VERSION } from "./lib/version";
+import { INVALID_CREDENTIALS_MESSAGE } from "./utils/sentry";
 
 Sentry.init({
   dsn: "https://976065906ffaab22c65cb37405653cea@o4507997605527552.ingest.de.sentry.io/4507997611098192",
+
+  // A failed sign-in throws out of the login server action so the form can show
+  // a message. Next's onRequestError hook reports every such throw, which made
+  // each wrong password produce a second Sentry event (PROST-COUNTER-8D) on top
+  // of the one reportSupabaseAuthException already suppresses.
+  ignoreErrors: [INVALID_CREDENTIALS_MESSAGE],
 
   // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
   tracesSampleRate: 1,

--- a/apps/web/utils/sentry.test.ts
+++ b/apps/web/utils/sentry.test.ts
@@ -1,0 +1,55 @@
+import type { AuthError } from "@supabase/supabase-js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@sentry/nextjs", () => ({
+  captureException: vi.fn(),
+  captureMessage: vi.fn(),
+  setUser: vi.fn(),
+}));
+
+import * as Sentry from "@sentry/nextjs";
+
+import { reportSupabaseAuthException } from "./sentry";
+
+function authError(code: string | undefined, message = "boom"): AuthError {
+  return { code, status: 400, name: "AuthApiError", message } as AuthError;
+}
+
+describe("reportSupabaseAuthException", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("does not report a wrong password, and does not store the typed email", () => {
+    reportSupabaseAuthException("login", authError("invalid_credentials"), {
+      email: "someone@example.com",
+    });
+
+    expect(Sentry.captureException).not.toHaveBeenCalled();
+    expect(Sentry.setUser).not.toHaveBeenCalled();
+  });
+
+  it.each(["email_not_confirmed", "user_already_exists", "weak_password", "same_password"])(
+    "does not report the expected auth failure %s",
+    (code) => {
+      reportSupabaseAuthException("signUp", authError(code));
+
+      expect(Sentry.captureException).not.toHaveBeenCalled();
+    },
+  );
+
+  it("still reports unexpected auth errors", () => {
+    reportSupabaseAuthException("login", authError("unexpected_failure"), {
+      email: "someone@example.com",
+    });
+
+    expect(Sentry.captureException).toHaveBeenCalledTimes(1);
+    expect(Sentry.setUser).toHaveBeenCalledWith({ email: "someone@example.com" });
+  });
+
+  it("still reports auth errors that carry no code", () => {
+    reportSupabaseAuthException("login", authError(undefined, "fetch failed"));
+
+    expect(Sentry.captureException).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/utils/sentry.ts
+++ b/apps/web/utils/sentry.ts
@@ -21,11 +21,41 @@ export const reportSupabaseException = (
   Sentry.captureException(new Error(`Supabase Error in action "${fnName}": ${errorDetails}`));
 };
 
+/**
+ * Message the login action throws when credentials don't match. Deliberately
+ * generic so it doesn't reveal whether the account exists.
+ *
+ * Also listed in sentry.server.config.ts's ignoreErrors: the throw escapes the
+ * server action into Next's onRequestError hook, which reports it a second time
+ * on top of reportSupabaseAuthException.
+ */
+export const INVALID_CREDENTIALS_MESSAGE = "Invalid email or password";
+
+/**
+ * Auth failures that are ordinary user behavior rather than defects: a mistyped
+ * password, an unconfirmed email, a duplicate signup.
+ *
+ * These were the single largest source of Sentry events in the project
+ * (PROST-COUNTER-8C, 373 events), which buried real auth bugs and stored the
+ * typed-in email address of everyone who fat-fingered a password.
+ */
+const EXPECTED_AUTH_ERROR_CODES = new Set([
+  "invalid_credentials",
+  "email_not_confirmed",
+  "user_already_exists",
+  "weak_password",
+  "same_password",
+]);
+
 export const reportSupabaseAuthException = (
   fnName: string,
   error: AuthError,
   userData?: { email?: string; id?: string; provider?: string },
 ) => {
+  if (error.code && EXPECTED_AUTH_ERROR_CODES.has(error.code)) {
+    return;
+  }
+
   const errorDetails = JSON.stringify({
     code: error.code,
     status: error.status,


### PR DESCRIPTION
## What

A wrong password created two Sentry errors. `reportSupabaseAuthException` captured every `AuthError` including `invalid_credentials` (PROST-COUNTER-8C, 373 events, second-highest volume in the project), and the generic error the login action throws so the form can render a message escaped into Next's `onRequestError` hook, which reported it again (PROST-COUNTER-8D).

It also called `Sentry.setUser({ email })` before capturing, so we were storing the typed-in address of everyone who mistyped a password.

Most of the volume is a deploy smoke test hitting `/sign-in` on vercel-preview with a fake account.

## How it works

`reportSupabaseAuthException` returns early for auth codes that are normal user behavior, before both the capture and the `setUser` call. Errors with no code, and any code not on the list, report exactly as before.

The thrown message moved to a shared constant so `sentry.server.config.ts` can list it in `ignoreErrors` without the two drifting apart.

Fixes PROST-COUNTER-8C
Fixes PROST-COUNTER-8D
