### PR TITLE
fix(mobile): show a single sync indicator, float it above tab bar

### DIFF
--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -381,7 +381,6 @@ export default function RootLayout() {
                                     <StoreUpdatePromptHandler />
                                     <WatchInstallPromptHandler />
                                     <TutorialOverlay />
-                                    <SyncStatusBar />
                                     <Stack
                                       screenOptions={{
                                         headerShown: false,
@@ -449,6 +448,8 @@ export default function RootLayout() {
                                       />
                                       <Stack.Screen name="+not-found" />
                                     </Stack>
+                                    {/* Rendered after Stack so the floating pill paints above screen content */}
+                                    <SyncStatusBar />
                                   </NavigationGuard>
                                 </LocationProvider>
                               </NovuProviderWrapper>

--- a/apps/mobile/components/sync/SyncStatusBar.tsx
+++ b/apps/mobile/components/sync/SyncStatusBar.tsx
@@ -12,7 +12,7 @@ import { useTranslation } from "@prostcounter/shared/i18n";
 import { cn } from "@prostcounter/ui";
 import { AlertCircle, CheckCircle, Cloud, CloudOff, RefreshCw } from "lucide-react-native";
 import { useCallback, useState } from "react";
-import { Pressable, View } from "react-native";
+import { Platform, Pressable, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 import { HStack } from "@/components/ui/hstack";
@@ -20,6 +20,9 @@ import { Spinner } from "@/components/ui/spinner";
 import { Text } from "@/components/ui/text";
 import { Colors, IconColors } from "@/lib/constants/colors";
 import { useOfflineSafe } from "@/lib/database/offline-provider";
+
+/** Height of the native tab bar, mirroring the FAB group in `app/(tabs)/_layout.tsx`. */
+const NATIVE_TAB_BAR_HEIGHT = Platform.OS === "android" ? 100 : 50;
 
 interface SyncStatusBarProps {
   /** Callback when user taps on errors to see details */
@@ -31,7 +34,7 @@ interface SyncStatusBarProps {
 export function SyncStatusBar({ onViewErrors, alwaysShow = false }: SyncStatusBarProps) {
   const { t } = useTranslation();
   const insets = useSafeAreaInsets();
-  const { isReady, isOnline, syncStatus, pendingCount, lastSyncResult, error, sync } =
+  const { isReady, isOnline, syncStatus, syncTrigger, pendingCount, lastSyncResult, error, sync } =
     useOfflineSafe();
 
   const [isRetrying, setIsRetrying] = useState(false);
@@ -50,8 +53,10 @@ export function SyncStatusBar({ onViewErrors, alwaysShow = false }: SyncStatusBa
     return null;
   }
 
-  // Determine what to show
-  const isSyncing = syncStatus === "syncing" || isRetrying;
+  // Determine what to show. Manual syncs (pull-to-refresh) already show the
+  // RefreshControl spinner, so the bar stays quiet for those to avoid two
+  // indicators for a single sync. Retries started from this bar still count.
+  const isSyncing = (syncStatus === "syncing" && syncTrigger === "auto") || isRetrying;
   const hasError = syncStatus === "error" || (lastSyncResult?.failed ?? 0) > 0;
   const isOffline = !isOnline || syncStatus === "offline";
   const hasPending = pendingCount > 0;
@@ -66,22 +71,26 @@ export function SyncStatusBar({ onViewErrors, alwaysShow = false }: SyncStatusBa
   let statusText;
   let bgColor = "bg-background-50";
   let textColor = "text-typography-500";
+  let borderColor = "border border-background-200";
 
   if (isSyncing) {
     icon = <Spinner size="small" color={Colors.primary[500]} />;
     statusText = t("sync.status.syncing");
     bgColor = "bg-primary-50";
     textColor = "text-primary-700";
+    borderColor = "border border-primary-200";
   } else if (isOffline) {
     icon = <CloudOff size={16} color={IconColors.muted} />;
     statusText = t("sync.status.offline");
     bgColor = "bg-background-100";
     textColor = "text-typography-500";
+    borderColor = "border border-background-300";
   } else if (hasError) {
     icon = <AlertCircle size={16} color={IconColors.error} />;
     statusText = error || t("sync.status.error");
     bgColor = "bg-error-50";
     textColor = "text-error-700";
+    borderColor = "border border-error-200";
   } else if (hasPending) {
     icon = <Cloud size={16} color={Colors.primary[500]} />;
     statusText = t("sync.status.pending", {
@@ -89,17 +98,26 @@ export function SyncStatusBar({ onViewErrors, alwaysShow = false }: SyncStatusBa
     });
     bgColor = "bg-primary-50";
     textColor = "text-primary-700";
+    borderColor = "border border-primary-200";
   } else {
     icon = <CheckCircle size={16} color={IconColors.success} />;
     statusText = t("sync.status.synced");
     bgColor = "bg-success-50";
     textColor = "text-success-700";
+    borderColor = "border border-success-200";
   }
 
   const isInteractive = hasError || hasPending;
 
   const content = (
-    <HStack space="sm" className={cn("items-center justify-center px-4 py-2", bgColor)}>
+    <HStack
+      space="sm"
+      className={cn(
+        "items-center justify-center rounded-full px-4 py-2 shadow-sm",
+        bgColor,
+        borderColor,
+      )}
+    >
       {icon}
       <Text className={cn("text-xs", textColor)} numberOfLines={1}>
         {statusText}
@@ -108,26 +126,33 @@ export function SyncStatusBar({ onViewErrors, alwaysShow = false }: SyncStatusBa
     </HStack>
   );
 
-  // Wrap in a View with safe area padding for dynamic island/notch
-  const wrappedContent = (
-    <View style={{ paddingTop: insets.top }} className={cn(bgColor)}>
-      {content}
+  // Floats above the screen so appearing/disappearing never reflows page content.
+  // Sits just above the tab bar, on the same baseline as the FAB group, which
+  // keeps it clear of every screen's header and content. Screens outside the tab
+  // navigator have no tab bar, so there it simply floats a little higher.
+  //
+  // When there is something to tap, box-none passes touches through everywhere
+  // except the pill; otherwise the whole overlay is inert, so the pill doesn't
+  // swallow taps meant for the screen underneath it.
+  const bottomOffset = NATIVE_TAB_BAR_HEIGHT + (insets.bottom === 0 ? 40 : 24) + insets.bottom;
+
+  return (
+    <View
+      pointerEvents={isInteractive ? "box-none" : "none"}
+      style={{ bottom: bottomOffset }}
+      className="absolute left-0 right-0 z-50 items-center"
+    >
+      {isInteractive ? (
+        <Pressable
+          onPress={hasError ? (onViewErrors ?? handleRetry) : handleRetry}
+          accessibilityRole="button"
+          accessibilityLabel={hasError ? t("sync.tapToRetry") : t("sync.tapToSync")}
+        >
+          {content}
+        </Pressable>
+      ) : (
+        content
+      )}
     </View>
   );
-
-  if (isInteractive) {
-    return (
-      <Pressable
-        onPress={hasError ? (onViewErrors ?? handleRetry) : handleRetry}
-        accessibilityRole="button"
-        accessibilityLabel={hasError ? t("sync.tapToRetry") : t("sync.tapToSync")}
-        style={{ paddingTop: insets.top }}
-        className={cn(bgColor)}
-      >
-        {content}
-      </Pressable>
-    );
-  }
-
-  return wrappedContent;
 }

--- a/apps/mobile/components/sync/SyncStatusBar.tsx
+++ b/apps/mobile/components/sync/SyncStatusBar.tsx
@@ -107,7 +107,11 @@ export function SyncStatusBar({ onViewErrors, alwaysShow = false }: SyncStatusBa
     borderColor = "border border-success-200";
   }
 
-  const isInteractive = hasError || hasPending;
+  // Stay inert while a sync runs. Retrying mid-sync would flash a second
+  // progress indicator next to the one already showing, and the retry itself
+  // bounces off the provider's in-flight guard anyway.
+  const isSyncInFlight = syncStatus === "syncing" || isRetrying;
+  const isInteractive = (hasError || hasPending) && !isSyncInFlight;
 
   const content = (
     <HStack

--- a/apps/mobile/hooks/useResyncFromServer.ts
+++ b/apps/mobile/hooks/useResyncFromServer.ts
@@ -20,7 +20,9 @@ export function useResyncFromServer() {
       await clearAllData(db);
 
       logger.debug("[Resync] Pulling fresh data from server");
-      const result = await offline.sync({ direction: "pull", force: true });
+      // Manual trigger: this screen already shows its own spinner, so the
+      // SyncStatusBar stays quiet instead of adding a second indicator.
+      const result = await offline.sync({ direction: "pull", force: true, trigger: "manual" });
 
       if (!result.success) {
         throw new Error(result.errors[0] ?? "Sync failed");

--- a/apps/mobile/lib/database/adapted-hooks.ts
+++ b/apps/mobile/lib/database/adapted-hooks.ts
@@ -147,7 +147,7 @@ export function useSyncRefresh() {
     try {
       // Step 1: Pull fresh data from API into SQLite
       if (context?.isOnline && context?.sync) {
-        await context.sync({ direction: "pull" });
+        await context.sync({ direction: "pull", trigger: "manual" });
       }
     } catch (error) {
       logger.error("[useSyncRefresh] Sync pull failed:", error);
@@ -164,7 +164,10 @@ export function useSyncRefresh() {
 
   return {
     syncAndRefresh,
-    isSyncing: context?.syncStatus === "syncing",
+    // Only user-initiated syncs drive the pull-to-refresh spinner. Background
+    // syncs are surfaced by the SyncStatusBar instead, so binding this to the
+    // global sync status would show two indicators for a single sync.
+    isSyncing: context?.syncStatus === "syncing" && context?.syncTrigger === "manual",
   };
 }
 

--- a/apps/mobile/lib/database/offline-provider.tsx
+++ b/apps/mobile/lib/database/offline-provider.tsx
@@ -39,6 +39,14 @@ import { getQueueStats } from "./sync-queue";
 
 export type SyncStatus = "idle" | "syncing" | "error" | "offline";
 
+/**
+ * What kicked off the current sync.
+ * "auto" covers background syncs (app start, coming online, foregrounding);
+ * "manual" covers user gestures like pull-to-refresh.
+ * Consumers use this to avoid showing two progress indicators for one sync.
+ */
+export type SyncTrigger = "auto" | "manual";
+
 export interface OfflineContextType {
   /** Whether the database is initialized and ready */
   isReady: boolean;
@@ -46,6 +54,8 @@ export interface OfflineContextType {
   isOnline: boolean;
   /** Current sync status */
   syncStatus: SyncStatus;
+  /** What kicked off the most recent sync */
+  syncTrigger: SyncTrigger;
   /** Last sync result (if any) */
   lastSyncResult: SyncResult | null;
   /** Number of pending operations in the sync queue */
@@ -54,8 +64,8 @@ export interface OfflineContextType {
   lastSyncAt: Date | null;
   /** Error message if sync failed */
   error: string | null;
-  /** Trigger a manual sync */
-  sync: (options?: SyncOptions) => Promise<SyncResult>;
+  /** Trigger a sync (defaults to the "auto" trigger) */
+  sync: (options?: SyncOptions & { trigger?: SyncTrigger }) => Promise<SyncResult>;
   /** Abort any in-progress sync */
   abortSync: () => void;
   /** Get the database instance (throws if not ready) */
@@ -116,6 +126,7 @@ export function OfflineDataProvider({
   // Effective online status (respects simulation for testing)
   const effectiveIsOnline = isOnline && !simulateOffline;
   const [syncStatus, setSyncStatus] = useState<SyncStatus>("idle");
+  const [syncTrigger, setSyncTrigger] = useState<SyncTrigger>("auto");
   const [lastSyncResult, setLastSyncResult] = useState<SyncResult | null>(null);
   const [pendingCount, setPendingCount] = useState(0);
   const [lastSyncAt, setLastSyncAt] = useState<Date | null>(null);
@@ -184,7 +195,9 @@ export function OfflineDataProvider({
 
   // Perform sync operation (defined before useEffects that depend on it)
   const performSync = useCallback(
-    async (options: SyncOptions): Promise<SyncResult> => {
+    async ({ trigger = "auto", ...options }: SyncOptions & { trigger?: SyncTrigger }): Promise<
+      SyncResult
+    > => {
       if (!syncManagerRef.current) {
         return {
           success: false,
@@ -209,6 +222,23 @@ export function OfflineDataProvider({
         };
       }
 
+      // The SyncManager rejects concurrent syncs, so bail out before touching any
+      // state. Stamping the trigger here would hand the in-flight sync's indicator
+      // to the wrong owner (e.g. a background push flipping a pull-to-refresh to
+      // "auto" mid-gesture), and the call is about to bounce regardless.
+      if (syncManagerRef.current.syncing) {
+        return {
+          success: false,
+          direction: options.direction ?? "both",
+          pulled: 0,
+          pushed: 0,
+          failed: 0,
+          errors: ["Sync already in progress"],
+          duration: 0,
+        };
+      }
+
+      setSyncTrigger(trigger);
       setSyncStatus("syncing");
       setError(null);
 
@@ -259,14 +289,13 @@ export function OfflineDataProvider({
 
   // Manual sync trigger
   const sync = useCallback(
-    async (options?: SyncOptions): Promise<SyncResult> => {
-      const syncOptions: SyncOptions = {
+    async (options?: SyncOptions & { trigger?: SyncTrigger }): Promise<SyncResult> => {
+      return performSync({
         festivalId,
         userId,
         direction: "both",
         ...options,
-      };
-      return performSync(syncOptions);
+      });
     },
     [festivalId, userId, performSync],
   );
@@ -377,6 +406,7 @@ export function OfflineDataProvider({
       isReady,
       isOnline: effectiveIsOnline,
       syncStatus,
+      syncTrigger,
       lastSyncResult,
       pendingCount,
       lastSyncAt,
@@ -393,6 +423,7 @@ export function OfflineDataProvider({
       isReady,
       effectiveIsOnline,
       syncStatus,
+      syncTrigger,
       lastSyncResult,
       pendingCount,
       lastSyncAt,
@@ -458,6 +489,7 @@ const DEFAULT_OFFLINE_CONTEXT: OfflineContextType = {
   isReady: false,
   isOnline: true,
   syncStatus: "idle",
+  syncTrigger: "auto",
   lastSyncResult: null,
   pendingCount: 0,
   lastSyncAt: null,


### PR DESCRIPTION
## Summary

On app start you'd see both the "Syncing…" banner and the pull-to-refresh wheel at the same time, even though nobody pulled.

Root cause: `OfflineProvider` sets a single global `syncStatus`, and two independent consumers reacted to it. `SyncStatusBar` rendered the banner, and `useSyncRefresh`'s `isSyncing` went straight into `<RefreshControl refreshing={...} />` on four screens, programmatically forcing the spinner. The inverse happened too: a real pull-to-refresh also raised the banner.

Fix: add a `syncTrigger` (`"auto" | "manual"`) to the offline context. Both indicators derive from it with opposite comparisons, so they're mutually exclusive by construction. Background syncs (app start, coming online, foregrounding) show the pill; user gestures show the spinner. One change in `useSyncRefresh` covers all four screens.

Also in here:

- `performSync` now bails out before touching state when a sync is already in flight. Without that, a background push firing mid pull-to-refresh would flip the trigger to `"auto"`, snapping the RefreshControl back and popping the pill, which is the exact bug this PR removes. It also no longer records a failed result for a sync that never ran.
- Profile → "Sync now" passes the manual trigger, since that screen already renders its own button spinner.
- The banner is now a floating pill anchored just above the tab bar (reusing `FabGroup`'s offset math so the two stay aligned) instead of an in-flow bar, so showing and hiding it never reflows page content.
- The pill is `pointerEvents: none` when there's nothing to tap, so the syncing and offline states don't swallow taps meant for the screen underneath.
